### PR TITLE
Move some tool neutral logic out of claude backend

### DIFF
--- a/pkg/cli/logs.go
+++ b/pkg/cli/logs.go
@@ -396,7 +396,7 @@ func DownloadWorkflowLogs(workflowName string, count int, startDate, endDate, ou
 	for i, pr := range processedRuns {
 		workflowRuns[i] = pr.Run
 	}
-	displayLogsOverview(workflowRuns, outputDir)
+	displayLogsOverview(workflowRuns)
 
 	// Display access log analysis
 	displayAccessLogAnalysis(processedRuns, verbose)
@@ -852,7 +852,7 @@ func parseLogFileWithEngine(filePath string, detectedEngine workflow.CodingAgent
 var extractJSONMetrics = workflow.ExtractJSONMetrics
 
 // displayLogsOverview displays a summary table of workflow runs and metrics
-func displayLogsOverview(runs []WorkflowRun, outputDir string) {
+func displayLogsOverview(runs []WorkflowRun) {
 	if len(runs) == 0 {
 		return
 	}

--- a/pkg/cli/mcp_inspect_mcp.go
+++ b/pkg/cli/mcp_inspect_mcp.go
@@ -49,7 +49,7 @@ func inspectMCPServer(config parser.MCPServerConfig, toolFilter string, verbose 
 	}
 
 	// Connect to the server
-	info, err := connectToMCPServer(config, toolFilter, verbose)
+	info, err := connectToMCPServer(config, verbose)
 	if err != nil {
 		fmt.Print(errorBoxStyle.Render(fmt.Sprintf("❌ Connection failed: %s", err)))
 		return nil // Don't return error, just show connection failure
@@ -145,25 +145,25 @@ func validateServerSecrets(config parser.MCPServerConfig) error {
 }
 
 // connectToMCPServer establishes a connection to the MCP server and queries its capabilities
-func connectToMCPServer(config parser.MCPServerConfig, toolFilter string, verbose bool) (*parser.MCPServerInfo, error) {
+func connectToMCPServer(config parser.MCPServerConfig, verbose bool) (*parser.MCPServerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	switch config.Type {
 	case "stdio":
-		return connectStdioMCPServer(ctx, config, toolFilter, verbose)
+		return connectStdioMCPServer(ctx, config, verbose)
 	case "docker":
 		// Docker MCP servers are treated as stdio servers that run via docker command
-		return connectStdioMCPServer(ctx, config, toolFilter, verbose)
+		return connectStdioMCPServer(ctx, config, verbose)
 	case "http":
-		return connectHTTPMCPServer(ctx, config, toolFilter, verbose)
+		return connectHTTPMCPServer(ctx, config, verbose)
 	default:
 		return nil, fmt.Errorf("unsupported MCP server type: %s", config.Type)
 	}
 }
 
 // connectStdioMCPServer connects to a stdio-based MCP server using the Go SDK
-func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, toolFilter string, verbose bool) (*parser.MCPServerInfo, error) {
+func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, verbose bool) (*parser.MCPServerInfo, error) {
 	if verbose {
 		fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Starting stdio MCP server: %s %s", config.Command, strings.Join(config.Args, " "))))
 	}
@@ -277,7 +277,7 @@ func connectStdioMCPServer(ctx context.Context, config parser.MCPServerConfig, t
 }
 
 // connectHTTPMCPServer connects to an HTTP-based MCP server using the Go SDK
-func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, toolFilter string, verbose bool) (*parser.MCPServerInfo, error) {
+func connectHTTPMCPServer(ctx context.Context, config parser.MCPServerConfig, verbose bool) (*parser.MCPServerInfo, error) {
 	if verbose {
 		fmt.Println(console.FormatInfoMessage(fmt.Sprintf("Connecting to HTTP MCP server: %s", config.URL)))
 	}

--- a/pkg/parser/json_path_locator.go
+++ b/pkg/parser/json_path_locator.go
@@ -153,7 +153,8 @@ func matchesPathAtLevel(line string, pathSegments []PathSegment, level int, arra
 	if level < len(pathSegments) {
 		segment := pathSegments[level]
 
-		if segment.Type == "key" {
+		switch segment.Type {
+		case "key":
 			// Look for "key:" pattern
 			keyPattern := regexp.MustCompile(`^` + regexp.QuoteMeta(segment.Value) + `\s*:`)
 			if keyPattern.MatchString(trimmedLine) {
@@ -163,7 +164,7 @@ func matchesPathAtLevel(line string, pathSegments []PathSegment, level int, arra
 					return level == len(pathSegments)-1, colonIndex + 2
 				}
 			}
-		} else if segment.Type == "index" {
+		case "index":
 			// For array elements, check if this is a list item at the right index
 			if strings.HasPrefix(trimmedLine, "-") {
 				currentIndex := arrayContexts[level]

--- a/pkg/workflow/claude_engine_tools_test.go
+++ b/pkg/workflow/claude_engine_tools_test.go
@@ -19,36 +19,24 @@ func TestClaudeEngineComputeAllowedTools(t *testing.T) {
 			expected: "ExitPlanMode,Glob,Grep,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
-			name: "bash with specific commands in claude section (new format)",
+			name: "bash with specific commands (neutral format)",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{"echo", "ls"},
-					},
-				},
+				"bash": []any{"echo", "ls"},
 			},
 			expected: "Bash(echo),Bash(ls),BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
 			name: "bash with nil value (all commands allowed)",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": nil,
-					},
-				},
+				"bash": nil,
 			},
 			expected: "Bash,BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
-			name: "regular tools in claude section (new format)",
+			name: "neutral web tools",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"WebFetch":  nil,
-						"WebSearch": nil,
-					},
-				},
+				"web-fetch":  nil,
+				"web-search": nil,
 			},
 			expected: "ExitPlanMode,Glob,Grep,LS,NotebookRead,Read,Task,TodoWrite,WebFetch,WebSearch",
 		},
@@ -62,14 +50,10 @@ func TestClaudeEngineComputeAllowedTools(t *testing.T) {
 			expected: "ExitPlanMode,Glob,Grep,LS,NotebookRead,Read,Task,TodoWrite,mcp__github__create_issue,mcp__github__list_issues",
 		},
 		{
-			name: "mixed claude and mcp tools",
+			name: "mixed neutral and mcp tools",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"WebFetch":  nil,
-						"WebSearch": nil,
-					},
-				},
+				"web-fetch":  nil,
+				"web-search": nil,
 				"github": map[string]any{
 					"allowed": []any{"list_issues"},
 				},
@@ -116,34 +100,22 @@ func TestClaudeEngineComputeAllowedTools(t *testing.T) {
 		{
 			name: "bash with :* wildcard (should ignore other bash tools)",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{":*"},
-					},
-				},
+				"bash": []any{":*"},
 			},
 			expected: "Bash,BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
 			name: "bash with :* wildcard mixed with other commands (should ignore other commands)",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{"echo", "ls", ":*", "cat"},
-					},
-				},
+				"bash": []any{"echo", "ls", ":*", "cat"},
 			},
 			expected: "Bash,BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
 			name: "bash with :* wildcard and other tools",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash":     []any{":*"},
