### PR TITLE
remove max-runs

### DIFF
--- a/pkg/cli/templates/instructions.md
+++ b/pkg/cli/templates/instructions.md
@@ -443,7 +443,8 @@ Agentic workflows compile to GitHub Actions YAML:
 4. **Use @include directives** for common patterns and security boilerplate
 5. **Test with `gh aw compile`** before committing
 6. **Review generated `.lock.yml`** files before deploying
-7. **Use specific tool permissions** rather than broad access
+7. **Set `stop-time`** for cost-sensitive workflows
+8. **Use specific tool permissions** rather than broad access
 
 ## Validation
 

--- a/pkg/parser/schema_test.go
+++ b/pkg/parser/schema_test.go
@@ -27,7 +27,6 @@ func TestValidateMainWorkflowFrontmatterWithSchema(t *testing.T) {
 				"steps":           []string{"step1"},
 				"engine":          "claude",
 				"tools":           map[string]any{"github": "test"},
-				"max-runs":        5,
 				"stop-time":       "2024-12-31",
 				"alias":           "test-workflow",
 			},
@@ -173,14 +172,6 @@ func TestValidateMainWorkflowFrontmatterWithSchema(t *testing.T) {
 			name: "invalid type for timeout_minutes",
 			frontmatter: map[string]any{
 				"timeout_minutes": "not-a-number",
-			},
-			wantErr:     true,
-			errContains: "got string, want integer",
-		},
-		{
-			name: "invalid type for max-runs",
-			frontmatter: map[string]any{
-				"max-runs": "not-a-number",
 			},
 			wantErr:     true,
 			errContains: "got string, want integer",

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -371,10 +371,6 @@
         ]
       }
     },
-    "max-runs": {
-      "type": "integer",
-      "description": "Maximum number of workflow runs"
-    },
     "stop-time": {
       "type": "string",
       "description": "Time when workflow should stop running"


### PR DESCRIPTION
See https://github.com/githubnext/gh-aw-internal/pull/764/

This PR completely removes the `max-runs` feature from gh-aw workflows as requested, while preserving the existing `stop-time` functionality for cost control.

## Changes Made

**Core Implementation:**
- Removed `MaxRuns` field from `WorkflowData` struct
- Removed `max-runs` parsing from workflow frontmatter processing
- Updated `generateSafetyChecks()` function to only handle `stop-time` checks
- Updated JSON schema to reject `max-runs` field with proper validation

**Documentation Updates:**
- Updated `docs/frontmatter.md` to remove max-runs section
- Updated `docs/workflow-structure.md` examples
- Updated instruction templates in `pkg/cli/templates/`
- Updated `.github/instructions/` files

**Workflow Updates:**
- Removed `max-runs: 1` from `.github/workflows/daily-qa.md`
- Updated schema tests to remove max-runs test cases

## Validation

The implementation has been thoroughly tested:

```bash
# max-runs is now properly rejected
$ ./gh-aw compile workflow-with-max-runs.md
✗ error: additional properties 'max-runs' not allowed

# stop-time continues to work correctly  
$ ./gh-aw compile workflow-with-stop-time.md
✓ workflow-with-stop-time.md
```

Generated workflows now only include stop-time safety checks that validate the deadline and disable the workflow if the time limit is reached:

```yaml
- name: Safety checks
  run: |
    # Check stop-time limit
    STOP_TIME="2025-12-31 23:59:59"
    # ... validation logic for stop-time only
```

All existing tests pass and all 23 workflow files in the repository recompile successfully without the max-runs functionality.

Fixes #684.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `api.contoso.com`
>   - Triggering command: `/tmp/go-build668954542/b260/cli.test -test.testlogfile=/tmp/go-build668954542/b260/testlog.txt -test.paniconexit0 -test.timeout=10m0s -test.v=true` (dns block)
>   - Triggering command: `/tmp/go-build2792383895/b260/cli.test -test.testlogfile=/tmp/go-build2792383895/b260/testlog.txt -test.paniconexit0 -test.timeout=10m0s -test.v=true` (dns block)
>   - Triggering command: `/tmp/go-build2075455822/b260/cli.test -test.testlogfile=/tmp/go-build2075455822/b260/testlog.txt -test.paniconexit0 -test.timeout=10m0s -test.v=true` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/githubnext/gh-aw-internal/settings/copilot/coding_agent) (admins only)
>
> </details>

