### PR TITLE
Declare output variables on the fly to guard safe-outputs jobs

### DIFF
--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -1876,7 +1876,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -1876,7 +1876,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -27,6 +27,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1609,11 +1610,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -1880,7 +1876,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -1606,6 +1606,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -1872,6 +1880,7 @@ jobs:
 
   create_issue:
     needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -2343,7 +2343,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -37,6 +37,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"add-comment\":{\"max\":1},\"create-issue\":{\"max\":1}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1810,11 +1811,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2347,7 +2343,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -2343,7 +2343,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -1807,6 +1807,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2339,6 +2347,7 @@ jobs:
 
   create_issue:
     needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -4,7 +4,7 @@
 # For more information: https://github.com/githubnext/gh-aw/blob/main/.github/instructions/github-agentic-workflows.instructions.md
 
 name: "Dev"
-"on":
+on:
   push:
     branches:
     - copilot/*
@@ -101,164 +101,13 @@ jobs:
     steps:
       - run: echo "Activation success"
 
-  add_reaction:
-    needs: activation
-    if: >
-      github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_comment' ||
-      github.event_name == 'pull_request_review_comment' || (github.event_name == 'pull_request') &&
-      (github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    outputs:
-      reaction_id: ${{ steps.react.outputs.reaction-id }}
-    steps:
-      - name: Add eyes reaction to the triggering item
-        id: react
-        uses: actions/github-script@v8
-        env:
-          GITHUB_AW_REACTION: eyes
-        with:
-          script: |
-            async function main() {
-              const reaction = process.env.GITHUB_AW_REACTION || "eyes";
-              const command = process.env.GITHUB_AW_COMMAND; 
-              const runId = context.runId;
-              const runUrl = context.payload.repository
-                ? `${context.payload.repository.html_url}/actions/runs/${runId}`
-                : `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
-              core.info(`Reaction type: ${reaction}`);
-              core.info(`Command name: ${command || "none"}`);
-              core.info(`Run ID: ${runId}`);
-              core.info(`Run URL: ${runUrl}`);
-              const validReactions = ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"];
-              if (!validReactions.includes(reaction)) {
-                core.setFailed(`Invalid reaction type: ${reaction}. Valid reactions are: ${validReactions.join(", ")}`);
-                return;
-              }
-              let reactionEndpoint;
-              let commentUpdateEndpoint;
-              let shouldEditComment = false;
-              const eventName = context.eventName;
-              const owner = context.repo.owner;
-              const repo = context.repo.repo;
-              try {
-                switch (eventName) {
-                  case "issues":
-                    const issueNumber = context.payload?.issue?.number;
-                    if (!issueNumber) {
-                      core.setFailed("Issue number not found in event payload");
-                      return;
-                    }
-                    reactionEndpoint = `/repos/${owner}/${repo}/issues/${issueNumber}/reactions`;
-                    shouldEditComment = false;
-                    break;
-                  case "issue_comment":
-                    const commentId = context.payload?.comment?.id;
-                    if (!commentId) {
-                      core.setFailed("Comment ID not found in event payload");
-                      return;
-                    }
-                    reactionEndpoint = `/repos/${owner}/${repo}/issues/comments/${commentId}/reactions`;
-                    commentUpdateEndpoint = `/repos/${owner}/${repo}/issues/comments/${commentId}`;
-                    shouldEditComment = command ? true : false;
-                    break;
-                  case "pull_request":
-                    const prNumber = context.payload?.pull_request?.number;
-                    if (!prNumber) {
-                      core.setFailed("Pull request number not found in event payload");
-                      return;
-                    }
-                    reactionEndpoint = `/repos/${owner}/${repo}/issues/${prNumber}/reactions`;
-                    shouldEditComment = false;
-                    break;
-                  case "pull_request_review_comment":
-                    const reviewCommentId = context.payload?.comment?.id;
-                    if (!reviewCommentId) {
-                      core.setFailed("Review comment ID not found in event payload");
-                      return;
-                    }
-                    reactionEndpoint = `/repos/${owner}/${repo}/pulls/comments/${reviewCommentId}/reactions`;
-                    commentUpdateEndpoint = `/repos/${owner}/${repo}/pulls/comments/${reviewCommentId}`;
-                    shouldEditComment = command ? true : false;
-                    break;
-                  default:
-                    core.setFailed(`Unsupported event type: ${eventName}`);
-                    return;
-                }
-                core.info(`Reaction API endpoint: ${reactionEndpoint}`);
-                await addReaction(reactionEndpoint, reaction);
-                if (shouldEditComment && commentUpdateEndpoint) {
-                  core.info(`Comment update endpoint: ${commentUpdateEndpoint}`);
-                  await editCommentWithWorkflowLink(commentUpdateEndpoint, runUrl);
-                } else {
-                  if (!command && commentUpdateEndpoint) {
-                    core.info("Skipping comment edit - only available for command workflows");
-                  } else {
-                    core.info(`Skipping comment edit for event type: ${eventName}`);
-                  }
-                }
-              } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
-                core.error(`Failed to process reaction and comment edit: ${errorMessage}`);
-                core.setFailed(`Failed to process reaction and comment edit: ${errorMessage}`);
-              }
-            }
-            async function addReaction(endpoint, reaction) {
-              const response = await github.request("POST " + endpoint, {
-                content: reaction,
-                headers: {
-                  Accept: "application/vnd.github+json",
-                },
-              });
-              const reactionId = response.data?.id;
-              if (reactionId) {
-                core.info(`Successfully added reaction: ${reaction} (id: ${reactionId})`);
-                core.setOutput("reaction-id", reactionId.toString());
-              } else {
-                core.info(`Successfully added reaction: ${reaction}`);
-                core.setOutput("reaction-id", "");
-              }
-            }
-            async function editCommentWithWorkflowLink(endpoint, runUrl) {
-              try {
-                const getResponse = await github.request("GET " + endpoint, {
-                  headers: {
-                    Accept: "application/vnd.github+json",
-                  },
-                });
-                const originalBody = getResponse.data.body || "";
-                const workflowLinkText = `\n\n---\n*🤖 [Workflow run](${runUrl}) triggered by this comment*`;
-                if (originalBody.includes("*🤖 [Workflow run](")) {
-                  core.info("Comment already contains a workflow run link, skipping edit");
-                  return;
-                }
-                const updatedBody = originalBody + workflowLinkText;
-                const updateResponse = await github.request("PATCH " + endpoint, {
-                  body: updatedBody,
-                  headers: {
-                    Accept: "application/vnd.github+json",
-                  },
-                });
-                core.info(`Successfully updated comment with workflow link`);
-                core.info(`Comment ID: ${updateResponse.data.id}`);
-              } catch (error) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
-                core.warning(
-                  "Failed to edit comment with workflow link (This is not critical - the reaction was still added successfully): " + errorMessage
-                );
-              }
-            }
-            await main();
-
   agent:
     needs: activation
     runs-on: ubuntu-latest
     permissions: read-all
     env:
       GITHUB_AW_SAFE_OUTPUTS: /tmp/safe-outputs/outputs.jsonl
-      GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
+      GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
     steps:
@@ -274,7 +123,7 @@ jobs:
         run: |
           mkdir -p /tmp/safe-outputs
           cat > /tmp/safe-outputs/config.json << 'EOF'
-          {"create-issue":{"max":1},"print":{"inputs":{"message":{"description":"Message to print","required":true,"type":"string"}}}}
+          {"create-issue":{"max":1}}
           EOF
           cat > /tmp/safe-outputs/mcp-server.cjs << 'EOF'
             const fs = require("fs");
@@ -880,7 +729,7 @@ jobs:
       - name: Setup MCPs
         env:
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
-          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
+          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
         run: |
           mkdir -p /tmp/mcp-config
           mkdir -p /home/runner/.copilot
@@ -914,9 +763,7 @@ jobs:
         run: |
           mkdir -p $(dirname "$GITHUB_AW_PROMPT")
           cat > $GITHUB_AW_PROMPT << 'EOF'
-          Summarize and use print the message using the `print` tool.
-          
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          Do nothing.
           
           EOF
       - name: Append safe outputs instructions to prompt
@@ -1048,7 +895,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
-          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
+          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
         with:
           script: |
             async function main() {
@@ -2225,31 +2072,4 @@ jobs:
             (async () => {
               await main();
             })();
-
-  print:
-    needs: agent
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download agent output artifact
-        continue-on-error: true
-        uses: actions/download-artifact@v5
-        with:
-          name: agent_output.json
-          path: /tmp/safe-jobs/
-      - name: Setup Safe Job Environment Variables
-        run: |
-          echo "Setting up environment for safe job"
-          echo "GITHUB_AW_AGENT_OUTPUT=/tmp/safe-jobs/agent_output.json" >> $GITHUB_ENV
-      - name: See artifacts
-        run: cd /tmp/safe-jobs && ls -lR
-      - name: print message
-        run: |-
-          if [ -f "$GITHUB_AW_AGENT_OUTPUT" ]; then
-            MESSAGE=$(cat "$GITHUB_AW_AGENT_OUTPUT" | jq -r '.items[] | select(.type == "print") | .message')
-            echo "print: $MESSAGE"
-            echo "### Print Step Summary" >> "$GITHUB_STEP_SUMMARY"
-            echo "$MESSAGE" >> "$GITHUB_STEP_SUMMARY"    
-          else
-            echo "No agent output found, using default: Hello from safe-job!"
-          fi
 

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -2018,7 +2018,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -2199,6 +2199,7 @@ jobs:
 
   create_pull_request:
     needs: agent
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -2018,7 +2018,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -2199,7 +2199,7 @@ jobs:
 
   create_pull_request:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
+    if: contains(needs.agent.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
     - copilot/*
+    - collect-guards
   workflow_dispatch: null
 
 permissions: {}
@@ -107,12 +108,18 @@ jobs:
     permissions: read-all
     env:
       GITHUB_AW_SAFE_OUTPUTS: /tmp/safe-outputs/outputs.jsonl
-      GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
+      GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"create-pull-request\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+      - name: Configure Git credentials
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${{ github.workflow }}"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -123,7 +130,7 @@ jobs:
         run: |
           mkdir -p /tmp/safe-outputs
           cat > /tmp/safe-outputs/config.json << 'EOF'
-          {"create-issue":{"max":1}}
+          {"create-issue":{"max":1},"create-pull-request":{}}
           EOF
           cat > /tmp/safe-outputs/mcp-server.cjs << 'EOF'
             const fs = require("fs");
@@ -729,7 +736,7 @@ jobs:
       - name: Setup MCPs
         env:
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
-          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
+          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"create-pull-request\":{}}"
         run: |
           mkdir -p /tmp/mcp-config
           mkdir -p /home/runner/.copilot
@@ -774,13 +781,22 @@ jobs:
           
           ---
           
-          ## Creating an IssueReporting Missing Tools or Functionality
+          ## Creating an IssueCreating a Pull RequestReporting Missing Tools or Functionality
           
           **IMPORTANT**: To do the actions mentioned in the header of this section, use the **safe-outputs** tools, do NOT attempt to use `gh`, do NOT attempt to use the GitHub API. You don't have write access to the GitHub repo.
           
           **Creating an Issue**
           
           To create an issue, use the create-issue tool from the safe-outputs MCP
+          
+          **Creating a Pull Request**
+          
+          To create a pull request:
+          1. Make any file changes directly in the working directory
+          2. If you haven't done so already, create a local branch using an appropriate unique name
+          3. Add and commit your changes to the branch. Be careful to add exactly the files you intend, and check there are no extra files left un-added. Check you haven't deleted or changed any files you didn't intend to.
+          4. Do not push your changes. That will be done by the tool.
+          5. Create the pull request with the create-pull-request tool from the safe-outputs MCP
           
           EOF
       - name: Print prompt to step summary
@@ -843,6 +859,25 @@ jobs:
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
         # --allow-tool safe_outputs
+        # --allow-tool shell(cat)
+        # --allow-tool shell(date)
+        # --allow-tool shell(echo)
+        # --allow-tool shell(git add:*)
+        # --allow-tool shell(git branch:*)
+        # --allow-tool shell(git checkout:*)
+        # --allow-tool shell(git commit:*)
+        # --allow-tool shell(git merge:*)
+        # --allow-tool shell(git rm:*)
+        # --allow-tool shell(git switch:*)
+        # --allow-tool shell(grep)
+        # --allow-tool shell(head)
+        # --allow-tool shell(ls)
+        # --allow-tool shell(pwd)
+        # --allow-tool shell(sort)
+        # --allow-tool shell(tail)
+        # --allow-tool shell(uniq)
+        # --allow-tool shell(wc)
+        # --allow-tool write
         timeout-minutes: 5
         run: |
           set -o pipefail
@@ -850,7 +885,7 @@ jobs:
           INSTRUCTION=$(cat /tmp/aw-prompts/prompt.txt)
           
           # Run copilot CLI with log capture
-          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
+          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(cat)' --allow-tool 'shell(date)' --allow-tool 'shell(echo)' --allow-tool 'shell(git add:*)' --allow-tool 'shell(git branch:*)' --allow-tool 'shell(git checkout:*)' --allow-tool 'shell(git commit:*)' --allow-tool 'shell(git merge:*)' --allow-tool 'shell(git rm:*)' --allow-tool 'shell(git switch:*)' --allow-tool 'shell(grep)' --allow-tool 'shell(head)' --allow-tool 'shell(ls)' --allow-tool 'shell(pwd)' --allow-tool 'shell(sort)' --allow-tool 'shell(tail)' --allow-tool 'shell(uniq)' --allow-tool 'shell(wc)' --allow-tool write --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
@@ -895,7 +930,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
-          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
+          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"create-pull-request\":{}}"
         with:
           script: |
             async function main() {
@@ -1623,11 +1658,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -1891,10 +1921,104 @@ jobs:
             if (typeof module === "undefined" || require.main === module) {
               main();
             }
+      - name: Generate git patch
+        if: always()
+        env:
+          GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          # Check current git status
+          echo "Current git status:"
+          git status
+          
+          # Extract branch name from JSONL output
+          BRANCH_NAME=""
+          if [ -f "$GITHUB_AW_SAFE_OUTPUTS" ]; then
+            echo "Checking for branch name in JSONL output..."
+            while IFS= read -r line; do
+              if [ -n "$line" ]; then
+                # Extract branch from create-pull-request line using simple grep and sed
+                if echo "$line" | grep -q '"type"[[:space:]]*:[[:space:]]*"create-pull-request"'; then
+                  echo "Found create-pull-request line: $line"
+                  # Extract branch value using sed
+                  BRANCH_NAME=$(echo "$line" | sed -n 's/.*"branch"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+                  if [ -n "$BRANCH_NAME" ]; then
+                    echo "Extracted branch name from create-pull-request: $BRANCH_NAME"
+                    break
+                  fi
+                # Extract branch from push-to-pull-request-branch line using simple grep and sed
+                elif echo "$line" | grep -q '"type"[[:space:]]*:[[:space:]]*"push-to-pull-request-branch"'; then
+                  echo "Found push-to-pull-request-branch line: $line"
+                  # Extract branch value using sed
+                  BRANCH_NAME=$(echo "$line" | sed -n 's/.*"branch"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+                  if [ -n "$BRANCH_NAME" ]; then
+                    echo "Extracted branch name from push-to-pull-request-branch: $BRANCH_NAME"
+                    break
+                  fi
+                fi
+              fi
+            done < "$GITHUB_AW_SAFE_OUTPUTS"
+          fi
+          
+          # If no branch or branch doesn't exist, no patch
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "No branch found, no patch generation"
+          fi
+          
+          # If we have a branch name, check if that branch exists and get its diff
+          if [ -n "$BRANCH_NAME" ]; then
+            echo "Looking for branch: $BRANCH_NAME"
+            # Check if the branch exists
+            if git show-ref --verify --quiet refs/heads/$BRANCH_NAME; then
+              echo "Branch $BRANCH_NAME exists, generating patch from branch changes"
+              
+              # Check if origin/$BRANCH_NAME exists to use as base
+              if git show-ref --verify --quiet refs/remotes/origin/$BRANCH_NAME; then
+                echo "Using origin/$BRANCH_NAME as base for patch generation"
+                BASE_REF="origin/$BRANCH_NAME"
+              else
+                echo "origin/$BRANCH_NAME does not exist, using merge-base with default branch"
+                # Get the default branch name
+                DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+                echo "Default branch: $DEFAULT_BRANCH"
+                # Fetch the default branch to ensure it's available locally
+                git fetch origin $DEFAULT_BRANCH
+                # Find merge base between default branch and current branch
+                BASE_REF=$(git merge-base origin/$DEFAULT_BRANCH $BRANCH_NAME)
+                echo "Using merge-base as base: $BASE_REF"
+              fi
+              
+              # Generate patch from the determined base to the branch
+              git format-patch "$BASE_REF".."$BRANCH_NAME" --stdout > /tmp/aw.patch || echo "Failed to generate patch from branch" > /tmp/aw.patch
+              echo "Patch file created from branch: $BRANCH_NAME (base: $BASE_REF)"
+            else
+              echo "Branch $BRANCH_NAME does not exist, no patch"
+            fi
+          fi
+          
+          # Show patch info if it exists
+          if [ -f /tmp/aw.patch ]; then
+            ls -la /tmp/aw.patch
+            # Show the first 50 lines of the patch for review
+            echo '## Git Patch' >> $GITHUB_STEP_SUMMARY
+            echo '' >> $GITHUB_STEP_SUMMARY
+            echo '```diff' >> $GITHUB_STEP_SUMMARY
+            head -500 /tmp/aw.patch >> $GITHUB_STEP_SUMMARY || echo "Could not display patch contents" >> $GITHUB_STEP_SUMMARY
+            echo '...' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo '' >> $GITHUB_STEP_SUMMARY
+          fi
+      - name: Upload git patch
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aw.patch
+          path: /tmp/aw.patch
+          if-no-files-found: ignore
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -2072,4 +2196,332 @@ jobs:
             (async () => {
               await main();
             })();
+
+  create_pull_request:
+    needs: agent
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    timeout-minutes: 10
+    outputs:
+      branch_name: ${{ steps.create_pull_request.outputs.branch_name }}
+      fallback_used: ${{ steps.create_pull_request.outputs.fallback_used }}
+      issue_number: ${{ steps.create_pull_request.outputs.issue_number }}
+      issue_url: ${{ steps.create_pull_request.outputs.issue_url }}
+      pull_request_number: ${{ steps.create_pull_request.outputs.pull_request_number }}
+      pull_request_url: ${{ steps.create_pull_request.outputs.pull_request_url }}
+    steps:
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v5
+        with:
+          name: aw.patch
+          path: /tmp/
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Configure Git credentials
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "${{ github.workflow }}"
+          echo "Git configured with standard GitHub Actions identity"
+      - name: Create Pull Request
+        id: create_pull_request
+        uses: actions/github-script@v8
+        env:
+          GITHUB_AW_AGENT_OUTPUT: ${{ needs.agent.outputs.output }}
+          GITHUB_AW_WORKFLOW_ID: "agent"
+          GITHUB_AW_BASE_BRANCH: ${{ github.ref_name }}
+          GITHUB_AW_PR_DRAFT: "true"
+          GITHUB_AW_PR_IF_NO_CHANGES: "warn"
+          GITHUB_AW_MAX_PATCH_SIZE: 1024
+          GITHUB_AW_SAFE_OUTPUTS_STAGED: "true"
+        with:
+          script: |
+            const fs = require("fs");
+            const crypto = require("crypto");
+            async function main() {
+              const isStaged = process.env.GITHUB_AW_SAFE_OUTPUTS_STAGED === "true";
+              const workflowId = process.env.GITHUB_AW_WORKFLOW_ID;
+              if (!workflowId) {
+                throw new Error("GITHUB_AW_WORKFLOW_ID environment variable is required");
+              }
+              const baseBranch = process.env.GITHUB_AW_BASE_BRANCH;
+              if (!baseBranch) {
+                throw new Error("GITHUB_AW_BASE_BRANCH environment variable is required");
+              }
+              const outputContent = process.env.GITHUB_AW_AGENT_OUTPUT || "";
+              if (outputContent.trim() === "") {
+                core.info("Agent output content is empty");
+              }
+              const ifNoChanges = process.env.GITHUB_AW_PR_IF_NO_CHANGES || "warn";
+              if (!fs.existsSync("/tmp/aw.patch")) {
+                const message = "No patch file found - cannot create pull request without changes";
+                if (isStaged) {
+                  let summaryContent = "## 🎭 Staged Mode: Create Pull Request Preview\n\n";
+                  summaryContent += "The following pull request would be created if staged mode was disabled:\n\n";
+                  summaryContent += `**Status:** ⚠️ No patch file found\n\n`;
+                  summaryContent += `**Message:** ${message}\n\n`;
+                  await core.summary.addRaw(summaryContent).write();
+                  core.info("📝 Pull request creation preview written to step summary (no patch file)");
+                  return;
+                }
+                switch (ifNoChanges) {
+                  case "error":
+                    throw new Error(message);
+                  case "ignore":
+                    return;
+                  case "warn":
+                  default:
+                    core.warning(message);
+                    return;
+                }
+              }
+              const patchContent = fs.readFileSync("/tmp/aw.patch", "utf8");
+              if (patchContent.includes("Failed to generate patch")) {
+                const message = "Patch file contains error message - cannot create pull request without changes";
+                if (isStaged) {
+                  let summaryContent = "## 🎭 Staged Mode: Create Pull Request Preview\n\n";
+                  summaryContent += "The following pull request would be created if staged mode was disabled:\n\n";
+                  summaryContent += `**Status:** ⚠️ Patch file contains error\n\n`;
+                  summaryContent += `**Message:** ${message}\n\n`;
+                  await core.summary.addRaw(summaryContent).write();
+                  core.info("📝 Pull request creation preview written to step summary (patch error)");
+                  return;
+                }
+                switch (ifNoChanges) {
+                  case "error":
+                    throw new Error(message);
+                  case "ignore":
+                    return;
+                  case "warn":
+                  default:
+                    core.warning(message);
+                    return;
+                }
+              }
+              const isEmpty = !patchContent || !patchContent.trim();
+              if (!isEmpty) {
+                const maxSizeKb = parseInt(process.env.GITHUB_AW_MAX_PATCH_SIZE || "1024", 10);
+                const patchSizeBytes = Buffer.byteLength(patchContent, "utf8");
+                const patchSizeKb = Math.ceil(patchSizeBytes / 1024);
+                core.info(`Patch size: ${patchSizeKb} KB (maximum allowed: ${maxSizeKb} KB)`);
+                if (patchSizeKb > maxSizeKb) {
+                  const message = `Patch size (${patchSizeKb} KB) exceeds maximum allowed size (${maxSizeKb} KB)`;
+                  if (isStaged) {
+                    let summaryContent = "## 🎭 Staged Mode: Create Pull Request Preview\n\n";
+                    summaryContent += "The following pull request would be created if staged mode was disabled:\n\n";
+                    summaryContent += `**Status:** ❌ Patch size exceeded\n\n`;
+                    summaryContent += `**Message:** ${message}\n\n`;
+                    await core.summary.addRaw(summaryContent).write();
+                    core.info("📝 Pull request creation preview written to step summary (patch size error)");
+                    return;
+                  }
+                  throw new Error(message);
+                }
+                core.info("Patch size validation passed");
+              }
+              if (isEmpty && !isStaged) {
+                const message = "Patch file is empty - no changes to apply (noop operation)";
+                switch (ifNoChanges) {
+                  case "error":
+                    throw new Error("No changes to push - failing as configured by if-no-changes: error");
+                  case "ignore":
+                    return;
+                  case "warn":
+                  default:
+                    core.warning(message);
+                    return;
+                }
+              }
+              core.debug(`Agent output content length: ${outputContent.length}`);
+              if (!isEmpty) {
+                core.info("Patch content validation passed");
+              } else {
+                core.info("Patch file is empty - processing noop operation");
+              }
+              let validatedOutput;
+              try {
+                validatedOutput = JSON.parse(outputContent);
+              } catch (error) {
+                core.setFailed(`Error parsing agent output JSON: ${error instanceof Error ? error.message : String(error)}`);
+                return;
+              }
+              if (!validatedOutput.items || !Array.isArray(validatedOutput.items)) {
+                core.warning("No valid items found in agent output");
+                return;
+              }
+              const pullRequestItem = validatedOutput.items.find( item => item.type === "create-pull-request");
+              if (!pullRequestItem) {
+                core.warning("No create-pull-request item found in agent output");
+                return;
+              }
+              core.debug(`Found create-pull-request item: title="${pullRequestItem.title}", bodyLength=${pullRequestItem.body.length}`);
+              if (isStaged) {
+                let summaryContent = "## 🎭 Staged Mode: Create Pull Request Preview\n\n";
+                summaryContent += "The following pull request would be created if staged mode was disabled:\n\n";
+                summaryContent += `**Title:** ${pullRequestItem.title || "No title provided"}\n\n`;
+                summaryContent += `**Branch:** ${pullRequestItem.branch || "auto-generated"}\n\n`;
+                summaryContent += `**Base:** ${baseBranch}\n\n`;
+                if (pullRequestItem.body) {
+                  summaryContent += `**Body:**\n${pullRequestItem.body}\n\n`;
+                }
+                if (fs.existsSync("/tmp/aw.patch")) {
+                  const patchStats = fs.readFileSync("/tmp/aw.patch", "utf8");
+                  if (patchStats.trim()) {
+                    summaryContent += `**Changes:** Patch file exists with ${patchStats.split("\n").length} lines\n\n`;
+                    summaryContent += `<details><summary>Show patch preview</summary>\n\n\`\`\`diff\n${patchStats.slice(0, 2000)}${patchStats.length > 2000 ? "\n... (truncated)" : ""}\n\`\`\`\n\n</details>\n\n`;
+                  } else {
+                    summaryContent += `**Changes:** No changes (empty patch)\n\n`;
+                  }
+                }
+                await core.summary.addRaw(summaryContent).write();
+                core.info("📝 Pull request creation preview written to step summary");
+                return;
+              }
+              let title = pullRequestItem.title.trim();
+              let bodyLines = pullRequestItem.body.split("\n");
+              let branchName = pullRequestItem.branch ? pullRequestItem.branch.trim() : null;
+              if (!title) {
+                title = "Agent Output";
+              }
+              const titlePrefix = process.env.GITHUB_AW_PR_TITLE_PREFIX;
+              if (titlePrefix && !title.startsWith(titlePrefix)) {
+                title = titlePrefix + title;
+              }
+              const runId = context.runId;
+              const runUrl = context.payload.repository
+                ? `${context.payload.repository.html_url}/actions/runs/${runId}`
+                : `https://github.com/actions/runs/${runId}`;
+              bodyLines.push(``, ``, `> Generated by Agentic Workflow [Run](${runUrl})`, "");
+              const body = bodyLines.join("\n").trim();
+              const labelsEnv = process.env.GITHUB_AW_PR_LABELS;
+              const labels = labelsEnv
+                ? labelsEnv
+                    .split(",")
+                    .map( label => label.trim())
+                    .filter( label => label)
+                : [];
+              const draftEnv = process.env.GITHUB_AW_PR_DRAFT;
+              const draft = draftEnv ? draftEnv.toLowerCase() === "true" : true;
+              core.info(`Creating pull request with title: ${title}`);
+              core.debug(`Labels: ${JSON.stringify(labels)}`);
+              core.debug(`Draft: ${draft}`);
+              core.debug(`Body length: ${body.length}`);
+              const randomHex = crypto.randomBytes(8).toString("hex");
+              if (!branchName) {
+                core.debug("No branch name provided in JSONL, generating unique branch name");
+                branchName = `${workflowId}-${randomHex}`;
+              } else {
+                branchName = `${branchName}-${randomHex}`;
+                core.debug(`Using branch name from JSONL with added salt: ${branchName}`);
+              }
+              core.info(`Generated branch name: ${branchName}`);
+              core.debug(`Base branch: ${baseBranch}`);
+              core.debug(`Fetching latest changes and checking out base branch: ${baseBranch}`);
+              await exec.exec("git fetch origin");
+              await exec.exec(`git checkout ${baseBranch}`);
+              core.debug(`Branch should not exist locally, creating new branch from base: ${branchName}`);
+              await exec.exec(`git checkout -b ${branchName}`);
+              core.info(`Created new branch from base: ${branchName}`);
+              if (!isEmpty) {
+                core.info("Applying patch...");
+                await exec.exec("git am /tmp/aw.patch");
+                core.info("Patch applied successfully");
+                await exec.exec(`git push origin ${branchName}`);
+                core.info("Changes pushed to branch");
+              } else {
+                core.info("Skipping patch application (empty patch)");
+                const message = "No changes to apply - noop operation completed successfully";
+                switch (ifNoChanges) {
+                  case "error":
+                    throw new Error("No changes to apply - failing as configured by if-no-changes: error");
+                  case "ignore":
+                    return;
+                  case "warn":
+                  default:
+                    core.warning(message);
+                    return;
+                }
+              }
+              try {
+                const { data: pullRequest } = await github.rest.pulls.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: title,
+                  body: body,
+                  head: branchName,
+                  base: baseBranch,
+                  draft: draft,
+                });
+                core.info(`Created pull request #${pullRequest.number}: ${pullRequest.html_url}`);
+                if (labels.length > 0) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pullRequest.number,
+                    labels: labels,
+                  });
+                  core.info(`Added labels to pull request: ${JSON.stringify(labels)}`);
+                }
+                core.setOutput("pull_request_number", pullRequest.number);
+                core.setOutput("pull_request_url", pullRequest.html_url);
+                core.setOutput("branch_name", branchName);
+                await core.summary
+                  .addRaw(
+                    `
+            ## Pull Request
+            - **Pull Request**: [#${pullRequest.number}](${pullRequest.html_url})
+            - **Branch**: \`${branchName}\`
+            - **Base Branch**: \`${baseBranch}\`
+            `
+                  )
+                  .write();
+              } catch (prError) {
+                core.warning(`Failed to create pull request: ${prError instanceof Error ? prError.message : String(prError)}`);
+                core.info("Falling back to creating an issue instead");
+                const branchUrl = context.payload.repository
+                  ? `${context.payload.repository.html_url}/tree/${branchName}`
+                  : `https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branchName}`;
+                const fallbackBody = `${body}
+            ---
+            **Note:** This was originally intended as a pull request, but PR creation failed. The changes have been pushed to the branch [\`${branchName}\`](${branchUrl}).
+            **Original error:** ${prError instanceof Error ? prError.message : String(prError)}
+            You can manually create a pull request from the branch if needed.`;
+                try {
+                  const { data: issue } = await github.rest.issues.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: title,
+                    body: fallbackBody,
+                    labels: labels,
+                  });
+                  core.info(`Created fallback issue #${issue.number}: ${issue.html_url}`);
+                  core.setOutput("issue_number", issue.number);
+                  core.setOutput("issue_url", issue.html_url);
+                  core.setOutput("branch_name", branchName);
+                  core.setOutput("fallback_used", "true");
+                  await core.summary
+                    .addRaw(
+                      `
+            ## Fallback Issue Created
+            - **Issue**: [#${issue.number}](${issue.html_url})
+            - **Branch**: [\`${branchName}\`](${branchUrl})
+            - **Base Branch**: \`${baseBranch}\`
+            - **Note**: Pull request creation failed, created issue as fallback
+            `
+                    )
+                    .write();
+                } catch (issueError) {
+                  core.setFailed(
+                    `Failed to create both pull request and fallback issue. PR error: ${prError instanceof Error ? prError.message : String(prError)}. Issue error: ${issueError instanceof Error ? issueError.message : String(issueError)}`
+                  );
+                  return;
+                }
+              }
+            }
+            await main();
 

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -258,7 +258,7 @@ jobs:
     permissions: read-all
     env:
       GITHUB_AW_SAFE_OUTPUTS: /tmp/safe-outputs/outputs.jsonl
-      GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
+      GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
     steps:
@@ -274,7 +274,7 @@ jobs:
         run: |
           mkdir -p /tmp/safe-outputs
           cat > /tmp/safe-outputs/config.json << 'EOF'
-          {"print":{"inputs":{"message":{"description":"Message to print","required":true,"type":"string"}}}}
+          {"create-issue":{"max":1},"print":{"inputs":{"message":{"description":"Message to print","required":true,"type":"string"}}}}
           EOF
           cat > /tmp/safe-outputs/mcp-server.cjs << 'EOF'
             const fs = require("fs");
@@ -880,7 +880,7 @@ jobs:
       - name: Setup MCPs
         env:
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
-          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
+          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
         run: |
           mkdir -p /tmp/mcp-config
           mkdir -p /home/runner/.copilot
@@ -927,9 +927,13 @@ jobs:
           
           ---
           
-          ## Reporting Missing Tools or Functionality
+          ## Creating an IssueReporting Missing Tools or Functionality
           
           **IMPORTANT**: To do the actions mentioned in the header of this section, use the **safe-outputs** tools, do NOT attempt to use `gh`, do NOT attempt to use the GitHub API. You don't have write access to the GitHub repo.
+          
+          **Creating an Issue**
+          
+          To create an issue, use the create-issue tool from the safe-outputs MCP
           
           EOF
       - name: Print prompt to step summary
@@ -1044,7 +1048,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
-          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
+          GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
         with:
           script: |
             async function main() {
@@ -1769,6 +1773,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2032,6 +2044,187 @@ jobs:
             if (typeof module === "undefined" || require.main === module) {
               main();
             }
+
+  create_issue:
+    needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    timeout-minutes: 10
+    outputs:
+      issue_number: ${{ steps.create_issue.outputs.issue_number }}
+      issue_url: ${{ steps.create_issue.outputs.issue_url }}
+    steps:
+      - name: Create Output Issue
+        id: create_issue
+        uses: actions/github-script@v8
+        env:
+          GITHUB_AW_AGENT_OUTPUT: ${{ needs.agent.outputs.output }}
+          GITHUB_AW_SAFE_OUTPUTS_STAGED: "true"
+        with:
+          script: |
+            function sanitizeLabelContent(content) {
+              if (!content || typeof content !== "string") {
+                return "";
+              }
+              let sanitized = content.trim();
+              sanitized = sanitized.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+              sanitized = sanitized.replace(/\x1b\[[0-9;]*[mGKH]/g, "");
+              sanitized = sanitized.replace(
+                /(^|[^\w`])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\/[A-Za-z0-9._-]+)?)/g,
+                (_m, p1, p2) => `${p1}\`@${p2}\``
+              );
+              sanitized = sanitized.replace(/[<>&'"]/g, "");
+              return sanitized.trim();
+            }
+            async function main() {
+              const isStaged = process.env.GITHUB_AW_SAFE_OUTPUTS_STAGED === "true";
+              const outputContent = process.env.GITHUB_AW_AGENT_OUTPUT;
+              if (!outputContent) {
+                core.info("No GITHUB_AW_AGENT_OUTPUT environment variable found");
+                return;
+              }
+              if (outputContent.trim() === "") {
+                core.info("Agent output content is empty");
+                return;
+              }
+              core.info(`Agent output content length: ${outputContent.length}`);
+              let validatedOutput;
+              try {
+                validatedOutput = JSON.parse(outputContent);
+              } catch (error) {
+                core.setFailed(`Error parsing agent output JSON: ${error instanceof Error ? error.message : String(error)}`);
+                return;
+              }
+              if (!validatedOutput.items || !Array.isArray(validatedOutput.items)) {
+                core.info("No valid items found in agent output");
+                return;
+              }
+              const createIssueItems = validatedOutput.items.filter(item => item.type === "create-issue");
+              if (createIssueItems.length === 0) {
+                core.info("No create-issue items found in agent output");
+                return;
+              }
+              core.info(`Found ${createIssueItems.length} create-issue item(s)`);
+              if (isStaged) {
+                let summaryContent = "## 🎭 Staged Mode: Create Issues Preview\n\n";
+                summaryContent += "The following issues would be created if staged mode was disabled:\n\n";
+                for (let i = 0; i < createIssueItems.length; i++) {
+                  const item = createIssueItems[i];
+                  summaryContent += `### Issue ${i + 1}\n`;
+                  summaryContent += `**Title:** ${item.title || "No title provided"}\n\n`;
+                  if (item.body) {
+                    summaryContent += `**Body:**\n${item.body}\n\n`;
+                  }
+                  if (item.labels && item.labels.length > 0) {
+                    summaryContent += `**Labels:** ${item.labels.join(", ")}\n\n`;
+                  }
+                  summaryContent += "---\n\n";
+                }
+                await core.summary.addRaw(summaryContent).write();
+                core.info("📝 Issue creation preview written to step summary");
+                return;
+              }
+              const parentIssueNumber = context.payload?.issue?.number;
+              const labelsEnv = process.env.GITHUB_AW_ISSUE_LABELS;
+              let envLabels = labelsEnv
+                ? labelsEnv
+                    .split(",")
+                    .map(label => label.trim())
+                    .filter(label => label)
+                : [];
+              const createdIssues = [];
+              for (let i = 0; i < createIssueItems.length; i++) {
+                const createIssueItem = createIssueItems[i];
+                core.info(
+                  `Processing create-issue item ${i + 1}/${createIssueItems.length}: title=${createIssueItem.title}, bodyLength=${createIssueItem.body.length}`
+                );
+                let labels = [...envLabels];
+                if (createIssueItem.labels && Array.isArray(createIssueItem.labels)) {
+                  labels = [...labels, ...createIssueItem.labels];
+                }
+                labels = labels
+                  .filter(label => label != null && label !== false && label !== 0)
+                  .map(label => String(label).trim())
+                  .filter(label => label)
+                  .map(label => sanitizeLabelContent(label))
+                  .filter(label => label)
+                  .map(label => (label.length > 64 ? label.substring(0, 64) : label))
+                  .filter((label, index, arr) => arr.indexOf(label) === index);
+                let title = createIssueItem.title ? createIssueItem.title.trim() : "";
+                let bodyLines = createIssueItem.body.split("\n");
+                if (!title) {
+                  title = createIssueItem.body || "Agent Output";
+                }
+                const titlePrefix = process.env.GITHUB_AW_ISSUE_TITLE_PREFIX;
+                if (titlePrefix && !title.startsWith(titlePrefix)) {
+                  title = titlePrefix + title;
+                }
+                if (parentIssueNumber) {
+                  core.info("Detected issue context, parent issue #" + parentIssueNumber);
+                  bodyLines.push(`Related to #${parentIssueNumber}`);
+                }
+                const runId = context.runId;
+                const runUrl = context.payload.repository
+                  ? `${context.payload.repository.html_url}/actions/runs/${runId}`
+                  : `https://github.com/actions/runs/${runId}`;
+                bodyLines.push(``, ``, `> Generated by Agentic Workflow [Run](${runUrl})`, "");
+                const body = bodyLines.join("\n").trim();
+                core.info(`Creating issue with title: ${title}`);
+                core.info(`Labels: ${labels}`);
+                core.info(`Body length: ${body.length}`);
+                try {
+                  const { data: issue } = await github.rest.issues.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: title,
+                    body: body,
+                    labels: labels,
+                  });
+                  core.info("Created issue #" + issue.number + ": " + issue.html_url);
+                  createdIssues.push(issue);
+                  if (parentIssueNumber) {
+                    try {
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: parentIssueNumber,
+                        body: `Created related issue: #${issue.number}`,
+                      });
+                      core.info("Added comment to parent issue #" + parentIssueNumber);
+                    } catch (error) {
+                      core.info(`Warning: Could not add comment to parent issue: ${error instanceof Error ? error.message : String(error)}`);
+                    }
+                  }
+                  if (i === createIssueItems.length - 1) {
+                    core.setOutput("issue_number", issue.number);
+                    core.setOutput("issue_url", issue.html_url);
+                  }
+                } catch (error) {
+                  const errorMessage = error instanceof Error ? error.message : String(error);
+                  if (errorMessage.includes("Issues has been disabled in this repository")) {
+                    core.info(`⚠ Cannot create issue "${title}": Issues are disabled for this repository`);
+                    core.info("Consider enabling issues in repository settings if you want to create issues automatically");
+                    continue;
+                  }
+                  core.error(`✗ Failed to create issue "${title}": ${errorMessage}`);
+                  throw error;
+                }
+              }
+              if (createdIssues.length > 0) {
+                let summaryContent = "\n\n## GitHub Issues\n";
+                for (const issue of createdIssues) {
+                  summaryContent += `- Issue #${issue.number}: [${issue.title}](${issue.html_url})\n`;
+                }
+                await core.summary.addRaw(summaryContent).write();
+              }
+              core.info(`Successfully created ${createdIssues.length} issue(s)`);
+            }
+            (async () => {
+              await main();
+            })();
 
   print:
     needs: agent

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -763,7 +763,7 @@ jobs:
         run: |
           mkdir -p $(dirname "$GITHUB_AW_PROMPT")
           cat > $GITHUB_AW_PROMPT << 'EOF'
-          Do nothing.
+          Create a poem and post it as a new issue.
           
           EOF
       - name: Append safe outputs instructions to prompt

--- a/.github/workflows/dev.md
+++ b/.github/workflows/dev.md
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - copilot/*
+      - collect-guards
 engine: copilot
 safe-outputs:
     staged: true
     create-issue:
+    create-pull-request:
 ---
 Create a poem and post it as a new issue.

--- a/.github/workflows/dev.md
+++ b/.github/workflows/dev.md
@@ -8,6 +8,7 @@ on:
 engine: copilot
 safe-outputs:
     staged: true
+    create-issue:
     jobs:
       print:
         #name: "print the message"

--- a/.github/workflows/dev.md
+++ b/.github/workflows/dev.md
@@ -1,7 +1,6 @@
 ---
 on: 
   workflow_dispatch:
-  reaction: "eyes"
   push:
     branches:
       - copilot/*
@@ -9,29 +8,5 @@ engine: copilot
 safe-outputs:
     staged: true
     create-issue:
-    jobs:
-      print:
-        #name: "print the message"
-        runs-on: ubuntu-latest
-        inputs:
-          message:
-            description: "Message to print"
-            required: true
-            type: string
-        steps:
-          - name: See artifacts
-            run: cd /tmp/safe-jobs && ls -lR
-          - name: print message
-            run: |
-              if [ -f "$GITHUB_AW_AGENT_OUTPUT" ]; then
-                MESSAGE=$(cat "$GITHUB_AW_AGENT_OUTPUT" | jq -r '.items[] | select(.type == "print") | .message')
-                echo "print: $MESSAGE"
-                echo "### Print Step Summary" >> "$GITHUB_STEP_SUMMARY"
-                echo "$MESSAGE" >> "$GITHUB_STEP_SUMMARY"    
-              else
-                echo "No agent output found, using default: Hello from safe-job!"
-              fi
 ---
-Summarize and use print the message using the `print` tool.
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Do nothing.

--- a/.github/workflows/dev.md
+++ b/.github/workflows/dev.md
@@ -9,4 +9,4 @@ safe-outputs:
     staged: true
     create-issue:
 ---
-Do nothing.
+Create a poem and post it as a new issue.

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -2114,6 +2114,7 @@ jobs:
 
   create_pull_request:
     needs: agent
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -1750,6 +1750,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -118,6 +118,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-pull-request\":{},\"missing-tool\":{},\"push-to-pull-request-branch\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1753,11 +1754,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -2114,7 +2114,7 @@ jobs:
 
   create_pull_request:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
+    if: contains(needs.agent.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-all.lock.yml
+++ b/pkg/cli/workflows/test-all.lock.yml
@@ -1383,6 +1383,7 @@ jobs:
       - name: Execute Claude Code CLI
         id: agentic_execution
         # Allowed tools (sorted):
+        # - Bash(cat)
         # - Bash(date)
         # - Bash(echo)
         # - Bash(git add:*)
@@ -1392,6 +1393,14 @@ jobs:
         # - Bash(git merge:*)
         # - Bash(git rm:*)
         # - Bash(git switch:*)
+        # - Bash(grep)
+        # - Bash(head)
+        # - Bash(ls)
+        # - Bash(pwd)
+        # - Bash(sort)
+        # - Bash(tail)
+        # - Bash(uniq)
+        # - Bash(wc)
         # - Bash(whoami)
         # - BashOutput
         # - Edit
@@ -1468,7 +1477,7 @@ jobs:
         run: |
           set -o pipefail
           # Execute Claude Code CLI with prompt from file
-          npx @anthropic-ai/claude-code@latest --print --model claude-3-5-sonnet-20241022 --max-turns 3 --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(date),Bash(echo),Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),Bash(whoami),BashOutput,Edit,Edit(/tmp/cache-memory/*),ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,MultiEdit(/tmp/cache-memory/*),NotebookEdit,NotebookRead,Read,Read(/tmp/cache-memory/*),Task,TodoWrite,WebFetch,Write,Write(/tmp/cache-memory/*),mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_repository,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
+          npx @anthropic-ai/claude-code@latest --print --model claude-3-5-sonnet-20241022 --max-turns 3 --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(cat),Bash(date),Bash(echo),Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),Bash(grep),Bash(head),Bash(ls),Bash(pwd),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),Bash(whoami),BashOutput,Edit,Edit(/tmp/cache-memory/*),ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,MultiEdit(/tmp/cache-memory/*),NotebookEdit,NotebookRead,Read,Read(/tmp/cache-memory/*),Task,TodoWrite,WebFetch,Write,Write(/tmp/cache-memory/*),mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_repository,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DISABLE_TELEMETRY: "1"
@@ -2248,6 +2257,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2874,6 +2891,7 @@ jobs:
 
   create_issue:
     needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-all.lock.yml
+++ b/pkg/cli/workflows/test-all.lock.yml
@@ -325,6 +325,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"add-comment\":{\"max\":3,\"target\":\"*\"},\"add-labels\":{\"max\":5},\"create-issue\":{\"max\":2},\"create-pull-request\":{},\"create-pull-request-review-comment\":{\"max\":2},\"missing-tool\":{},\"push-to-pull-request-branch\":{},\"update-issue\":{\"max\":2}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -2260,11 +2261,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2891,7 +2887,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-all.lock.yml
+++ b/pkg/cli/workflows/test-all.lock.yml
@@ -2887,7 +2887,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3429,7 +3429,7 @@ jobs:
 
   create_pull_request:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
+    if: contains(needs.agent.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-all.lock.yml
+++ b/pkg/cli/workflows/test-all.lock.yml
@@ -2887,7 +2887,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3429,6 +3429,7 @@ jobs:
 
   create_pull_request:
     needs: agent
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
@@ -2382,6 +2382,7 @@ jobs:
 
   create_pull_request:
     needs: agent
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
@@ -886,6 +886,9 @@ jobs:
       - name: Execute Claude Code CLI
         id: agentic_execution
         # Allowed tools (sorted):
+        # - Bash(cat)
+        # - Bash(date)
+        # - Bash(echo)
         # - Bash(git add:*)
         # - Bash(git branch:*)
         # - Bash(git checkout:*)
@@ -893,6 +896,14 @@ jobs:
         # - Bash(git merge:*)
         # - Bash(git rm:*)
         # - Bash(git switch:*)
+        # - Bash(grep)
+        # - Bash(head)
+        # - Bash(ls)
+        # - Bash(pwd)
+        # - Bash(sort)
+        # - Bash(tail)
+        # - Bash(uniq)
+        # - Bash(wc)
         # - BashOutput
         # - Edit
         # - ExitPlanMode
@@ -962,7 +973,7 @@ jobs:
         run: |
           set -o pipefail
           # Execute Claude Code CLI with prompt from file
-          npx @anthropic-ai/claude-code@latest --print --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
+          npx @anthropic-ai/claude-code@latest --print --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(cat),Bash(date),Bash(echo),Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),Bash(grep),Bash(head),Bash(ls),Bash(pwd),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DISABLE_TELEMETRY: "1"
@@ -1741,6 +1752,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
@@ -2382,7 +2382,7 @@ jobs:
 
   create_pull_request:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
+    if: contains(needs.agent.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-claude-max-patch-size.lock.yml
@@ -25,6 +25,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-pull-request\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1755,11 +1756,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-missing-tool.lock.yml
+++ b/pkg/cli/workflows/test-claude-missing-tool.lock.yml
@@ -1800,6 +1800,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-missing-tool.lock.yml
+++ b/pkg/cli/workflows/test-claude-missing-tool.lock.yml
@@ -28,6 +28,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"missing-tool\":{\"max\":5}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1803,11 +1804,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-patch-size-exceeded.lock.yml
+++ b/pkg/cli/workflows/test-claude-patch-size-exceeded.lock.yml
@@ -888,6 +888,9 @@ jobs:
       - name: Execute Claude Code CLI
         id: agentic_execution
         # Allowed tools (sorted):
+        # - Bash(cat)
+        # - Bash(date)
+        # - Bash(echo)
         # - Bash(git add:*)
         # - Bash(git branch:*)
         # - Bash(git checkout:*)
@@ -895,6 +898,14 @@ jobs:
         # - Bash(git merge:*)
         # - Bash(git rm:*)
         # - Bash(git switch:*)
+        # - Bash(grep)
+        # - Bash(head)
+        # - Bash(ls)
+        # - Bash(pwd)
+        # - Bash(sort)
+        # - Bash(tail)
+        # - Bash(uniq)
+        # - Bash(wc)
         # - BashOutput
         # - Edit
         # - ExitPlanMode
@@ -964,7 +975,7 @@ jobs:
         run: |
           set -o pipefail
           # Execute Claude Code CLI with prompt from file
-          npx @anthropic-ai/claude-code@latest --print --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
+          npx @anthropic-ai/claude-code@latest --print --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(cat),Bash(date),Bash(echo),Bash(git add:*),Bash(git branch:*),Bash(git checkout:*),Bash(git commit:*),Bash(git merge:*),Bash(git rm:*),Bash(git switch:*),Bash(grep),Bash(head),Bash(ls),Bash(pwd),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DISABLE_TELEMETRY: "1"
@@ -1743,6 +1754,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-patch-size-exceeded.lock.yml
+++ b/pkg/cli/workflows/test-claude-patch-size-exceeded.lock.yml
@@ -25,6 +25,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"push-to-pull-request-branch\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1757,11 +1758,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
@@ -1758,6 +1758,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2290,6 +2298,7 @@ jobs:
 
   create_issue:
     needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
@@ -2294,7 +2294,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
@@ -2294,7 +2294,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-accessibility-contrast.lock.yml
@@ -24,6 +24,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Generate Claude Settings
         run: |
@@ -1761,11 +1762,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2298,7 +2294,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
@@ -1025,16 +1025,27 @@ jobs:
       - name: Execute Claude Code CLI
         id: agentic_execution
         # Allowed tools (sorted):
+        # - Bash(cat)
         # - Bash(cd *)
         # - Bash(cp *)
         # - Bash(curl *)
+        # - Bash(date)
+        # - Bash(echo)
+        # - Bash(grep)
+        # - Bash(head)
         # - Bash(kill *)
+        # - Bash(ls)
         # - Bash(mkdir *)
         # - Bash(mv *)
         # - Bash(node *)
         # - Bash(npm *)
         # - Bash(ps *)
+        # - Bash(pwd)
         # - Bash(sleep *)
+        # - Bash(sort)
+        # - Bash(tail)
+        # - Bash(uniq)
+        # - Bash(wc)
         # - BashOutput
         # - ExitPlanMode
         # - Glob
@@ -1122,7 +1133,7 @@ jobs:
         run: |
           set -o pipefail
           # Execute Claude Code CLI with prompt from file
-          npx @anthropic-ai/claude-code@latest --print --max-turns 50 --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(cd *),Bash(cp *),Bash(curl *),Bash(kill *),Bash(mkdir *),Bash(mv *),Bash(node *),Bash(npm *),Bash(ps *),Bash(sleep *),BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users,mcp__playwright__browser_click,mcp__playwright__browser_close,mcp__playwright__browser_console_messages,mcp__playwright__browser_drag,mcp__playwright__browser_evaluate,mcp__playwright__browser_file_upload,mcp__playwright__browser_fill_form,mcp__playwright__browser_handle_dialog,mcp__playwright__browser_hover,mcp__playwright__browser_install,mcp__playwright__browser_navigate,mcp__playwright__browser_navigate_back,mcp__playwright__browser_network_requests,mcp__playwright__browser_press_key,mcp__playwright__browser_resize,mcp__playwright__browser_select_option,mcp__playwright__browser_snapshot,mcp__playwright__browser_tabs,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_type,mcp__playwright__browser_wait_for" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
+          npx @anthropic-ai/claude-code@latest --print --max-turns 50 --mcp-config /tmp/mcp-config/mcp-servers.json --allowed-tools "Bash(cat),Bash(cd *),Bash(cp *),Bash(curl *),Bash(date),Bash(echo),Bash(grep),Bash(head),Bash(kill *),Bash(ls),Bash(mkdir *),Bash(mv *),Bash(node *),Bash(npm *),Bash(ps *),Bash(pwd),Bash(sleep *),Bash(sort),Bash(tail),Bash(uniq),Bash(wc),BashOutput,ExitPlanMode,Glob,Grep,KillBash,LS,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__get_job_logs,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_sub_issues,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users,mcp__playwright__browser_click,mcp__playwright__browser_close,mcp__playwright__browser_console_messages,mcp__playwright__browser_drag,mcp__playwright__browser_evaluate,mcp__playwright__browser_file_upload,mcp__playwright__browser_fill_form,mcp__playwright__browser_handle_dialog,mcp__playwright__browser_hover,mcp__playwright__browser_install,mcp__playwright__browser_navigate,mcp__playwright__browser_navigate_back,mcp__playwright__browser_network_requests,mcp__playwright__browser_press_key,mcp__playwright__browser_resize,mcp__playwright__browser_select_option,mcp__playwright__browser_snapshot,mcp__playwright__browser_tabs,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_type,mcp__playwright__browser_wait_for" --debug --verbose --permission-mode bypassPermissions --output-format json --settings /tmp/.claude/settings.json "$(cat /tmp/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DISABLE_TELEMETRY: "1"
@@ -1906,6 +1917,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2445,6 +2464,7 @@ jobs:
 
   create_issue:
     needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
@@ -2460,7 +2460,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
@@ -111,6 +111,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"upload-asset\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1920,11 +1921,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -2464,7 +2460,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-claude-playwright-screenshots.lock.yml
@@ -2460,7 +2460,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-claude-safe-jobs.lock.yml
+++ b/pkg/cli/workflows/test-claude-safe-jobs.lock.yml
@@ -1944,6 +1944,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-claude-safe-jobs.lock.yml
+++ b/pkg/cli/workflows/test-claude-safe-jobs.lock.yml
@@ -261,6 +261,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1947,11 +1948,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
@@ -25,6 +25,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-pull-request\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1577,11 +1578,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
@@ -1938,6 +1938,7 @@ jobs:
 
   create_pull_request:
     needs: agent
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
@@ -1938,7 +1938,7 @@ jobs:
 
   create_pull_request:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')
+    if: contains(needs.agent.outputs.output_types, 'create-pull-request')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
+++ b/pkg/cli/workflows/test-copilot-max-patch-size.lock.yml
@@ -778,6 +778,9 @@ jobs:
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
         # --allow-tool safe_outputs
+        # --allow-tool shell(cat)
+        # --allow-tool shell(date)
+        # --allow-tool shell(echo)
         # --allow-tool shell(git add:*)
         # --allow-tool shell(git branch:*)
         # --allow-tool shell(git checkout:*)
@@ -785,6 +788,14 @@ jobs:
         # --allow-tool shell(git merge:*)
         # --allow-tool shell(git rm:*)
         # --allow-tool shell(git switch:*)
+        # --allow-tool shell(grep)
+        # --allow-tool shell(head)
+        # --allow-tool shell(ls)
+        # --allow-tool shell(pwd)
+        # --allow-tool shell(sort)
+        # --allow-tool shell(tail)
+        # --allow-tool shell(uniq)
+        # --allow-tool shell(wc)
         # --allow-tool write
         timeout-minutes: 5
         run: |
@@ -793,7 +804,7 @@ jobs:
           INSTRUCTION=$(cat /tmp/aw-prompts/prompt.txt)
           
           # Run copilot CLI with log capture
-          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(git add:*)' --allow-tool 'shell(git branch:*)' --allow-tool 'shell(git checkout:*)' --allow-tool 'shell(git commit:*)' --allow-tool 'shell(git merge:*)' --allow-tool 'shell(git rm:*)' --allow-tool 'shell(git switch:*)' --allow-tool write --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
+          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(cat)' --allow-tool 'shell(date)' --allow-tool 'shell(echo)' --allow-tool 'shell(git add:*)' --allow-tool 'shell(git branch:*)' --allow-tool 'shell(git checkout:*)' --allow-tool 'shell(git commit:*)' --allow-tool 'shell(git merge:*)' --allow-tool 'shell(git rm:*)' --allow-tool 'shell(git switch:*)' --allow-tool 'shell(grep)' --allow-tool 'shell(head)' --allow-tool 'shell(ls)' --allow-tool 'shell(pwd)' --allow-tool 'shell(sort)' --allow-tool 'shell(tail)' --allow-tool 'shell(uniq)' --allow-tool 'shell(wc)' --allow-tool write --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
@@ -1563,6 +1574,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-missing-tool.lock.yml
+++ b/pkg/cli/workflows/test-copilot-missing-tool.lock.yml
@@ -28,6 +28,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"missing-tool\":{\"max\":5}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1623,11 +1624,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-missing-tool.lock.yml
+++ b/pkg/cli/workflows/test-copilot-missing-tool.lock.yml
@@ -1620,6 +1620,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-patch-size-exceeded.lock.yml
+++ b/pkg/cli/workflows/test-copilot-patch-size-exceeded.lock.yml
@@ -25,6 +25,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"push-to-pull-request-branch\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1579,11 +1580,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-patch-size-exceeded.lock.yml
+++ b/pkg/cli/workflows/test-copilot-patch-size-exceeded.lock.yml
@@ -780,6 +780,9 @@ jobs:
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
         # --allow-tool safe_outputs
+        # --allow-tool shell(cat)
+        # --allow-tool shell(date)
+        # --allow-tool shell(echo)
         # --allow-tool shell(git add:*)
         # --allow-tool shell(git branch:*)
         # --allow-tool shell(git checkout:*)
@@ -787,6 +790,14 @@ jobs:
         # --allow-tool shell(git merge:*)
         # --allow-tool shell(git rm:*)
         # --allow-tool shell(git switch:*)
+        # --allow-tool shell(grep)
+        # --allow-tool shell(head)
+        # --allow-tool shell(ls)
+        # --allow-tool shell(pwd)
+        # --allow-tool shell(sort)
+        # --allow-tool shell(tail)
+        # --allow-tool shell(uniq)
+        # --allow-tool shell(wc)
         # --allow-tool write
         timeout-minutes: 5
         run: |
@@ -795,7 +806,7 @@ jobs:
           INSTRUCTION=$(cat /tmp/aw-prompts/prompt.txt)
           
           # Run copilot CLI with log capture
-          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(git add:*)' --allow-tool 'shell(git branch:*)' --allow-tool 'shell(git checkout:*)' --allow-tool 'shell(git commit:*)' --allow-tool 'shell(git merge:*)' --allow-tool 'shell(git rm:*)' --allow-tool 'shell(git switch:*)' --allow-tool write --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
+          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(cat)' --allow-tool 'shell(date)' --allow-tool 'shell(echo)' --allow-tool 'shell(git add:*)' --allow-tool 'shell(git branch:*)' --allow-tool 'shell(git checkout:*)' --allow-tool 'shell(git commit:*)' --allow-tool 'shell(git merge:*)' --allow-tool 'shell(git rm:*)' --allow-tool 'shell(git switch:*)' --allow-tool 'shell(grep)' --allow-tool 'shell(head)' --allow-tool 'shell(ls)' --allow-tool 'shell(pwd)' --allow-tool 'shell(sort)' --allow-tool 'shell(tail)' --allow-tool 'shell(uniq)' --allow-tool 'shell(wc)' --allow-tool write --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
@@ -1565,6 +1576,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
@@ -1988,7 +1988,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
@@ -111,6 +111,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"create-issue\":{\"max\":1},\"upload-asset\":{}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1714,11 +1715,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -1992,7 +1988,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: needs.agent.collect_output.outputs.output_type_create_issue
+    if: contains(needs.agent.collect_output.outputs.output_types, 'create_issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
@@ -1988,7 +1988,7 @@ jobs:
 
   create_issue:
     needs: agent
-    if: contains(needs.agent.collect_output.outputs.output_types, 'create-issue')
+    if: contains(needs.agent.outputs.output_types, 'create-issue')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
+++ b/pkg/cli/workflows/test-copilot-playwright-screenshots.lock.yml
@@ -913,16 +913,27 @@ jobs:
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
         # --allow-tool safe_outputs
+        # --allow-tool shell(cat)
         # --allow-tool shell(cd *)
         # --allow-tool shell(cp *)
         # --allow-tool shell(curl *)
+        # --allow-tool shell(date)
+        # --allow-tool shell(echo)
+        # --allow-tool shell(grep)
+        # --allow-tool shell(head)
         # --allow-tool shell(kill *)
+        # --allow-tool shell(ls)
         # --allow-tool shell(mkdir *)
         # --allow-tool shell(mv *)
         # --allow-tool shell(node *)
         # --allow-tool shell(npm *)
         # --allow-tool shell(ps *)
+        # --allow-tool shell(pwd)
         # --allow-tool shell(sleep *)
+        # --allow-tool shell(sort)
+        # --allow-tool shell(tail)
+        # --allow-tool shell(uniq)
+        # --allow-tool shell(wc)
         timeout-minutes: 5
         run: |
           set -o pipefail
@@ -930,7 +941,7 @@ jobs:
           INSTRUCTION=$(cat /tmp/aw-prompts/prompt.txt)
           
           # Run copilot CLI with log capture
-          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(cd *)' --allow-tool 'shell(cp *)' --allow-tool 'shell(curl *)' --allow-tool 'shell(kill *)' --allow-tool 'shell(mkdir *)' --allow-tool 'shell(mv *)' --allow-tool 'shell(node *)' --allow-tool 'shell(npm *)' --allow-tool 'shell(ps *)' --allow-tool 'shell(sleep *)' --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
+          copilot --add-dir /tmp/ --log-level all --log-dir /tmp/.copilot/logs/ --allow-tool safe_outputs --allow-tool 'shell(cat)' --allow-tool 'shell(cd *)' --allow-tool 'shell(cp *)' --allow-tool 'shell(curl *)' --allow-tool 'shell(date)' --allow-tool 'shell(echo)' --allow-tool 'shell(grep)' --allow-tool 'shell(head)' --allow-tool 'shell(kill *)' --allow-tool 'shell(ls)' --allow-tool 'shell(mkdir *)' --allow-tool 'shell(mv *)' --allow-tool 'shell(node *)' --allow-tool 'shell(npm *)' --allow-tool 'shell(ps *)' --allow-tool 'shell(pwd)' --allow-tool 'shell(sleep *)' --allow-tool 'shell(sort)' --allow-tool 'shell(tail)' --allow-tool 'shell(uniq)' --allow-tool 'shell(wc)' --prompt "$INSTRUCTION" 2>&1 | tee /tmp/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           GITHUB_AW_SAFE_OUTPUTS: ${{ env.GITHUB_AW_SAFE_OUTPUTS }}
@@ -1700,6 +1711,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")
@@ -1973,6 +1992,7 @@ jobs:
 
   create_issue:
     needs: agent
+    if: needs.agent.collect_output.outputs.output_type_create_issue
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/cli/workflows/test-copilot-safe-jobs.lock.yml
+++ b/pkg/cli/workflows/test-copilot-safe-jobs.lock.yml
@@ -261,6 +261,7 @@ jobs:
       GITHUB_AW_SAFE_OUTPUTS_CONFIG: "{\"print\":{\"inputs\":{\"message\":{\"description\":\"Message to print\",\"required\":true,\"type\":\"string\"}}}}"
     outputs:
       output: ${{ steps.collect_output.outputs.output }}
+      output_types: ${{ steps.collect_output.outputs.output_types }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -1772,11 +1773,6 @@ jobs:
               const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
               core.info(`output_types: ${outputTypes.join(", ")}`);
               core.setOutput("output_types", outputTypes.join(","));
-              outputTypes.forEach(type => {
-                const typeCount = parsedItems.filter(item => item.type === type).length;
-                core.info(`output_type_${type}: ${typeCount}`);
-                core.setOutput(`output_type_${type}`, typeCount);
-              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/cli/workflows/test-copilot-safe-jobs.lock.yml
+++ b/pkg/cli/workflows/test-copilot-safe-jobs.lock.yml
@@ -1769,6 +1769,14 @@ jobs:
               }
               core.setOutput("output", JSON.stringify(validatedOutput));
               core.setOutput("raw_output", outputContent);
+              const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+              core.info(`output_types: ${outputTypes.join(", ")}`);
+              core.setOutput("output_types", outputTypes.join(","));
+              outputTypes.forEach(type => {
+                const typeCount = parsedItems.filter(item => item.type === type).length;
+                core.info(`output_type_${type}: ${typeCount}`);
+                core.setOutput(`output_type_${type}`, typeCount);
+              });
               try {
                 await core.summary
                   .addRaw("## Processed Output\n\n")

--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -1554,7 +1554,7 @@ func (c *Compiler) buildMainJob(data *WorkflowData, activationJobCreated bool) (
 	var outputs map[string]string
 	if data.SafeOutputs != nil {
 		outputs = map[string]string{
-			"output": "${{ steps.collect_output.outputs.output }}",
+			"output":       "${{ steps.collect_output.outputs.output }}",
 			"output_types": "${{ steps.collect_output.outputs.output_types }}",
 		}
 	}

--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -1227,7 +1227,7 @@ func (c *Compiler) buildJobs(data *WorkflowData, markdownPath string) error {
 	}
 	// If frontmatter cannot be read, we'll fall back to the basic permission check logic
 
-	// Main job ID is always "agent"
+	// Main job ID is always constants.AgentJobName
 
 	// Build check-membership job if needed (validates team membership levels)
 	// Team membership checks are specifically for command workflows
@@ -1555,6 +1555,7 @@ func (c *Compiler) buildMainJob(data *WorkflowData, activationJobCreated bool) (
 	if data.SafeOutputs != nil {
 		outputs = map[string]string{
 			"output": "${{ steps.collect_output.outputs.output }}",
+			"output_types": "${{ steps.collect_output.outputs.output_types }}",
 		}
 	}
 
@@ -1575,7 +1576,7 @@ func (c *Compiler) buildMainJob(data *WorkflowData, activationJobCreated bool) (
 	}
 
 	job := &Job{
-		Name:        "agent",
+		Name:        constants.AgentJobName,
 		If:          jobCondition,
 		RunsOn:      c.indentYAMLLines(data.RunsOn, "    "),
 		Permissions: c.indentYAMLLines(data.Permissions, "    "),

--- a/pkg/workflow/create_issue.go
+++ b/pkg/workflow/create_issue.go
@@ -125,7 +125,7 @@ func (c *Compiler) buildCreateOutputIssueJob(data *WorkflowData, mainJobName str
 	}
 
 	// Determine the job condition for command workflows
-	jobCondition := "contains(needs.agent.collect_output.outputs.output_types, 'create_issue')"
+	jobCondition := "contains(needs.agent.collect_output.outputs.output_types, 'create-issue')"
 
 	// Set base permissions
 	permissions := "permissions:\n      contents: read\n      issues: write"

--- a/pkg/workflow/create_issue.go
+++ b/pkg/workflow/create_issue.go
@@ -125,7 +125,7 @@ func (c *Compiler) buildCreateOutputIssueJob(data *WorkflowData, mainJobName str
 	}
 
 	// Determine the job condition for command workflows
-	jobCondition := "needs.agent.collect_output.outputs.output_type_create_issue"
+	jobCondition := "contains(needs.agent.collect_output.outputs.output_types, 'create_issue')"
 
 	// Set base permissions
 	permissions := "permissions:\n      contents: read\n      issues: write"

--- a/pkg/workflow/create_issue.go
+++ b/pkg/workflow/create_issue.go
@@ -125,7 +125,7 @@ func (c *Compiler) buildCreateOutputIssueJob(data *WorkflowData, mainJobName str
 	}
 
 	// Determine the job condition for command workflows
-	jobCondition := "contains(needs.agent.collect_output.outputs.output_types, 'create-issue')"
+	jobCondition := BuildSafeOutputType("create-issue").Render()
 
 	// Set base permissions
 	permissions := "permissions:\n      contents: read\n      issues: write"

--- a/pkg/workflow/create_issue.go
+++ b/pkg/workflow/create_issue.go
@@ -125,15 +125,7 @@ func (c *Compiler) buildCreateOutputIssueJob(data *WorkflowData, mainJobName str
 	}
 
 	// Determine the job condition for command workflows
-	var jobCondition string
-	if data.Command != "" {
-		// Build the command trigger condition
-		commandCondition := buildCommandOnlyCondition(data.Command)
-		commandConditionStr := commandCondition.Render()
-		jobCondition = commandConditionStr
-	} else {
-		jobCondition = "" // No conditional execution
-	}
+	jobCondition := "needs.agent.collect_output.outputs.output_type_create_issue"
 
 	// Set base permissions
 	permissions := "permissions:\n      contents: read\n      issues: write"

--- a/pkg/workflow/create_pull_request.go
+++ b/pkg/workflow/create_pull_request.go
@@ -108,15 +108,7 @@ func (c *Compiler) buildCreateOutputPullRequestJob(data *WorkflowData, mainJobNa
 	}
 
 	// Determine the job condition for command workflows
-	var jobCondition string
-	if data.Command != "" {
-		// Build the command trigger condition
-		commandCondition := buildCommandOnlyCondition(data.Command)
-		commandConditionStr := commandCondition.Render()
-		jobCondition = commandConditionStr
-	} else {
-		jobCondition = "" // No conditional execution
-	}
+	jobCondition := "contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')"
 
 	job := &Job{
 		Name:           "create_pull_request",

--- a/pkg/workflow/create_pull_request.go
+++ b/pkg/workflow/create_pull_request.go
@@ -108,7 +108,7 @@ func (c *Compiler) buildCreateOutputPullRequestJob(data *WorkflowData, mainJobNa
 	}
 
 	// Determine the job condition for command workflows
-	jobCondition := "contains(needs.agent.collect_output.outputs.output_types, 'create-pull-request')"
+	jobCondition := BuildSafeOutputType("create-pull-request").Render()
 
 	job := &Job{
 		Name:           "create_pull_request",

--- a/pkg/workflow/expressions.go
+++ b/pkg/workflow/expressions.go
@@ -304,6 +304,13 @@ func BuildNotFromFork() *ComparisonNode {
 	)
 }
 
+func BuildSafeOutputType(outputType string) ConditionNode {
+	return BuildFunctionCall("contains",
+		BuildPropertyAccess(fmt.Sprintf("needs.%s.collect_output.outputs.output_types", constants.AgentJobName)),
+		BuildStringLiteral(outputType),
+	)
+}
+
 // BuildFromAllowedForks creates a condition to check if a pull request is from an allowed fork
 // Supports glob patterns like "org/*" and exact matches like "org/repo"
 func BuildFromAllowedForks(allowedForks []string) ConditionNode {

--- a/pkg/workflow/expressions.go
+++ b/pkg/workflow/expressions.go
@@ -306,7 +306,7 @@ func BuildNotFromFork() *ComparisonNode {
 
 func BuildSafeOutputType(outputType string) ConditionNode {
 	return BuildFunctionCall("contains",
-		BuildPropertyAccess(fmt.Sprintf("needs.%s.collect_output.outputs.output_types", constants.AgentJobName)),
+		BuildPropertyAccess(fmt.Sprintf("needs.%s.outputs.output_types", constants.AgentJobName)),
 		BuildStringLiteral(outputType),
 	)
 }

--- a/pkg/workflow/js/collect_ndjson_output.js
+++ b/pkg/workflow/js/collect_ndjson_output.js
@@ -723,11 +723,6 @@ async function main() {
   const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
   core.info(`output_types: ${outputTypes.join(", ")}`);
   core.setOutput("output_types", outputTypes.join(","));
-  outputTypes.forEach(type => {
-    const typeCount = parsedItems.filter(item => item.type === type).length;
-    core.info(`output_type_${type}: ${typeCount}`);
-    core.setOutput(`output_type_${type}`, typeCount);
-  });
   try {
     await core.summary
       .addRaw("## Processed Output\n\n")

--- a/pkg/workflow/js/collect_ndjson_output.js
+++ b/pkg/workflow/js/collect_ndjson_output.js
@@ -720,6 +720,14 @@ async function main() {
   }
   core.setOutput("output", JSON.stringify(validatedOutput));
   core.setOutput("raw_output", outputContent);
+  const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+  core.info(`output_types: ${outputTypes.join(", ")}`);
+  core.setOutput("output_types", outputTypes.join(","));
+  outputTypes.forEach(type => {
+    const typeCount = parsedItems.filter(item => item.type === type).length;
+    core.info(`output_type_${type}: ${typeCount}`);
+    core.setOutput(`output_type_${type}`, typeCount);
+  });
   try {
     await core.summary
       .addRaw("## Processed Output\n\n")

--- a/pkg/workflow/js/collect_ndjson_output.ts
+++ b/pkg/workflow/js/collect_ndjson_output.ts
@@ -1043,6 +1043,16 @@ async function main() {
   core.setOutput("output", JSON.stringify(validatedOutput));
   core.setOutput("raw_output", outputContent);
 
+  // collect set of validated output types and create output variables for it.
+  const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
+  core.info(`output_types: ${outputTypes.join(", ")}`);
+  core.setOutput("output_types", outputTypes.join(","));
+  outputTypes.forEach(type => {
+    const typeCount = parsedItems.filter(item => item.type === type).length;
+    core.info(`output_type_${type}: ${typeCount}`);
+    core.setOutput(`output_type_${type}`, typeCount);
+  });
+
   // Write processed output to step summary using core.summary
   try {
     await core.summary

--- a/pkg/workflow/js/collect_ndjson_output.ts
+++ b/pkg/workflow/js/collect_ndjson_output.ts
@@ -1047,11 +1047,6 @@ async function main() {
   const outputTypes = Array.from(new Set(parsedItems.map(item => item.type)));
   core.info(`output_types: ${outputTypes.join(", ")}`);
   core.setOutput("output_types", outputTypes.join(","));
-  outputTypes.forEach(type => {
-    const typeCount = parsedItems.filter(item => item.type === type).length;
-    core.info(`output_type_${type}: ${typeCount}`);
-    core.setOutput(`output_type_${type}`, typeCount);
-  });
 
   // Write processed output to step summary using core.summary
   try {


### PR DESCRIPTION
No need to spin the safe outputs job if none of the item are created, we can optimize this with jobs outputs.