### PR TITLE
🐛 Fix Codex log parsing and module detection

### DIFF
--- a/pkg/cli/workflows/test-codex-add-issue-labels.lock.yml
+++ b/pkg/cli/workflows/test-codex-add-issue-labels.lock.yml
@@ -556,7 +556,7 @@ jobs:
               };
             }
             // Only run main if this script is executed directly, not when imported for testing
-            if (require.main === module) {
+            if (typeof module === "undefined" || require.main === module) {
               main();
             }
 

--- a/pkg/cli/workflows/test-codex-command.lock.yml
+++ b/pkg/cli/workflows/test-codex-command.lock.yml
@@ -556,7 +556,7 @@ jobs:
               };
             }
             // Only run main if this script is executed directly, not when imported for testing
-            if (require.main === module) {
+            if (typeof module === "undefined" || require.main === module) {
               main();
             }
 

--- a/pkg/workflow/agentic_engine.go
+++ b/pkg/workflow/agentic_engine.go
@@ -51,8 +51,8 @@ type CodingAgentEngine interface {
 	// ParseLogMetrics extracts metrics from engine-specific log content
 	ParseLogMetrics(logContent string, verbose bool) LogMetrics
 
-	// GetLogParserScript returns the name of the JavaScript script to parse logs for this engine
-	GetLogParserScript() string
+	// GetLogParserScriptId returns the name of the JavaScript script to parse logs for this engine
+	GetLogParserScriptId() string
 
 	// GetErrorPatterns returns regex patterns for extracting error messages from logs
 	GetErrorPatterns() []ErrorPattern

--- a/pkg/workflow/claude_engine.go
+++ b/pkg/workflow/claude_engine.go
@@ -1107,7 +1107,7 @@ func (e *ClaudeEngine) distributeTotalDurationToToolCalls(toolCallMap map[string
 	}
 }
 
-// GetLogParserScript returns the JavaScript script name for parsing Claude logs
-func (e *ClaudeEngine) GetLogParserScript() string {
+// GetLogParserScriptId returns the JavaScript script name for parsing Claude logs
+func (e *ClaudeEngine) GetLogParserScriptId() string {
 	return "parse_claude_log"
 }

--- a/pkg/workflow/codex_engine.go
+++ b/pkg/workflow/codex_engine.go
@@ -489,8 +489,8 @@ func (e *CodexEngine) renderCodexMCPConfig(yaml *strings.Builder, toolName strin
 	return nil
 }
 
-// GetLogParserScript returns the JavaScript script name for parsing Codex logs
-func (e *CodexEngine) GetLogParserScript() string {
+// GetLogParserScriptId returns the JavaScript script name for parsing Codex logs
+func (e *CodexEngine) GetLogParserScriptId() string {
 	return "parse_codex_log"
 }
 

--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -3124,7 +3124,7 @@ func (c *Compiler) generateUploadAgentLogs(yaml *strings.Builder, logFile string
 }
 
 func (c *Compiler) generateLogParsing(yaml *strings.Builder, engine CodingAgentEngine, logFileFull string) {
-	parserScriptName := engine.GetLogParserScript()
+	parserScriptName := engine.GetLogParserScriptId()
 	if parserScriptName == "" {
 		// Skip log parsing if engine doesn't provide a parser
 		return

--- a/pkg/workflow/custom_engine.go
+++ b/pkg/workflow/custom_engine.go
@@ -321,7 +321,7 @@ func (e *CustomEngine) ParseLogMetrics(logContent string, verbose bool) LogMetri
 	return metrics
 }
 
-// GetLogParserScript returns the JavaScript script name for parsing custom engine logs
-func (e *CustomEngine) GetLogParserScript() string {
+// GetLogParserScriptId returns the JavaScript script name for parsing custom engine logs
+func (e *CustomEngine) GetLogParserScriptId() string {
 	return "parse_custom_log"
 }

--- a/pkg/workflow/custom_engine_test.go
+++ b/pkg/workflow/custom_engine_test.go
@@ -337,7 +337,7 @@ ERROR: Another error`
 func TestCustomEngineGetLogParserScript(t *testing.T) {
 	engine := NewCustomEngine()
 
-	script := engine.GetLogParserScript()
+	script := engine.GetLogParserScriptId()
 	if script != "parse_custom_log" {
 		t.Errorf("Expected log parser script 'parse_custom_log', got '%s'", script)
 	}

--- a/pkg/workflow/js/validate_errors.cjs
+++ b/pkg/workflow/js/validate_errors.cjs
@@ -160,6 +160,6 @@ if (typeof module !== "undefined" && module.exports) {
 }
 
 // Only run main if this script is executed directly, not when imported for testing
-if (require.main === module) {
+if (typeof module === "undefined" || require.main === module) {
   main();
 }

--- a/pkg/workflow/log_parser_test.go
+++ b/pkg/workflow/log_parser_test.go
@@ -8,7 +8,7 @@ import (
 func TestLogParserScriptMethods(t *testing.T) {
 	t.Run("ClaudeEngine returns correct log parser script", func(t *testing.T) {
 		engine := NewClaudeEngine()
-		scriptName := engine.GetLogParserScript()
+		scriptName := engine.GetLogParserScriptId()
 		if scriptName != "parse_claude_log" {
 			t.Errorf("Expected 'parse_claude_log', got '%s'", scriptName)
 		}
@@ -16,7 +16,7 @@ func TestLogParserScriptMethods(t *testing.T) {
 
 	t.Run("CodexEngine returns correct log parser script", func(t *testing.T) {
 		engine := NewCodexEngine()
-		scriptName := engine.GetLogParserScript()
+		scriptName := engine.GetLogParserScriptId()
 		if scriptName != "parse_codex_log" {
 			t.Errorf("Expected 'parse_codex_log', got '%s'", scriptName)
 		}


### PR DESCRIPTION
## Summary

- Renamed `GetLogParserScript()` method to `GetLogParserScriptId()` across multiple engines
- Updated module detection logic to handle undefined module scenarios
- Improved error parsing and log parsing compatibility

## Changes

The pull request addresses two main areas:
1. Method renaming for log parser script identification in various engine types
2. Enhanced module detection in JavaScript scripts to support different execution contexts