### PR TITLE
Fix #664 - track added actions and only emit ai-reaction action if feature is used

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -28,28 +28,6 @@ jobs:
           sparse-checkout: .github
           fetch-depth: 1
 
-  add-reaction:
-    needs: task
-    if: github.event_name == 'issues' || github.event_name == 'pull_request' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_comment' || github.event_name == 'pull_request_review_comment'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Read .github
-      issues: write
-      pull-requests: write
-    outputs:
-      reaction_id: ${{ steps.react.outputs.reaction-id }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-      - name: Add eyes reaction to the triggering item
-        id: react
-        uses: ./.github/actions/reaction
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          mode: add
-          reaction: eyes
-
   agentic-triage:
     needs: task
     runs-on: ubuntu-latest

--- a/.github/workflows/test-claude.lock.yml
+++ b/.github/workflows/test-claude.lock.yml
@@ -27,28 +27,6 @@ jobs:
           sparse-checkout: .github
           fetch-depth: 1
 
-  add-reaction:
-    needs: task
-    if: github.event_name == 'issues' || github.event_name == 'pull_request' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_comment' || github.event_name == 'pull_request_review_comment'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Read .github
-      issues: write
-      pull-requests: write
-    outputs:
-      reaction_id: ${{ steps.react.outputs.reaction-id }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-      - name: Add eyes reaction to the triggering item
-        id: react
-        uses: ./.github/actions/reaction
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          mode: add
-          reaction: eyes
-
   test-claude:
     needs: task
     runs-on: ubuntu-latest

--- a/.github/workflows/test-codex.lock.yml
+++ b/.github/workflows/test-codex.lock.yml
@@ -27,28 +27,6 @@ jobs:
           sparse-checkout: .github
           fetch-depth: 1
 
-  add-reaction:
-    needs: task
-    if: github.event_name == 'issues' || github.event_name == 'pull_request' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_comment' || github.event_name == 'pull_request_review_comment'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Read .github
-      issues: write
-      pull-requests: write
-    outputs:
-      reaction_id: ${{ steps.react.outputs.reaction-id }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-      - name: Add eyes reaction to the triggering item
-        id: react
-        uses: ./.github/actions/reaction
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          mode: add
-          reaction: eyes
-
   test-codex:
     needs: task
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-research.lock.yml
+++ b/.github/workflows/weekly-research.lock.yml
@@ -26,28 +26,6 @@ jobs:
           sparse-checkout: .github
           fetch-depth: 1
 
-  add-reaction:
-    needs: task
-    if: github.event_name == 'issues' || github.event_name == 'pull_request' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_comment' || github.event_name == 'pull_request_review_comment'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Read .github
-      issues: write
-      pull-requests: write
-    outputs:
-      reaction_id: ${{ steps.react.outputs.reaction-id }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-      - name: Add eyes reaction to the triggering item
-        id: react
-        uses: ./.github/actions/reaction
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          mode: add
-          reaction: eyes
-
   weekly-research:
     needs: task
     runs-on: ubuntu-latest

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -53,9 +53,9 @@ on:
   workflow_dispatch:
 ```
 
-### Special `alias` Trigger
+## Special `alias:` Trigger
 
-Create workflows that respond to `@mentions` in issues and comments:
+GitHub Agentic Workflows add the convenience `alias:` trigger to create workflows that respond to `@mentions` in issues and comments.
 
 ```yaml
 on:
@@ -79,7 +79,9 @@ on:
     - cron: "0 9 * * 1"
 ```
 
-**Note**: Cannot combine `alias` with `issues`, `issue_comment`, or `pull_request` as they would conflict.
+**Note**: You cannot combine `alias` with `issues`, `issue_comment`, or `pull_request` as they would conflict.
+
+**Note**: Using this feature results in the addition of `.github/actions/check-team-member/action.yml` file to the repository when the workflow is compiled. This file is used to check if the user triggering the workflow has appropriate permissions to operate in the repository.
 
 #### Example alias workflow
 
@@ -118,6 +120,8 @@ All workflows have access to a computed `text` output variable that provides con
 - **PR Review Comments**: `comment.body`
 - **PR Reviews**: `review.body`
 - **Other events**: Empty string
+
+**Note**: Using this feature results in the addition of ".github/actions/compute-text/action.yml" file to the repository when the workflow is compiled.
 
 ## Permissions (`permissions:`)
 
@@ -201,17 +205,20 @@ stop-time: "2025-12-31 23:59:59"
 Emoji reaction added/removed on triggering GitHub items:
 
 ```yaml
-ai-reaction: "eyes"  # Default
+ai-reaction: "eyes"
 ```
 
 **Available reactions:**
-- `+1` (👍), `-1` (👎), `laugh` (😄), `confused` (😕)
-- `heart` (❤️), `hooray` (🎉), `rocket` (🚀), `eyes` (👀)
+- `+1` (👍)
+- `-1` (👎)
+- `laugh` (😄)
+- `confused` (😕)
+- `heart` (❤️)
+- `hooray` (🎉)
+- `rocket` (🚀)
+- `eyes` (👀)
 
-**Behavior:**
-1. **Added**: When workflow starts
-2. **Removed**: When workflow completes successfully
-3. **Default**: `eyes` if not specified
+**Note**: Using this feature results in the addition of ".github/actions/reaction/action.yml" file to the repository when the workflow is compiled.
 
 ## Cache Configuration (`cache:`)
 

--- a/docs/include-directives.md
+++ b/docs/include-directives.md
@@ -68,12 +68,6 @@ Common permission set for repository automation workflows.
 on:
   issues:
     types: [opened]
-
-@include shared/github-permissions.md
-@include shared/common-tools.md
-
-max-runs: 50
-ai-reaction: "eyes"
 ---
 
 # Issue Auto-Handler
@@ -82,15 +76,16 @@ ai-reaction: "eyes"
 
 When an issue is opened, analyze and respond appropriately.
 
-Issue content: "${{ needs.task.outputs.text }}"
+@include shared/github-permissions.md
+
+@include shared/common-tools.md
+
 ```
 
-## Include Rules and Limitations
+## Frontmatter Merging
 
-### Frontmatter Merging
-- **Only `tools:` frontmatter** is allowed in included files
+- **Only `tools:` frontmatter** is allowed in included files, other entries give a warning.
 - **Tool merging**: `allowed:` tools are merged across all included files
-- **Conflict resolution**: Later includes override earlier ones for the same tool
 
 ### Example Tool Merging
 ```markdown
@@ -118,43 +113,11 @@ tools:
 
 **Result**: Final workflow has `github.allowed: [get_issue, add_issue_comment, update_issue]` and Claude Edit tool.
 
-### Include Path Resolution
+## Include Path Resolution
+
 - **Relative paths**: Resolved relative to the including file
 - **Nested includes**: Included files can include other files
 - **Circular protection**: System prevents infinite include loops
-
-## Advanced Include Patterns
-
-### Conditional Includes by Environment
-```markdown
----
-on:
-  issues:
-    types: [opened]
----
-
-@include shared/base-config.md
-
-# Development environment
-@include environments/development.md#Development Tools
-
-# Production environment  
-@include environments/production.md#Production Tools
-
-# Conditional based on repository
-```
-
-### Include with Section Targeting
-```markdown
-# Include only the permissions section
-@include shared/security-config.md#Permissions
-
-# Include only tool configuration
-@include shared/tool-config.md#GitHub Tools
-@include shared/tool-config.md#MCP Servers
-
-> **📘 Complete MCP Guide**: For comprehensive MCP server configuration, see the [MCPs](mcps.md).
-```
 
 ## Related Documentation
 

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -1362,15 +1362,11 @@ func compileWorkflowWithTracking(filePath string, verbose bool, engineOverride s
 		tracker.TrackCreated(gitAttributesPath)
 	}
 
-	// Create compiler and compile the workflow
+	// Create compiler and set the file tracker
 	compiler := workflow.NewCompiler(verbose, engineOverride, GetVersion())
+	compiler.SetFileTracker(tracker)
 	if err := compiler.CompileWorkflow(filePath); err != nil {
 		return err
-	}
-
-	// Track any shared action files created by the compiler
-	for _, createdFile := range compiler.GetCreatedFiles() {
-		tracker.TrackCreated(createdFile)
 	}
 
 	// Ensure .gitattributes marks .lock.yml files as generated

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -1368,6 +1368,11 @@ func compileWorkflowWithTracking(filePath string, verbose bool, engineOverride s
 		return err
 	}
 
+	// Track any shared action files created by the compiler
+	for _, createdFile := range compiler.GetCreatedFiles() {
+		tracker.TrackCreated(createdFile)
+	}
+
 	// Ensure .gitattributes marks .lock.yml files as generated
 	if err := ensureGitAttributes(); err != nil {
 		if verbose {

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -386,7 +386,6 @@
     "ai-reaction": {
       "type": "string",
       "enum": ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"],
-      "default": "eyes",
       "description": "AI reaction to add/remove on triggering item (one of: +1, -1, laugh, confused, heart, hooray, rocket, eyes). Defaults to 'eyes' if not specified."
     },
     "cache": {


### PR DESCRIPTION
Fixes: https://github.com/githubnext/gh-aw-internal/issues/664

Add is now clean:

```
Initialized empty Git repository in /home/dsyme/tmp/.git/
dsyme@DSYME-LAPDOG:~/tmp$ ../gh-aw/gh-aw add -r githubnext/agentics weekly-research
Package githubnext/agentics already exists. Updating...
Successfully installed package: githubnext/agentics
Added workflow: /home/dsyme/tmp/.github/workflows/weekly-research.md
✓ .github/workflows/weekly-research.md
dsyme@DSYME-LAPDOG:~/tmp$ git status
On branch master

No commits yet

Changes to be committed:
  (use "git rm --cached <file>..." to unstage)
        new file:   .gitattributes
        new file:   .github/workflows/agentics/shared/gh-extra-tools.md
        new file:   .github/workflows/agentics/shared/include-link.md
        new file:   .github/workflows/agentics/shared/job-summary.md
        new file:   .github/workflows/agentics/shared/tool-refused.md
        new file:   .github/workflows/agentics/shared/xpia.md
        new file:   .github/workflows/weekly-research.lock.yml
        new file:   .github/workflows/weekly-research.md
```
