### PR TITLE
fix timezone for stop time

### DIFF
--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -650,7 +650,7 @@ func (c *Compiler) parseWorkflowFile(markdownPath string) (*WorkflowData, error)
 
 	// Resolve relative stop-time to absolute time if needed
 	if workflowData.StopTime != "" {
-		resolvedStopTime, err := resolveStopTime(workflowData.StopTime, time.Now())
+		resolvedStopTime, err := resolveStopTime(workflowData.StopTime, time.Now().UTC())
 		if err != nil {
 			return nil, fmt.Errorf("invalid stop-time format: %w", err)
 		}

--- a/pkg/workflow/time_delta.go
+++ b/pkg/workflow/time_delta.go
@@ -196,8 +196,8 @@ func parseAbsoluteDateTime(dateTimeStr string) (string, error) {
 	// Try to parse with each format
 	for _, format := range formats {
 		if parsed, err := time.Parse(format, dateTimeStr); err == nil {
-			// Successfully parsed, return in standard format
-			return parsed.Format("2006-01-02 15:04:05"), nil
+			// Successfully parsed, convert to UTC and return in standard format
+			return parsed.UTC().Format("2006-01-02 15:04:05"), nil
 		}
 	}
 
@@ -207,8 +207,8 @@ func parseAbsoluteDateTime(dateTimeStr string) (string, error) {
 
 	for _, format := range formats {
 		if parsed, err := time.Parse(format, normalizedStr); err == nil {
-			// Successfully parsed, return in standard format
-			return parsed.Format("2006-01-02 15:04:05"), nil
+			// Successfully parsed, convert to UTC and return in standard format
+			return parsed.UTC().Format("2006-01-02 15:04:05"), nil
 		}
 	}
 
@@ -231,7 +231,7 @@ func parseAbsoluteDateTime(dateTimeStr string) (string, error) {
 
 	for _, format := range smartFormats {
 		if parsed, err := time.Parse(format, dateTimeStr); err == nil {
-			return parsed.Format("2006-01-02 15:04:05"), nil
+			return parsed.UTC().Format("2006-01-02 15:04:05"), nil
 		}
 	}
 
@@ -253,8 +253,8 @@ func resolveStopTime(stopTime string, compilationTime time.Time) (string, error)
 			return "", err
 		}
 
-		// Calculate absolute time
-		absoluteTime := compilationTime.Add(delta.toDuration())
+		// Calculate absolute time in UTC
+		absoluteTime := compilationTime.UTC().Add(delta.toDuration())
 
 		// Format in the expected format: "YYYY-MM-DD HH:MM:SS"
 		return absoluteTime.Format("2006-01-02 15:04:05"), nil


### PR DESCRIPTION
Stop times are not being recorded in the YML in UTC, instead they are using locale time depending on timezone/locale where compile was run.  

Please fix this. 