### PR TITLE
Run multiple workflows with "gh aw run" and add "--repeat SECONDS" flag to drive repeatedly repeat

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,6 +14,8 @@ gh aw add samples/weekly-research.md -r githubnext/agentics  # Add workflow and 
 gh aw compile                                                # Recompile to GitHub Actions
 gh aw status                                                 # Check status
 gh aw run weekly-research                                    # Execute workflow
+gh aw run weekly-research daily-plan                        # Execute multiple workflows
+gh aw run weekly-research --repeat 3600                     # Execute workflow every hour
 gh aw logs weekly-research                                   # View execution logs
 ```
 
@@ -102,8 +104,14 @@ These commands control the execution and state of your compiled agentic workflow
 
 **Workflow Execution:**
 ```bash
-# Run a workflow immediately in GitHub Actions
+# Run a single workflow immediately in GitHub Actions
 gh aw run WorkflowName
+
+# Run multiple workflows immediately in GitHub Actions
+gh aw run WorkflowName1 WorkflowName2 WorkflowName3
+
+# Run workflows and repeat every 3 minutes
+gh aw run WorkflowName --repeat 180
 
 # Run workflow with specific input parameters (if supported)
 gh aw run weekly-research --input priority=high

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -165,6 +165,32 @@ func TestRunWorkflowOnGitHub(t *testing.T) {
 	}
 }
 
+func TestRunWorkflowsOnGitHub(t *testing.T) {
+	// Test with empty workflow list
+	err := RunWorkflowsOnGitHub([]string{}, 0, false)
+	if err == nil {
+		t.Error("RunWorkflowsOnGitHub should return error for empty workflow list")
+	}
+
+	// Test with workflow list containing empty name
+	err = RunWorkflowsOnGitHub([]string{"valid-workflow", ""}, 0, false)
+	if err == nil {
+		t.Error("RunWorkflowsOnGitHub should return error for workflow list containing empty name")
+	}
+
+	// Test with nonexistent workflows (this will fail but gracefully)
+	err = RunWorkflowsOnGitHub([]string{"nonexistent-workflow1", "nonexistent-workflow2"}, 0, false)
+	if err == nil {
+		t.Error("RunWorkflowsOnGitHub should return error for non-existent workflows")
+	}
+
+	// Test with negative repeat seconds (should work as 0)
+	err = RunWorkflowsOnGitHub([]string{"nonexistent-workflow"}, -1, false)
+	if err == nil {
+		t.Error("RunWorkflowsOnGitHub should return error for non-existent workflow regardless of repeat value")
+	}
+}
+
 func TestGetLatestWorkflowRunWithTimestamp(t *testing.T) {
 	// Test with non-existent workflow - should handle gracefully
 	url, createdAt, err := getLatestWorkflowRunWithTimestamp("nonexistent-workflow.lock.yml", false)
@@ -215,6 +241,7 @@ func TestAllCommandsExist(t *testing.T) {
 		{func() error { return EnableWorkflows("test") }, false, "EnableWorkflows"},                                                        // Should handle missing directory gracefully
 		{func() error { return DisableWorkflows("test") }, false, "DisableWorkflows"},                                                      // Should handle missing directory gracefully
 		{func() error { return RunWorkflowOnGitHub("", false) }, true, "RunWorkflowOnGitHub"},                                              // Should error with empty workflow name
+		{func() error { return RunWorkflowsOnGitHub([]string{}, 0, false) }, true, "RunWorkflowsOnGitHub"},                                 // Should error with empty workflow list
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull request enhances the workflow execution capabilities of the CLI tool by allowing users to run multiple agentic workflows at once and to repeat executions at specified intervals. It updates both the implementation and documentation to reflect these new features, and adds comprehensive tests for the new functionality.