### PR TITLE
Copilot/fix 712

### DIFF
--- a/pkg/workflow/concurrency.go
+++ b/pkg/workflow/concurrency.go
@@ -15,9 +15,9 @@ func GenerateConcurrencyConfig(workflowData *WorkflowData, isAliasTrigger bool) 
 	// Generate concurrency configuration based on workflow type
 	// Note: Check alias trigger first since alias workflows also contain pull_request events
 	if isAliasTrigger {
-		// For alias workflows: include ref but do NOT enable cancellation
+		// For alias workflows: use issue/PR number for concurrency but do NOT enable cancellation
 		return `concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.ref }}"`
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}"`
 	} else if isPullRequestWorkflow(workflowData.On) {
 		// For PR workflows: include ref and enable cancellation
 		return `concurrency:


### PR DESCRIPTION
https://github.com/githubnext/gh-aw-internal/pull/765

---

Alias workflows were incorrectly using `github.ref` for concurrency grouping, which doesn't make sense for workflows triggered by @mentions in issues and pull requests. This change updates the concurrency configuration to use issue/pull request numbers instead.

**Problem:**
- Alias workflows are triggered by @mentions in issues, issue comments, pull requests, and pull request comments
- Using `github.ref` for concurrency grouping is inappropriate since these workflows aren't tied to specific git references
- Multiple @mentions in the same issue/PR should be handled sequentially, while different issues/PRs should be able to run concurrently

**Solution:**
The concurrency group now uses:
```yaml
concurrency:
  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}"
```

This ensures:
- Sequential execution of multiple @mentions within the same issue or pull request
- Concurrent execution across different issues and pull requests
- Proper workflow isolation based on the context where the alias was mentioned

**Changes:**
- Updated `GenerateConcurrencyConfig` function in `pkg/workflow/concurrency.go`
- Updated corresponding tests in `pkg/workflow/concurrency_test.go`
- All existing tests continue to pass, confirming no regressions for other workflow types

Fixes #712.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.