-						"WebFetch": nil,
-					},
-				},
+				"bash":      []any{":*"},
+				"web-fetch": nil,
 				"github": map[string]any{
 					"allowed": []any{"list_issues"},
 				},
@@ -153,34 +125,22 @@ func TestClaudeEngineComputeAllowedTools(t *testing.T) {
 		{
 			name: "bash with single command should include implicit tools",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{"ls"},
-					},
-				},
+				"bash": []any{"ls"},
 			},
 			expected: "Bash(ls),BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
 			name: "explicit KillBash and BashOutput should not duplicate",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{"echo"},
-					},
-				},
+				"bash": []any{"echo"},
 			},
 			expected: "Bash(echo),BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite",
 		},
 		{
 			name: "no bash tools means no implicit tools",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"WebFetch":  nil,
-						"WebSearch": nil,
-					},
-				},
+				"web-fetch":  nil,
+				"web-search": nil,
 			},
 			expected: "ExitPlanMode,Glob,Grep,LS,NotebookRead,Read,Task,TodoWrite,WebFetch,WebSearch",
 		},
@@ -294,13 +254,9 @@ func TestClaudeEngineComputeAllowedToolsWithSafeOutputs(t *testing.T) {
 		expected    string
 	}{
 		{
-			name: "SafeOutputs with no tools - should add Write permission",
+			name:  "SafeOutputs with no tools - should add Write permission",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Read": nil,
-					},
-				},
+				// Using neutral tools instead of claude section
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreateIssues: &CreateIssuesConfig{Max: 1},
@@ -310,26 +266,17 @@ func TestClaudeEngineComputeAllowedToolsWithSafeOutputs(t *testing.T) {
 		{
 			name: "SafeOutputs with general Write permission - should not add specific Write",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Read":  nil,
-						"Write": nil,
-					},
-				},
+				"edit": nil, // This provides Write capabilities
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreateIssues: &CreateIssuesConfig{Max: 1},
 			},
