### PR TITLE
Add max-turns feature

### DIFF
--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -21,6 +21,7 @@ The YAML frontmatter supports standard GitHub Actions properties plus additional
 - `engine`: AI engine configuration (claude/codex)
 - `tools`: Available tools and MCP servers for the AI engine  
 - `stop-time`: Deadline when workflow should stop running (absolute or relative time)
+- `max-turns`: Maximum number of chat iterations per run
 - `alias`: Alias name for the workflow
 - `ai-reaction`: Emoji reaction to add/remove on triggering GitHub item
 - `cache`: Cache configuration for workflow dependencies
@@ -186,13 +187,23 @@ engine:
 
 ## Cost Control Options
 
+### Maximum Turns (`max-turns:`)
+
+Limit the number of chat iterations within a single agentic run:
+
+```yaml
+max-turns: 5
+```
+
+**Behavior:**
+1. Passes the limit to the AI engine (e.g., Claude Code action)
+2. Engine stops iterating when the turn limit is reached
+3. Helps prevent runaway chat loops and control costs
+4. Only applies to engines that support turn limiting (currently Claude)
+
 ### Stop Time (`stop-time:`)
 
-Automatically disable workflow after a deadline. Supports both absolute timestamps and relative time deltas:
-
-**Absolute time (multiple formats supported):**
-```yaml
-```
+Automatically disable workflow after a deadline:
 
 **Relative time delta (calculated from compilation time):**
 ```yaml

--- a/pkg/cli/templates/instructions.md
+++ b/pkg/cli/templates/instructions.md
@@ -74,6 +74,7 @@ The YAML frontmatter supports these fields:
   - `claude:` - Claude-specific tools  
   - Custom tool names for MCP servers
   
+- **`max-turns:`** - Maximum chat iterations per run (integer)
 - **`stop-time:`** - Deadline for workflow. Can be absolute timestamp ("YYYY-MM-DD HH:MM:SS") or relative delta (+25h, +3d, +1d12h30m)
 - **`alias:`** - Alternative workflow name (string)
 - **`cache:`** - Cache configuration for workflow dependencies (object or array)
@@ -444,7 +445,8 @@ Agentic workflows compile to GitHub Actions YAML:
 5. **Test with `gh aw compile`** before committing
 6. **Review generated `.lock.yml`** files before deploying
 7. **Set `stop-time`** for cost-sensitive workflows
-8. **Use specific tool permissions** rather than broad access
+8. **Set `max-turns`** to limit chat iterations and prevent runaway loops
+9. **Use specific tool permissions** rather than broad access
 
 ## Validation
 

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -371,6 +371,10 @@
         ]
       }
     },
+    "max-turns": {
+      "type": "integer",
+      "description": "Maximum number of chat iterations per run"
+    },
     "stop-time": {
       "type": "string",
       "description": "Time when workflow should stop running. Supports multiple formats: absolute dates (YYYY-MM-DD HH:MM:SS, June 1 2025, 1st June 2025, 06/01/2025, etc.) or relative time deltas (+25h, +3d, +1d12h30m)"

--- a/pkg/workflow/agentic_engine.go
+++ b/pkg/workflow/agentic_engine.go
@@ -29,6 +29,9 @@ type AgenticEngine interface {
 	// SupportsHTTPTransport returns true if this engine supports HTTP transport for MCP servers
 	SupportsHTTPTransport() bool
 
+	// SupportsMaxTurns returns true if this engine supports the max-turns feature
+	SupportsMaxTurns() bool
+
 	// GetInstallationSteps returns the GitHub Actions steps needed to install this engine
 	GetInstallationSteps(engineConfig *EngineConfig) []GitHubActionStep
 
@@ -68,6 +71,7 @@ type BaseEngine struct {
 	experimental           bool
 	supportsToolsWhitelist bool
 	supportsHTTPTransport  bool
+	supportsMaxTurns       bool
 }
 
 func (e *BaseEngine) GetID() string {
@@ -92,6 +96,10 @@ func (e *BaseEngine) SupportsToolsWhitelist() bool {
 
 func (e *BaseEngine) SupportsHTTPTransport() bool {
 	return e.supportsHTTPTransport
+}
+
+func (e *BaseEngine) SupportsMaxTurns() bool {
+	return e.supportsMaxTurns
 }
 
 // EngineRegistry manages available agentic engines

--- a/pkg/workflow/claude_engine.go
+++ b/pkg/workflow/claude_engine.go
@@ -25,6 +25,7 @@ func NewClaudeEngine() *ClaudeEngine {
 			experimental:           false,
 			supportsToolsWhitelist: true,
 			supportsHTTPTransport:  true, // Claude supports both stdio and HTTP transport
+			supportsMaxTurns:       true, // Claude supports max-turns feature
 		},
 	}
 }
@@ -51,6 +52,7 @@ func (e *ClaudeEngine) GetExecutionConfig(workflowName string, logFile string, e
 			"claude_env":        "|\n            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
 			"allowed_tools":     "", // Will be filled in during generation
 			"timeout_minutes":   "", // Will be filled in during generation
+			"max_turns":         "", // Will be filled in during generation
 		},
 		Environment: map[string]string{
 			"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}",

--- a/pkg/workflow/claude_engine_test.go
+++ b/pkg/workflow/claude_engine_test.go
@@ -76,6 +76,10 @@ func TestClaudeEngine(t *testing.T) {
 		t.Error("Expected timeout_minutes input to be present")
 	}
 
+	if _, hasMaxTurns := config.Inputs["max_turns"]; !hasMaxTurns {
+		t.Error("Expected max_turns input to be present")
+	}
+
 	// Check environment variables
 	if config.Environment["GH_TOKEN"] != "${{ secrets.GITHUB_TOKEN }}" {
 		t.Errorf("Expected GH_TOKEN environment variable, got '%s'", config.Environment["GH_TOKEN"])
@@ -109,7 +113,7 @@ func TestClaudeEngineConfiguration(t *testing.T) {
 			}
 
 			// Verify all required inputs are present
-			requiredInputs := []string{"prompt_file", "anthropic_api_key", "mcp_config", "claude_env", "allowed_tools", "timeout_minutes"}
+			requiredInputs := []string{"prompt_file", "anthropic_api_key", "mcp_config", "claude_env", "allowed_tools", "timeout_minutes", "max_turns"}
 			for _, input := range requiredInputs {
 				if _, exists := config.Inputs[input]; !exists {
 					t.Errorf("Expected input '%s' to be present", input)

--- a/pkg/workflow/codex_engine.go
+++ b/pkg/workflow/codex_engine.go
@@ -20,6 +20,7 @@ func NewCodexEngine() *CodexEngine {
 			experimental:           true,
 			supportsToolsWhitelist: true,
 			supportsHTTPTransport:  false, // Codex only supports stdio transport
+			supportsMaxTurns:       false, // Codex does not support max-turns feature
 		},
 	}
 }

--- a/pkg/workflow/max_turns_test.go
+++ b/pkg/workflow/max_turns_test.go
@@ -1,0 +1,229 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaxTurnsCompilation(t *testing.T) {
+	tests := []struct {
+		name             string
+		content          string
+		expectedMaxTurns string
+		shouldInclude    bool
+	}{
+		{
+			name: "workflow with max-turns",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+max-turns: 3
+tools:
+  github:
+    allowed: [get_issue]
+---
+
+# Test Max Turns
+
+This workflow tests the max-turns feature.`,
+			expectedMaxTurns: "max_turns: 3",
+			shouldInclude:    true,
+		},
+		{
+			name: "workflow without max-turns",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+tools:
+  github:
+    allowed: [get_issue]
+---
+
+# Test Without Max Turns
+
+This workflow should not include max-turns.`,
+			expectedMaxTurns: "",
+			shouldInclude:    false,
+		},
+		{
+			name: "workflow with max-turns and timeout",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+max-turns: 10
+timeout_minutes: 15
+tools:
+  github:
+    allowed: [get_issue]
+---
+
+# Test Max Turns and Timeout
+
+This workflow tests max-turns with timeout.`,
+			expectedMaxTurns: "max_turns: 10",
+			shouldInclude:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for the test
+			tmpDir, err := os.MkdirTemp("", "max-turns-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			// Create the test workflow file
+			testFile := filepath.Join(tmpDir, "test-workflow.md")
+			if err := os.WriteFile(testFile, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Compile the workflow
+			compiler := NewCompiler(false, "", "")
+			if err := compiler.CompileWorkflow(testFile); err != nil {
+				t.Fatalf("Failed to compile workflow: %v", err)
+			}
+
+			// Read the generated lock file
+			lockFile := strings.TrimSuffix(testFile, ".md") + ".lock.yml"
+			lockContent, err := os.ReadFile(lockFile)
+			if err != nil {
+				t.Fatalf("Failed to read lock file: %v", err)
+			}
+
+			lockContentStr := string(lockContent)
+
+			if tt.shouldInclude {
+				// Verify max_turns is included in the generated workflow
+				if !strings.Contains(lockContentStr, tt.expectedMaxTurns) {
+					t.Errorf("Expected max_turns to be included in generated workflow. Expected: %s\nActual content:\n%s", tt.expectedMaxTurns, lockContentStr)
+				}
+
+				// Verify it's in the correct context (under the Claude action inputs)
+				if !strings.Contains(lockContentStr, "anthropics/claude-code-base-action") {
+					t.Error("Expected to find Claude action in generated workflow")
+				}
+
+				// Look for max_turns in the inputs section
+				lines := strings.Split(lockContentStr, "\n")
+				foundAction := false
+				foundMaxTurns := false
+				for i, line := range lines {
+					if strings.Contains(line, "anthropics/claude-code-base-action") {
+						foundAction = true
+					}
+					if foundAction && strings.Contains(line, "with:") {
+						// Look for max_turns in the subsequent lines
+						for j := i + 1; j < len(lines) && strings.HasPrefix(lines[j], "          "); j++ {
+							if strings.Contains(lines[j], "max_turns:") {
+								foundMaxTurns = true
+								break
+							}
+						}
+						break
+					}
+				}
+
+				if !foundMaxTurns {
+					t.Error("Expected to find max_turns in the action inputs section")
+				}
+			} else {
+				// Verify max_turns is NOT included when not specified
+				if strings.Contains(lockContentStr, "max_turns:") {
+					t.Error("Expected max_turns NOT to be included when not specified in frontmatter")
+				}
+			}
+		})
+	}
+}
+
+func TestMaxTurnsValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		expectError bool
+	}{
+		{
+			name: "valid integer max-turns",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+max-turns: 5
+---
+
+# Valid Max Turns`,
+			expectError: false,
+		},
+		{
+			name: "invalid string max-turns",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+max-turns: "invalid"
+---
+
+# Invalid Max Turns`,
+			expectError: true,
+		},
+		{
+			name: "zero max-turns",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+max-turns: 0
+---
+
+# Zero Max Turns`,
+			expectError: false, // Zero should be valid (might mean unlimited)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for the test
+			tmpDir, err := os.MkdirTemp("", "max-turns-validation-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			// Create the test workflow file
+			testFile := filepath.Join(tmpDir, "test-workflow.md")
+			if err := os.WriteFile(testFile, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Compile the workflow
+			compiler := NewCompiler(false, "", "")
+			err = compiler.CompileWorkflow(testFile)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected compilation to fail but it succeeded")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Expected compilation to succeed but it failed: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/workflow/max_turns_validation_test.go
+++ b/pkg/workflow/max_turns_validation_test.go
@@ -1,0 +1,164 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaxTurnsValidationWithUnsupportedEngine(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		engine      string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "max-turns with codex engine should fail",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: codex
+max-turns: 5
+---
+
+# Test Workflow
+
+This should fail because codex doesn't support max-turns.`,
+			engine:      "codex",
+			expectError: true,
+			errorMsg:    "max-turns not supported: engine 'codex' does not support the max-turns feature",
+		},
+		{
+			name: "max-turns with claude engine should succeed",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+max-turns: 5
+---
+
+# Test Workflow
+
+This should succeed because claude supports max-turns.`,
+			engine:      "claude",
+			expectError: false,
+		},
+		{
+			name: "codex engine without max-turns should succeed",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: codex
+---
+
+# Test Workflow
+
+This should succeed because no max-turns is specified.`,
+			engine:      "codex",
+			expectError: false,
+		},
+		{
+			name: "claude engine without max-turns should succeed",
+			content: `---
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+engine: claude
+---
+
+# Test Workflow
+
+This should succeed because no max-turns is specified.`,
+			engine:      "claude",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory for the test
+			tmpDir, err := os.MkdirTemp("", "max-turns-validation-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			// Create a test workflow file
+			testFile := filepath.Join(tmpDir, "test.md")
+			err = os.WriteFile(testFile, []byte(tt.content), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create a compiler instance
+			compiler := NewCompiler(false, "", "test")
+			compiler.SetSkipValidation(false)
+
+			// Try to compile the workflow
+			err = compiler.CompileWorkflow(testFile)
+
+			if tt.expectError {
+				// We expect an error
+				if err == nil {
+					t.Errorf("Expected error but compilation succeeded")
+					return
+				}
+
+				// Check if the error message contains the expected text
+				if !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error message to contain '%s', but got: %s", tt.errorMsg, err.Error())
+				}
+			} else {
+				// We don't expect an error
+				if err != nil {
+					t.Errorf("Expected compilation to succeed but got error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEngineSupportsMaxTurns(t *testing.T) {
+	tests := []struct {
+		name            string
+		engineID        string
+		expectedSupport bool
+	}{
+		{
+			name:            "claude engine supports max-turns",
+			engineID:        "claude",
+			expectedSupport: true,
+		},
+		{
+			name:            "codex engine does not support max-turns",
+			engineID:        "codex",
+			expectedSupport: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := GetGlobalEngineRegistry()
+			engine, err := registry.GetEngine(tt.engineID)
+			if err != nil {
+				t.Fatalf("Failed to get engine '%s': %v", tt.engineID, err)
+			}
+
+			actualSupport := engine.SupportsMaxTurns()
+			if actualSupport != tt.expectedSupport {
+				t.Errorf("Expected engine '%s' to have SupportsMaxTurns() = %v, but got %v",
+					tt.engineID, tt.expectedSupport, actualSupport)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/githubnext/gh-aw-internal/pull/768

-----

This PR implements the `max-turns` frontmatter parameter to limit the number of chat iterations within a single agentic run, providing a crucial safety mechanism to prevent runaway chat loops and control API costs.

## Overview

The `max-turns` feature works by passing a turn limit directly to the AI engine (currently Claude Code action), which enforces the restriction at the engine level. This is different from `max-runs` which limits the number of separate workflow executions.

**New in this version**: Engine capability validation ensures `max-turns` can only be used with compatible engines, preventing compilation errors at runtime.

## Usage

Add `max-turns` to any workflow frontmatter with a supported engine:

```yaml
---
on:
  workflow_dispatch:
permissions:
  contents: read
engine: claude  # Only Claude currently supports max-turns
max-turns: 5
tools:
  github:
    allowed: [get_issue, add_issue_comment]
---

# Example Workflow

This workflow will limit Claude to exactly 5 chat iterations.
```

When compiled, this generates a GitHub Actions workflow that passes `max_turns: 5` to the Claude Code action, ensuring the AI stops after the specified number of iterations.

## Engine Compatibility

- ✅ **Claude**: Fully supports max-turns feature
- ❌ **Codex**: Does not support max-turns (compilation will fail with clear error message)

The system now validates engine capabilities during compilation:

```bash
# This will fail with a clear error message
$ gh aw compile workflow-with-codex-and-max-turns.md
✗ workflow.md:1:1: error: max-turns not supported: max-turns feature is not supported by engine 'codex' (only supported by: claude)
```

## Implementation Details

- **Schema Validation**: Added `max-turns` as an integer field to the JSON schema
- **Frontmatter Parsing**: Extended workflow data extraction to handle the new parameter
- **Engine Integration**: Modified Claude engine to include `max_turns` in action inputs
- **Engine Capability System**: Added `SupportsMaxTurns()` method to `AgenticEngine` interface
- **Validation Logic**: Prevents compilation when max-turns is used with incompatible engines
- **Documentation**: Updated frontmatter documentation with examples and best practices
- **Testing**: Added comprehensive unit tests covering validation and compilation scenarios

## Benefits

- 🛡️ **Safety**: Prevents infinite chat loops that could consume excessive API credits
- 💰 **Cost Control**: Provides predictable bounds on API usage per workflow run
- 🎯 **Efficiency**: Encourages focused, concise AI responses
- 🔧 **Flexibility**: Can be configured per-workflow based on complexity needs
- 🚨 **Validation**: Prevents usage with incompatible engines at compile time

The feature seamlessly integrates with existing workflows and maintains backward compatibility - workflows without `max-turns` continue to work unchanged.

Fixes #713.

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Share your feedback on Copilot coding agent for the chance to win a $200 gift card! Click [here](https://survey.alchemer.com/s3/8343779/Copilot-Coding-agent) to start the survey.