### PR TITLE
inspect --tool filter

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -124,6 +124,9 @@ gh aw inspect workflow-name
 # Filter inspection to specific servers by name
 gh aw inspect workflow-name --server server-name
 
+# Show detailed information about a specific tool (requires --server)
+gh aw inspect workflow-name --server server-name --tool tool-name
+
 # Enable verbose output with connection details
 gh aw inspect workflow-name --verbose
 
@@ -134,6 +137,7 @@ gh aw inspect workflow-name --inspector
 **Key Features:**
 - Server discovery and connection testing
 - Tool and capability inspection
+- Detailed tool information with `--tool` flag
 - Permission analysis
 - Multi-protocol support (stdio, Docker, HTTP)
 - Web inspector integration

--- a/pkg/cli/inspect.go
+++ b/pkg/cli/inspect.go
@@ -16,7 +16,7 @@ import (
 )
 
 // InspectWorkflowMCP inspects MCP servers used by a workflow and lists available tools, resources, and roots
-func InspectWorkflowMCP(workflowFile string, serverFilter string, verbose bool) error {
+func InspectWorkflowMCP(workflowFile string, serverFilter string, toolFilter string, verbose bool) error {
 	workflowsDir := getWorkflowsDir()
 
 	// If no workflow file specified, show available workflow files with MCP configs
@@ -102,14 +102,18 @@ func InspectWorkflowMCP(workflowFile string, serverFilter string, verbose bool) 
 	}
 
 	// Inspect each MCP server
-	fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Found %d MCP server(s) to inspect", len(mcpConfigs))))
+	if toolFilter != "" {
+		fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Found %d MCP server(s), looking for tool '%s'", len(mcpConfigs), toolFilter)))
+	} else {
+		fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Found %d MCP server(s) to inspect", len(mcpConfigs))))
+	}
 	fmt.Println()
 
 	for i, config := range mcpConfigs {
 		if i > 0 {
 			fmt.Println()
 		}
-		if err := inspectMCPServer(config, verbose); err != nil {
+		if err := inspectMCPServer(config, toolFilter, verbose); err != nil {
 			fmt.Println(console.FormatError(console.CompilerError{
 				Type:    "error",
 				Message: fmt.Sprintf("Failed to inspect MCP server '%s': %v", config.Name, err),
@@ -188,6 +192,7 @@ func listWorkflowsWithMCP(workflowsDir string, verbose bool) error {
 // NewInspectCommand creates the inspect command
 func NewInspectCommand() *cobra.Command {
 	var serverFilter string
+	var toolFilter string
 	var spawnInspector bool
 
 	cmd := &cobra.Command{
@@ -202,6 +207,7 @@ Examples:
   gh aw inspect                    # List workflows with MCP servers
   gh aw inspect weekly-research    # Inspect MCP servers in weekly-research.md  
   gh aw inspect repomind --server repo-mind  # Inspect only the repo-mind server
+  gh aw inspect weekly-research --server github --tool create_issue  # Show details for a specific tool
   gh aw inspect weekly-research -v # Verbose output with detailed connection info
   gh aw inspect weekly-research --inspector  # Launch @modelcontextprotocol/inspector
 
@@ -224,16 +230,22 @@ The command will:
 				verbose = verbose || parentVerbose
 			}
 
+			// Validate that tool flag requires server flag
+			if toolFilter != "" && serverFilter == "" {
+				return fmt.Errorf("--tool flag requires --server flag to be specified")
+			}
+
 			// Handle spawn inspector flag
 			if spawnInspector {
 				return spawnMCPInspector(workflowFile, serverFilter, verbose)
 			}
 
-			return InspectWorkflowMCP(workflowFile, serverFilter, verbose)
+			return InspectWorkflowMCP(workflowFile, serverFilter, toolFilter, verbose)
 		},
 	}
 
 	cmd.Flags().StringVar(&serverFilter, "server", "", "Filter to inspect only the specified MCP server")
+	cmd.Flags().StringVar(&toolFilter, "tool", "", "Show detailed information about a specific tool (requires --server)")
 	cmd.Flags().BoolP("verbose", "v", false, "Enable verbose output with detailed connection information")
 	cmd.Flags().BoolVar(&spawnInspector, "inspector", false, "Launch the official @modelcontextprotocol/inspector tool")
 
@@ -278,18 +290,18 @@ func spawnMCPInspector(workflowFile string, serverFilter string, verbose bool) e
 		// Parse the workflow file to extract MCP configurations
 		content, err := os.ReadFile(workflowPath)
 		if err != nil {
-			return fmt.Errorf("failed to read workflow file: %w", err)
+			return err
 		}
 
 		workflowData, err := parser.ExtractFrontmatterFromContent(string(content))
 		if err != nil {
-			return fmt.Errorf("failed to parse workflow file: %w", err)
+			return err
 		}
 
 		// Extract MCP configurations
 		mcpConfigs, err = parser.ExtractMCPConfigurations(workflowData.Frontmatter, serverFilter)
 		if err != nil {
-			return fmt.Errorf("failed to extract MCP configurations: %w", err)
+			return err
 		}
 
 		if len(mcpConfigs) > 0 {
@@ -388,6 +400,7 @@ func spawnMCPInspector(workflowFile string, serverFilter string, verbose bool) e
 			fmt.Println()
 		} else {
 			fmt.Println(console.FormatWarningMessage("No MCP servers found in workflow"))
+			return nil
 		}
 	}
 

--- a/pkg/cli/inspect.go
+++ b/pkg/cli/inspect.go
@@ -17,7 +17,7 @@ import (
 
 // InspectWorkflowMCP inspects MCP servers used by a workflow and lists available tools, resources, and roots
 func InspectWorkflowMCP(workflowFile string, serverFilter string, verbose bool) error {
-	workflowsDir := filepath.Join(".github", "workflows")
+	workflowsDir := getWorkflowsDir()
 
 	// If no workflow file specified, show available workflow files with MCP configs
 	if workflowFile == "" {
@@ -254,7 +254,7 @@ func spawnMCPInspector(workflowFile string, serverFilter string, verbose bool) e
 
 	// If workflow file is specified, extract MCP configurations and start servers
 	if workflowFile != "" {
-		workflowsDir := filepath.Join(".github", "workflows")
+		workflowsDir := workflow.GetWorkflowDir()
 
 		// Normalize the workflow file path
 		if !strings.HasSuffix(workflowFile, ".md") {

--- a/pkg/cli/inspect_mcp.go
+++ b/pkg/cli/inspect_mcp.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,48 @@ import (
 	"github.com/githubnext/gh-aw/pkg/parser"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// extractToolInfo creates a detailed MCPToolInfo from an MCP Tool
+func extractToolInfo(tool *mcp.Tool) parser.MCPToolInfo {
+	toolInfo := parser.MCPToolInfo{
+		Name:        tool.Name,
+		Description: tool.Description,
+	}
+
+	// Capture detailed information from the MCP tool
+	if tool.Annotations != nil {
+		toolInfo.Title = tool.Annotations.Title
+		toolInfo.Annotations = &parser.MCPToolAnnotations{
+			DestructiveHint: tool.Annotations.DestructiveHint,
+			IdempotentHint:  tool.Annotations.IdempotentHint,
+			OpenWorldHint:   tool.Annotations.OpenWorldHint,
+			ReadOnlyHint:    tool.Annotations.ReadOnlyHint,
+			Title:           tool.Annotations.Title,
+		}
+	}
+
+	// Convert input schema to map[string]interface{}
+	if tool.InputSchema != nil {
+		if schemaBytes, err := json.Marshal(tool.InputSchema); err == nil {
+			var schemaMap map[string]interface{}
+			if err := json.Unmarshal(schemaBytes, &schemaMap); err == nil {
+				toolInfo.InputSchema = schemaMap
+			}
+		}
+	}
+
+	// Convert output schema to map[string]interface{}
+	if tool.OutputSchema != nil {
+		if schemaBytes, err := json.Marshal(tool.OutputSchema); err == nil {
+			var schemaMap map[string]interface{}
+			if err := json.Unmarshal(schemaBytes, &schemaMap); err == nil {
+				toolInfo.OutputSchema = schemaMap
+			}
+		}
+	}
+
+	return toolInfo
+}
 
 var (
 	headerStyle = lipgloss.NewStyle().
@@ -41,7 +84,7 @@ var (
 )
 
 // inspectMCPServer connects to an MCP server and queries its capabilities
-func inspectMCPServer(config parser.MCPServerConfig, verbose bool) error {
+func inspectMCPServer(config parser.MCPServerConfig, toolFilter string, verbose bool) error {
 	fmt.Printf("%s %s (%s)\n",
 		serverNameStyle.Render("📡 "+config.Name),
 		typeStyle.Render(config.Type),
@@ -54,7 +97,7 @@ func inspectMCPServer(config parser.MCPServerConfig, verbose bool) error {
 	}
 
 	// Connect to the server
-	info, err := connectToMCPServer(config, verbose)
+	info, err := connectToMCPServer(config, toolFilter, verbose)
 	if err != nil {
 		fmt.Print(errorBoxStyle.Render(fmt.Sprintf("❌ Connection failed: %s", err)))
 		return nil // Don't return error, just show connection failure
@@ -65,7 +108,7 @@ func inspectMCPServer(config parser.MCPServerConfig, verbose bool) error {
 	}
 
 	// Display server capabilities
-	displayServerCapabilities(info)
+	displayServerCapabilities(info, toolFilter)
 
 	return nil
 }
@@ -150,25 +193,25 @@ func validateServerSecrets(config parser.MCPServerConfig) error {
 }
 
 // connectToMCPServer establishes a connection to the MCP server and queries its capabilities
-func connectToMCPServer(config parser.MCPServerConfig, verbose bool) (*parser.MCPServerInfo, error) {
+func connectToMCPServer(config parser.MCPServerConfig, toolFilter string, verbose bool) (*parser.MCPServerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	switch config.Type {
 	case "stdio":
-		return connectStdioMCPServer(ctx, config, verbose)
+		return connectStdioMCPServer(ctx, config, toolFilter, verbose)
 	case "docker":
 		// Docker MCP servers are treated as stdio servers that run via docker command
-		return connectStdioMCPServer(ctx, config, verbose)
+		return connectStdioMCPServer(ctx, config, toolFilter, verbose)
 	case "http":
-		return connectHTTPMCPServer(ctx, config, verbose)
+		return connectHTTPMCPServer(ctx, config, toolFilter, verbose)
 	default:
 		return nil, fmt.Errorf("unsupported MCP server type: %s", config.Type)
 	}
 }
 
 // connectStdioMCPServer connects to a stdio-based MCP server using the Go SDK
-func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, verbose bool) (*parser.MCPServerInfo, error) {
+func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, toolFilter string, verbose bool) (*parser.MCPServerInfo, error) {
 	if verbose {
 		fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Starting stdio MCP server: %s %s", config.Command, strings.Join(config.Args, " "))))
 	}
@@ -237,10 +280,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, v
 		}
 	} else {
 		for _, tool := range toolsResult.Tools {
-			info.Tools = append(info.Tools, parser.MCPToolInfo{
-				Name:        tool.Name,
-				Description: tool.Description,
-			})
+			info.Tools = append(info.Tools, extractToolInfo(tool))
 		}
 	}
 
@@ -295,7 +335,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, v
 }
 
 // connectHTTPMCPServer connects to an HTTP-based MCP server using the Go SDK
-func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, verbose bool) (*parser.MCPServerInfo, error) {
+func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, toolFilter string, verbose bool) (*parser.MCPServerInfo, error) {
 	if verbose {
 		fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Connecting to HTTP MCP server: %s", config.URL)))
 	}
@@ -340,10 +380,7 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, ve
 		}
 	} else {
 		for _, tool := range toolsResult.Tools {
-			info.Tools = append(info.Tools, parser.MCPToolInfo{
-				Name:        tool.Name,
-				Description: tool.Description,
-			})
+			info.Tools = append(info.Tools, extractToolInfo(tool))
 		}
 	}
 
@@ -396,65 +433,74 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, ve
 }
 
 // displayServerCapabilities shows the server's tools, resources, and roots in formatted tables
-func displayServerCapabilities(info *parser.MCPServerInfo) {
+func displayServerCapabilities(info *parser.MCPServerInfo, toolFilter string) {
 	fmt.Print(successBoxStyle.Render("✅ Connection successful"))
 
 	// Display tools with allowed/not allowed status
 	if len(info.Tools) > 0 {
-		fmt.Printf("\n%s\n", headerStyle.Render("🛠️  Tool Access Status"))
+		// If a specific tool is requested, show detailed information
+		if toolFilter != "" {
+			displayDetailedToolInfo(info, toolFilter)
+		} else {
+			fmt.Printf("\n%s\n", headerStyle.Render("🛠️  Tool Access Status"))
 
-		// Create a map for quick lookup of allowed tools
-		allowedMap := make(map[string]bool)
-		for _, allowed := range info.Config.Allowed {
-			allowedMap[allowed] = true
-		}
-
-		headers := []string{"Tool Name", "Allow", "Description"}
-		rows := make([][]string, 0, len(info.Tools))
-
-		for _, tool := range info.Tools {
-			description := tool.Description
-			if len(description) > 50 {
-				description = description[:47] + "..."
+			// Create a map for quick lookup of allowed tools
+			allowedMap := make(map[string]bool)
+			for _, allowed := range info.Config.Allowed {
+				allowedMap[allowed] = true
 			}
 
-			// Determine status
-			status := "🚫"
-			if len(info.Config.Allowed) == 0 {
-				// If no allowed list is specified, assume all tools are allowed
-				status = "✅"
-			} else if allowedMap[tool.Name] {
-				status = "✅"
+			headers := []string{"Tool Name", "Allow", "Description"}
+			rows := make([][]string, 0, len(info.Tools))
+
+			for _, tool := range info.Tools {
+				description := tool.Description
+				if len(description) > 50 {
+					description = description[:47] + "..."
+				}
+
+				// Determine status
+				status := "🚫"
+				if len(info.Config.Allowed) == 0 {
+					// If no allowed list is specified, assume all tools are allowed
+					status = "✅"
+				} else if allowedMap[tool.Name] {
+					status = "✅"
+				}
+
+				rows = append(rows, []string{tool.Name, status, description})
 			}
 
-			rows = append(rows, []string{tool.Name, status, description})
-		}
+			table := console.RenderTable(console.TableConfig{
+				Headers: headers,
+				Rows:    rows,
+			})
+			fmt.Print(table)
 
-		table := console.RenderTable(console.TableConfig{
-			Headers: headers,
-			Rows:    rows,
-		})
-		fmt.Print(table)
-
-		// Display summary
-		allowedCount := 0
-		for _, tool := range info.Tools {
-			if len(info.Config.Allowed) == 0 || allowedMap[tool.Name] {
-				allowedCount++
+			// Display summary
+			allowedCount := 0
+			for _, tool := range info.Tools {
+				if len(info.Config.Allowed) == 0 || allowedMap[tool.Name] {
+					allowedCount++
+				}
 			}
-		}
-		fmt.Printf("\n📊 Summary: %d allowed, %d not allowed out of %d total tools\n",
-			allowedCount, len(info.Tools)-allowedCount, len(info.Tools))
+			fmt.Printf("\n📊 Summary: %d allowed, %d not allowed out of %d total tools\n",
+				allowedCount, len(info.Tools)-allowedCount, len(info.Tools))
 
-		// Add helpful hint about how to allow tools in workflow frontmatter
-		displayToolAllowanceHint(info)
+			// Add helpful hint about how to allow tools in workflow frontmatter
+			displayToolAllowanceHint(info)
+		}
 
 	} else {
-		fmt.Printf("\n%s\n", console.FormatWarningMessage("No tools available"))
+		if toolFilter != "" {
+			fmt.Printf("\n%s\n", console.FormatWarningMessage(fmt.Sprintf("Tool '%s' not found", toolFilter)))
+		} else {
+			fmt.Printf("\n%s\n", console.FormatWarningMessage("No tools available"))
+		}
 	}
 
-	// Display resources
-	if len(info.Resources) > 0 {
+	// Display resources (skip if showing specific tool details)
+	if toolFilter == "" && len(info.Resources) > 0 {
 		fmt.Printf("\n%s\n", headerStyle.Render("📚 Available Resources"))
 
 		headers := []string{"URI", "Name", "Description", "MIME Type"}
@@ -479,12 +525,12 @@ func displayServerCapabilities(info *parser.MCPServerInfo) {
 			Rows:    rows,
 		})
 		fmt.Print(table)
-	} else {
+	} else if toolFilter == "" {
 		fmt.Printf("\n%s\n", console.FormatWarningMessage("No resources available"))
 	}
 
-	// Display roots
-	if len(info.Roots) > 0 {
+	// Display roots (skip if showing specific tool details)
+	if toolFilter == "" && len(info.Roots) > 0 {
 		fmt.Printf("\n%s\n", headerStyle.Render("🌳 Available Roots"))
 
 		headers := []string{"URI", "Name"}
@@ -499,8 +545,119 @@ func displayServerCapabilities(info *parser.MCPServerInfo) {
 			Rows:    rows,
 		})
 		fmt.Print(table)
-	} else {
+	} else if toolFilter == "" {
 		fmt.Printf("\n%s\n", console.FormatWarningMessage("No roots available"))
+	}
+
+	fmt.Println()
+}
+
+// displayDetailedToolInfo shows detailed information about a specific tool
+func displayDetailedToolInfo(info *parser.MCPServerInfo, toolName string) {
+	// Find the specific tool
+	var foundTool *parser.MCPToolInfo
+	for i, tool := range info.Tools {
+		if tool.Name == toolName {
+			foundTool = &info.Tools[i]
+			break
+		}
+	}
+
+	if foundTool == nil {
+		fmt.Printf("\n%s\n", console.FormatWarningMessage(fmt.Sprintf("Tool '%s' not found", toolName)))
+		fmt.Printf("Available tools: ")
+		toolNames := make([]string, len(info.Tools))
+		for i, tool := range info.Tools {
+			toolNames[i] = tool.Name
+		}
+		fmt.Printf("%s\n", strings.Join(toolNames, ", "))
+		return
+	}
+
+	// Check if tool is allowed
+	isAllowed := len(info.Config.Allowed) == 0 // Default to allowed if no allowlist
+	for _, allowed := range info.Config.Allowed {
+		if allowed == toolName {
+			isAllowed = true
+			break
+		}
+	}
+
+	fmt.Printf("\n%s\n", headerStyle.Render(fmt.Sprintf("🛠️  Tool Details: %s", foundTool.Name)))
+
+	// Display basic information
+	fmt.Printf("📋 **Name:** %s\n", foundTool.Name)
+
+	// Show title if available and different from name
+	if foundTool.Title != "" && foundTool.Title != foundTool.Name {
+		fmt.Printf("📄 **Title:** %s\n", foundTool.Title)
+	}
+	if foundTool.Annotations != nil && foundTool.Annotations.Title != "" && foundTool.Annotations.Title != foundTool.Name && foundTool.Annotations.Title != foundTool.Title {
+		fmt.Printf("📄 **Annotation Title:** %s\n", foundTool.Annotations.Title)
+	}
+
+	fmt.Printf("📝 **Description:** %s\n", foundTool.Description)
+
+	// Display allowance status
+	if isAllowed {
+		fmt.Printf("✅ **Status:** Allowed\n")
+	} else {
+		fmt.Printf("🚫 **Status:** Not allowed (add to 'allowed' list in workflow frontmatter)\n")
+	}
+
+	// Display annotations if available
+	if foundTool.Annotations != nil {
+		fmt.Printf("\n%s\n", headerStyle.Render("⚙️  Tool Attributes"))
+
+		if foundTool.Annotations.ReadOnlyHint {
+			fmt.Printf("🔒 **Read-only:** This tool does not modify its environment\n")
+		} else {
+			fmt.Printf("🔓 **Modifies environment:** This tool can make changes\n")
+		}
+
+		if foundTool.Annotations.IdempotentHint {
+			fmt.Printf("🔄 **Idempotent:** Calling with same arguments has no additional effect\n")
+		}
+
+		if foundTool.Annotations.DestructiveHint != nil {
+			if *foundTool.Annotations.DestructiveHint {
+				fmt.Printf("⚠️  **Destructive:** May perform destructive updates\n")
+			} else {
+				fmt.Printf("➕ **Additive:** Performs only additive updates\n")
+			}
+		}
+
+		if foundTool.Annotations.OpenWorldHint != nil {
+			if *foundTool.Annotations.OpenWorldHint {
+				fmt.Printf("🌐 **Open world:** Interacts with external entities\n")
+			} else {
+				fmt.Printf("🏠 **Closed world:** Domain of interaction is closed\n")
+			}
+		}
+	}
+
+	// Display input schema
+	if foundTool.InputSchema != nil {
+		fmt.Printf("\n%s\n", headerStyle.Render("📥 Input Schema"))
+		if schemaJSON, err := json.MarshalIndent(foundTool.InputSchema, "", "  "); err == nil {
+			fmt.Printf("```json\n%s\n```\n", string(schemaJSON))
+		} else {
+			fmt.Printf("Error displaying input schema: %v\n", err)
+		}
+	} else {
+		fmt.Printf("\n%s\n", console.FormatInfoMessage("📥 No input schema defined"))
+	}
+
+	// Display output schema
+	if foundTool.OutputSchema != nil {
+		fmt.Printf("\n%s\n", headerStyle.Render("📤 Output Schema"))
+		if schemaJSON, err := json.MarshalIndent(foundTool.OutputSchema, "", "  "); err == nil {
+			fmt.Printf("```json\n%s\n```\n", string(schemaJSON))
+		} else {
+			fmt.Printf("Error displaying output schema: %v\n", err)
+		}
+	} else {
+		fmt.Printf("\n%s\n", console.FormatInfoMessage("📤 No output schema defined"))
 	}
 
 	fmt.Println()

--- a/pkg/cli/inspect_mcp.go
+++ b/pkg/cli/inspect_mcp.go
@@ -223,8 +223,8 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, t
 		Config:    config,
 		Connected: true,
 		Tools:     []*mcp.Tool{},
-		Resources: []parser.MCPResourceInfo{},
-		Roots:     []parser.MCPRootInfo{},
+		Resources: []*mcp.Resource{},
+		Roots:     []*mcp.Root{},
 	}
 
 	// List tools
@@ -253,13 +253,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, t
 		}
 	} else {
 		for _, resource := range resourcesResult.Resources {
-			mimeType := resource.MIMEType
-			info.Resources = append(info.Resources, parser.MCPResourceInfo{
-				URI:         resource.URI,
-				Name:        resource.Name,
-				Description: resource.Description,
-				MimeType:    mimeType,
-			})
+			info.Resources = append(info.Resources, resource)
 		}
 	}
 
@@ -280,7 +274,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, t
 					}
 				}
 				if !found {
-					info.Roots = append(info.Roots, parser.MCPRootInfo{
+					info.Roots = append(info.Roots, &mcp.Root{
 						URI:  rootURI,
 						Name: parts[0],
 					})
@@ -323,8 +317,8 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, to
 		Config:    config,
 		Connected: true,
 		Tools:     []*mcp.Tool{},
-		Resources: []parser.MCPResourceInfo{},
-		Roots:     []parser.MCPRootInfo{},
+		Resources: []*mcp.Resource{},
+		Roots:     []*mcp.Root{},
 	}
 
 	// List tools
@@ -353,13 +347,7 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, to
 		}
 	} else {
 		for _, resource := range resourcesResult.Resources {
-			mimeType := resource.MIMEType
-			info.Resources = append(info.Resources, parser.MCPResourceInfo{
-				URI:         resource.URI,
-				Name:        resource.Name,
-				Description: resource.Description,
-				MimeType:    mimeType,
-			})
+			info.Resources = append(info.Resources, resource)
 		}
 	}
 
@@ -378,7 +366,7 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, to
 					}
 				}
 				if !found {
-					info.Roots = append(info.Roots, parser.MCPRootInfo{
+					info.Roots = append(info.Roots, &mcp.Root{
 						URI:  rootURI,
 						Name: parts[0],
 					})
@@ -468,7 +456,7 @@ func displayServerCapabilities(info *parser.MCPServerInfo, toolFilter string) {
 				description = description[:37] + "..."
 			}
 
-			mimeType := resource.MimeType
+			mimeType := resource.MIMEType
 			if mimeType == "" {
 				mimeType = "N/A"
 			}

--- a/pkg/cli/inspect_mcp.go
+++ b/pkg/cli/inspect_mcp.go
@@ -33,12 +33,6 @@ var (
 			BorderForeground(lipgloss.Color("#FF5555")).
 			Padding(1).
 			Margin(1)
-
-	successBoxStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#50FA7B")).
-			Padding(1).
-			Margin(1)
 )
 
 // inspectMCPServer connects to an MCP server and queries its capabilities
@@ -237,9 +231,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, t
 			fmt.Println(console.FormatWarningMessage(fmt.Sprintf("Failed to list tools: %v", err)))
 		}
 	} else {
-		for _, tool := range toolsResult.Tools {
-			info.Tools = append(info.Tools, tool)
-		}
+		info.Tools = append(info.Tools, toolsResult.Tools...)
 	}
 
 	// List resources
@@ -252,9 +244,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, t
 			fmt.Println(console.FormatWarningMessage(fmt.Sprintf("Failed to list resources: %v", err)))
 		}
 	} else {
-		for _, resource := range resourcesResult.Resources {
-			info.Resources = append(info.Resources, resource)
-		}
+		info.Resources = append(info.Resources, resourcesResult.Resources...)
 	}
 
 	// Note: Roots are not directly available via MCP protocol in the current spec,
@@ -331,9 +321,7 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, to
 			fmt.Println(console.FormatWarningMessage(fmt.Sprintf("Failed to list tools: %v", err)))
 		}
 	} else {
-		for _, tool := range toolsResult.Tools {
-			info.Tools = append(info.Tools, tool)
-		}
+		info.Tools = append(info.Tools, toolsResult.Tools...)
 	}
 
 	// List resources
@@ -346,9 +334,7 @@ func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, to
 			fmt.Println(console.FormatWarningMessage(fmt.Sprintf("Failed to list resources: %v", err)))
 		}
 	} else {
-		for _, resource := range resourcesResult.Resources {
-			info.Resources = append(info.Resources, resource)
-		}
+		info.Resources = append(info.Resources, resourcesResult.Resources...)
 	}
 
 	// Extract root URIs from resources (simple heuristic)

--- a/pkg/cli/inspect_test.go
+++ b/pkg/cli/inspect_test.go
@@ -191,30 +191,6 @@ func TestInspectWorkflowMCPWithToolFilter(t *testing.T) {
 	}
 }
 
-func TestExtractToolInfo(t *testing.T) {
-	// Create a mock MCP tool with various properties
-	testTool := &mcp.Tool{
-		Name:        "test_tool",
-		Description: "A test tool for unit testing",
-	}
-
-	// Test basic extraction
-	result := extractToolInfo(testTool)
-
-	if result.Name != "test_tool" {
-		t.Errorf("Expected tool name 'test_tool', got '%s'", result.Name)
-	}
-
-	if result.Description != "A test tool for unit testing" {
-		t.Errorf("Expected description 'A test tool for unit testing', got '%s'", result.Description)
-	}
-
-	// Test that it doesn't crash with nil annotations
-	if result.Annotations != nil {
-		t.Errorf("Expected nil annotations for tool without annotations, got %+v", result.Annotations)
-	}
-}
-
 func TestExtractMCPConfigurations(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -642,7 +618,7 @@ func TestDisplayToolAllowanceHint(t *testing.T) {
 					Name:    "test-server",
 					Allowed: []string{"tool1", "tool2"},
 				},
-				Tools: []parser.MCPToolInfo{
+				Tools: []*mcp.Tool{
 					{Name: "tool1", Description: "Allowed tool 1"},
 					{Name: "tool2", Description: "Allowed tool 2"},
 					{Name: "tool3", Description: "Blocked tool 3"},
@@ -667,7 +643,7 @@ func TestDisplayToolAllowanceHint(t *testing.T) {
 					Name:    "open-server",
 					Allowed: []string{}, // Empty means all allowed
 				},
-				Tools: []parser.MCPToolInfo{
+				Tools: []*mcp.Tool{
 					{Name: "tool1", Description: "Tool 1"},
 					{Name: "tool2", Description: "Tool 2"},
 				},
@@ -688,7 +664,7 @@ func TestDisplayToolAllowanceHint(t *testing.T) {
 					Name:    "explicit-server",
 					Allowed: []string{"tool1", "tool2"},
 				},
-				Tools: []parser.MCPToolInfo{
+				Tools: []*mcp.Tool{
 					{Name: "tool1", Description: "Tool 1"},
 					{Name: "tool2", Description: "Tool 2"},
 				},

--- a/pkg/cli/templates/instructions.md
+++ b/pkg/cli/templates/instructions.md
@@ -428,6 +428,37 @@ permissions:
   models: read      # Typically needed for AI workflows
 ```
 
+## Debugging and Inspection
+
+### MCP Server Inspection
+
+Use the `inspect` command to analyze and debug MCP servers in workflows:
+
+```bash
+# List workflows with MCP configurations
+gh aw inspect
+
+# Inspect MCP servers in a specific workflow
+gh aw inspect workflow-name
+
+# Filter to a specific MCP server
+gh aw inspect workflow-name --server server-name
+
+# Show detailed information about a specific tool
+gh aw inspect workflow-name --server server-name --tool tool-name
+
+# Enable verbose output with connection details
+gh aw inspect workflow-name --verbose
+```
+
+The `--tool` flag provides detailed information about a specific tool, including:
+- Tool name, title, and description
+- Input schema and parameters
+- Whether the tool is allowed in the workflow configuration
+- Annotations and additional metadata
+
+**Note**: The `--tool` flag requires the `--server` flag to specify which MCP server contains the tool.
+
 ## Compilation Process
 
 Agentic workflows compile to GitHub Actions YAML:

--- a/pkg/parser/mcp.go
+++ b/pkg/parser/mcp.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // MCPServerConfig represents a parsed MCP server configuration
@@ -17,25 +19,6 @@ type MCPServerConfig struct {
 	Headers   map[string]string `json:"headers"`   // for http
 	Env       map[string]string `json:"env"`       // environment variables
 	Allowed   []string          `json:"allowed"`   // allowed tools
-}
-
-// MCPToolInfo represents a tool available from an MCP server
-type MCPToolInfo struct {
-	Name         string                 `json:"name"`
-	Description  string                 `json:"description"`
-	Title        string                 `json:"title,omitempty"`
-	InputSchema  map[string]interface{} `json:"inputSchema,omitempty"`
-	OutputSchema map[string]interface{} `json:"outputSchema,omitempty"`
-	Annotations  *MCPToolAnnotations    `json:"annotations,omitempty"`
-}
-
-// MCPToolAnnotations represents tool annotations from an MCP server
-type MCPToolAnnotations struct {
-	DestructiveHint *bool  `json:"destructiveHint,omitempty"`
-	IdempotentHint  bool   `json:"idempotentHint,omitempty"`
-	OpenWorldHint   *bool  `json:"openWorldHint,omitempty"`
-	ReadOnlyHint    bool   `json:"readOnlyHint,omitempty"`
-	Title           string `json:"title,omitempty"`
 }
 
 // MCPResourceInfo represents a resource available from an MCP server
@@ -57,7 +40,7 @@ type MCPServerInfo struct {
 	Config    MCPServerConfig
 	Connected bool
 	Error     error
-	Tools     []MCPToolInfo
+	Tools     []*mcp.Tool
 	Resources []MCPResourceInfo
 	Roots     []MCPRootInfo
 }

--- a/pkg/parser/mcp.go
+++ b/pkg/parser/mcp.go
@@ -21,28 +21,14 @@ type MCPServerConfig struct {
 	Allowed   []string          `json:"allowed"`   // allowed tools
 }
 
-// MCPResourceInfo represents a resource available from an MCP server
-type MCPResourceInfo struct {
-	URI         string `json:"uri"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	MimeType    string `json:"mimeType"`
-}
-
-// MCPRootInfo represents a root available from an MCP server
-type MCPRootInfo struct {
-	URI  string `json:"uri"`
-	Name string `json:"name"`
-}
-
 // MCPServerInfo contains the inspection results for an MCP server
 type MCPServerInfo struct {
 	Config    MCPServerConfig
 	Connected bool
 	Error     error
 	Tools     []*mcp.Tool
-	Resources []MCPResourceInfo
-	Roots     []MCPRootInfo
+	Resources []*mcp.Resource
+	Roots     []*mcp.Root
 }
 
 // ExtractMCPConfigurations extracts MCP server configurations from workflow frontmatter

--- a/pkg/parser/mcp.go
+++ b/pkg/parser/mcp.go
@@ -21,8 +21,21 @@ type MCPServerConfig struct {
 
 // MCPToolInfo represents a tool available from an MCP server
 type MCPToolInfo struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description"`
+	Title        string                 `json:"title,omitempty"`
+	InputSchema  map[string]interface{} `json:"inputSchema,omitempty"`
+	OutputSchema map[string]interface{} `json:"outputSchema,omitempty"`
+	Annotations  *MCPToolAnnotations    `json:"annotations,omitempty"`
+}
+
+// MCPToolAnnotations represents tool annotations from an MCP server
+type MCPToolAnnotations struct {
+	DestructiveHint *bool  `json:"destructiveHint,omitempty"`
+	IdempotentHint  bool   `json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool  `json:"openWorldHint,omitempty"`
+	ReadOnlyHint    bool   `json:"readOnlyHint,omitempty"`
+	Title           string `json:"title,omitempty"`
 }
 
 // MCPResourceInfo represents a resource available from an MCP server

--- a/pkg/workflow/resolve.go
+++ b/pkg/workflow/resolve.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func GetWorkflowDir() string {
+	return filepath.Join(".github", "workflows")
+}
+
 // ResolveWorkflowName converts an agentic workflow ID to the GitHub Actions workflow name.
 // It normalizes the input by removing .md and .lock.yml extensions, then finds the
 // corresponding workflow files and extracts the actual workflow name from the lock.yml file.
@@ -29,7 +33,7 @@ func ResolveWorkflowName(workflowInput string) (string, error) {
 	normalizedName := normalizeWorkflowName(workflowInput)
 
 	// Get the workflows directory
-	workflowsDir := filepath.Join(".github", "workflows")
+	workflowsDir := GetWorkflowDir()
 
 	// Check if the agentic workflow markdown file exists
 	mdFile := filepath.Join(workflowsDir, normalizedName+".md")


### PR DESCRIPTION
Add a flag to print the full tool information (as opposed to an overview in the default mode). This useful for human/agent to understand better how the tool works.
- remove some duplicate types in favor of mcp package types