-			expected: "ExitPlanMode,Glob,Grep,LS,NotebookRead,Read,Task,TodoWrite,Write",
+			expected: "Edit,ExitPlanMode,Glob,Grep,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write",
 		},
 		{
-			name: "No SafeOutputs - should not add Write permission",
+			name:  "No SafeOutputs - should not add Write permission",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Read": nil,
-					},
-				},
+				// Using neutral tools instead of claude section
 			},
 			safeOutputs: nil,
 			expected:    "ExitPlanMode,Glob,Grep,LS,NotebookRead,Read,Task,TodoWrite",
@@ -337,13 +284,8 @@ func TestClaudeEngineComputeAllowedToolsWithSafeOutputs(t *testing.T) {
 		{
 			name: "SafeOutputs with multiple output types",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash":       nil,
-						"BashOutput": nil,
-						"KillBash":   nil,
-					},
-				},
+				"bash": nil, // This provides Bash, BashOutput, KillBash
+				"edit": nil,
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreateIssues:       &CreateIssuesConfig{Max: 1},
@@ -355,11 +297,6 @@ func TestClaudeEngineComputeAllowedToolsWithSafeOutputs(t *testing.T) {
 		{
 			name: "SafeOutputs with MCP tools",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Read": nil,
-					},
-				},
 				"github": map[string]any{
 					"allowed": []any{"create_issue", "create_pull_request"},
 				},
@@ -374,11 +311,12 @@ func TestClaudeEngineComputeAllowedToolsWithSafeOutputs(t *testing.T) {
 			tools: map[string]any{
 				"bash":      []any{"echo", "ls"},
 				"web-fetch": nil,
+				"edit":      nil,
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreatePullRequests: &CreatePullRequestsConfig{Max: 1},
 			},
-			expected: "Bash(echo),Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),Bash(ls),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,WebFetch,Write",
+			expected: "Bash(echo),Bash(ls),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,WebFetch,Write",
 		},
 	}
 

--- a/pkg/workflow/codex_engine.go
+++ b/pkg/workflow/codex_engine.go
@@ -300,7 +300,7 @@ func (e *CodexEngine) renderCodexMCPConfig(yaml *strings.Builder, toolName strin
 		Format:      "toml",
 	}
 
-	err := renderSharedMCPConfig(yaml, toolName, toolConfig, false, renderer)
+	err := renderSharedMCPConfig(yaml, toolName, toolConfig, renderer)
 	if err != nil {
 		return err
 	}

--- a/pkg/workflow/custom_engine.go
+++ b/pkg/workflow/custom_engine.go
@@ -223,7 +223,7 @@ func (e *CustomEngine) renderCustomMCPConfig(yaml *strings.Builder, toolName str
 		Format:      "json",
 	}
 
-	err := renderSharedMCPConfig(yaml, toolName, toolConfig, isLast, renderer)
+	err := renderSharedMCPConfig(yaml, toolName, toolConfig, renderer)
 	if err != nil {
 		return err
 	}

