### PR TITLE
fix: build script now works on MacOS

### DIFF
--- a/pkg/workflow/js/package.json
+++ b/pkg/workflow/js/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "compile": "tsc --project tsconfig.build.json && sed -i 's/^export {};$//' *.js && prettier --write '*.js'",
+    "compile": "tsc --project tsconfig.build.json && node remove-empty-exports.js && prettier --write '*.js'",
     "test": "npm run typecheck && vitest run",
     "test:js": "vitest run",
     "test:js-watch": "vitest",

--- a/pkg/workflow/js/remove-empty-exports.js
+++ b/pkg/workflow/js/remove-empty-exports.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+// Get all .js files in the current directory
+const files = fs.readdirSync(__dirname).filter(f => f.endsWith(".js") && f !== "remove-empty-exports.js");
+
+files.forEach(file => {
+  const filePath = path.join(__dirname, file);
+  let content = fs.readFileSync(filePath, "utf8");
+
+  // Remove lines that are exactly "export {};" or "export {};\n"
+  content = content.replace(/^export \{\};?\s*$/gm, "");
+
+  fs.writeFileSync(filePath, content, "utf8");
+});
+
+console.log(`Processed ${files.length} files`);


### PR DESCRIPTION
The semantics of `sed -i` behaves different on macOS and Linux. I swtiched to a javascript file for cross-compatibility.