--- a/pkg/workflow/git_commands_integration_test.go
+++ b/pkg/workflow/git_commands_integration_test.go
@@ -191,7 +191,7 @@ func (c *Compiler) parseWorkflowMarkdownContentWithToolsString(content string) (
 
 	// Extract and process tools
 	topTools := extractToolsFromFrontmatter(result.Frontmatter)
-	topTools = c.applyDefaultGitHubMCPTools(topTools)
+	topTools = c.applyDefaultTools(topTools, safeOutputs)
 
 	// Build basic workflow data for testing
 	workflowData := &WorkflowData{

--- a/pkg/workflow/git_commands_test.go
+++ b/pkg/workflow/git_commands_test.go
@@ -48,11 +48,7 @@ func TestApplyDefaultGitCommandsForSafeOutputs(t *testing.T) {
 		{
 			name: "existing bash commands should be preserved",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{"echo", "ls"},
-					},
-				},
+				"bash": []any{"echo", "ls"},
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreatePullRequests: &CreatePullRequestsConfig{},
@@ -62,11 +58,7 @@ func TestApplyDefaultGitCommandsForSafeOutputs(t *testing.T) {
 		{
 			name: "bash with wildcard should remain wildcard",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": []any{":*"},
-					},
-				},
+				"bash": []any{":*"},
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreatePullRequests: &CreatePullRequestsConfig{},
@@ -76,11 +68,7 @@ func TestApplyDefaultGitCommandsForSafeOutputs(t *testing.T) {
 		{
 			name: "bash with nil value should remain nil",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Bash": nil,
-					},
-				},
+				"bash": nil,
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreatePullRequests: &CreatePullRequestsConfig{},
@@ -98,7 +86,7 @@ func TestApplyDefaultGitCommandsForSafeOutputs(t *testing.T) {
 			}
 
 			// Apply both default tool functions in sequence
-			tools = compiler.applyDefaultGitHubMCPTools(tools)
+			tools = compiler.applyDefaultTools(tools, tt.safeOutputs)
 			result := engine.computeAllowedClaudeToolsString(tools, tt.safeOutputs)
 
 			// Parse the result string into individual tools
@@ -182,12 +170,7 @@ func TestAdditionalClaudeToolsForSafeOutputs(t *testing.T) {
 		{
 			name: "existing editing tools should be preserved",
 			tools: map[string]any{
-				"claude": map[string]any{
-					"allowed": map[string]any{
-						"Edit": nil,
-						"Task": nil,
-					},
-				},
+				"edit": nil,
 			},
 			safeOutputs: &SafeOutputsConfig{
 				CreatePullRequests: &CreatePullRequestsConfig{},
@@ -208,7 +191,7 @@ func TestAdditionalClaudeToolsForSafeOutputs(t *testing.T) {
 			}
 
 			// Apply both default tool functions in sequence
-			tools = compiler.applyDefaultGitHubMCPTools(tools)
+			tools = compiler.applyDefaultTools(tools, tt.safeOutputs)
 			result := engine.computeAllowedClaudeToolsString(tools, tt.safeOutputs)
 
 			// Parse the result string into individual tools

--- a/pkg/workflow/mcp-config.go
+++ b/pkg/workflow/mcp-config.go
@@ -18,7 +18,7 @@ type MCPConfigRenderer struct {
 
 // renderSharedMCPConfig generates MCP server configuration for a single tool using shared logic
 // This function handles the common logic for rendering MCP configurations across different engines
-func renderSharedMCPConfig(yaml *strings.Builder, toolName string, toolConfig map[string]any, isLast bool, renderer MCPConfigRenderer) error {
+func renderSharedMCPConfig(yaml *strings.Builder, toolName string, toolConfig map[string]any, renderer MCPConfigRenderer) error {
 	// Get MCP configuration in the new format
 	mcpConfig, err := getMCPConfig(toolConfig, toolName)
 	if err != nil {

--- a/pkg/workflow/network_defaults_integration_test.go
+++ b/pkg/workflow/network_defaults_integration_test.go
@@ -48,11 +48,12 @@ func TestNetworkDefaultsIntegration(t *testing.T) {
 		apiExampleFound := false
 
 		for _, domain := range domains {
-			if domain == "good.com" {
+			switch domain {
+			case "good.com":
 				goodComFound = true
-			} else if domain == "api.example.org" {
+			case "api.example.org":
 				apiExampleFound = true
-			} else {
+			default:
 				// Check if this is a default domain
 				for _, defaultDomain := range defaultDomains {
 					if domain == defaultDomain {

--- a/pkg/workflow/neutral_tools_simple_test.go
+++ b/pkg/workflow/neutral_tools_simple_test.go
@@ -42,21 +42,7 @@ func TestNeutralToolsExpandsToClaudeTools(t *testing.T) {
 		"mcp__github__list_issues",
 	}
 
-	// Verify Git commands are added due to safe outputs
-	expectedGitTools := []string{
-		"Bash(git add:*)",
-		"Bash(git commit:*)",
-		"Bash(git checkout:*)",
-		"Bash(git branch:*)",
-		"Bash(git rm:*)",
-		"Bash(git switch:*)",
-		"Bash(git merge:*)",
-	}
-
-	// Combine expected tools
-	allExpectedTools := append(expectedTools, expectedGitTools...)
-
-	for _, expectedTool := range allExpectedTools {
+	for _, expectedTool := range expectedTools {
 		if !containsTool(result, expectedTool) {
 			t.Errorf("Expected tool '%s' not found in result: %s", expectedTool, result)
 		}

--- a/pkg/workflow/output_missing_tool_test.go
+++ b/pkg/workflow/output_missing_tool_test.go
@@ -121,7 +121,7 @@ func TestGeneratePromptIncludesGitHubAWPrompt(t *testing.T) {
 	}
 
 	var yaml strings.Builder
-	compiler.generatePrompt(&yaml, data, &ClaudeEngine{})
+	compiler.generatePrompt(&yaml, data)
 
 	output := yaml.String()
 
@@ -148,7 +148,7 @@ func TestMissingToolPromptGeneration(t *testing.T) {
 	}
 
 	var yaml strings.Builder
-	compiler.generatePrompt(&yaml, data, &ClaudeEngine{})
+	compiler.generatePrompt(&yaml, data)
 
 	output := yaml.String()
 


### PR DESCRIPTION
More carefully separating the parts of out tool/bash logic that are "neutral" (apply to any backend) from the parts that are backend-specific.