### PR TITLE
🔧 Fix GitHub Actions checkout configuration

### DIFF
--- a/.github/instructions/github-agentic-workflows.instructions.md
+++ b/.github/instructions/github-agentic-workflows.instructions.md
@@ -792,7 +792,7 @@ Monitor workflow execution and costs using the `logs` command:
 gh aw logs
 
 # Download logs for a specific workflow
-gh aw logs ci-doctor
+gh aw logs weekly-research
 
 # Filter logs by AI engine type
 gh aw logs --engine claude           # Only Claude workflows
@@ -904,7 +904,7 @@ Use the `mcp list-tools` command to explore tools available from specific MCP se
 gh aw mcp list-tools github
 
 # List tools from a specific MCP server in a workflow
-gh aw mcp list-tools github ci-doctor
+gh aw mcp list-tools github weekly-research
 
 # List tools with detailed descriptions and allowance status  
 gh aw mcp list-tools safe-outputs issue-triage --verbose

--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -1684,7 +1684,7 @@ func (c *Compiler) generateMainJobSteps(yaml *strings.Builder, data *WorkflowDat
 			if c.trialTargetRepo != "" {
 				yaml.WriteString(fmt.Sprintf("          repository: %s\n", c.trialTargetRepo))
 			}
-			yaml.WriteString("          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
+			yaml.WriteString("          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
 		}
 
 		// Add step to checkout PR branch if the event is a comment on a PR

--- a/pkg/workflow/create_pull_request.go
+++ b/pkg/workflow/create_pull_request.go
@@ -35,6 +35,13 @@ func (c *Compiler) buildCreateOutputPullRequestJob(data *WorkflowData, mainJobNa
 	steps = append(steps, "        uses: actions/checkout@v5\n")
 	steps = append(steps, "        with:\n")
 	steps = append(steps, "          fetch-depth: 0\n")
+	if c.trialMode {
+		steps = append(steps, "        with:\n")
+		if c.trialTargetRepo != "" {
+			steps = append(steps, fmt.Sprintf("          repository: %s\n", c.trialTargetRepo))
+		}
+		steps = append(steps, "          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
+	}
 
 	// Step 3: Configure Git credentials
 	steps = append(steps, c.generateGitConfigurationSteps()...)

--- a/pkg/workflow/publish_assets.go
+++ b/pkg/workflow/publish_assets.go
@@ -107,6 +107,13 @@ func (c *Compiler) buildUploadAssetsJob(data *WorkflowData, mainJobName string, 
 	steps = append(steps, "        uses: actions/checkout@v5\n")
 	steps = append(steps, "        with:\n")
 	steps = append(steps, "          fetch-depth: 0\n")
+	if c.trialMode {
+		steps = append(steps, "        with:\n")
+		if c.trialTargetRepo != "" {
+			steps = append(steps, fmt.Sprintf("          repository: %s\n", c.trialTargetRepo))
+		}
+		steps = append(steps, "          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
+	}
 
 	// Step 3: Configure Git credentials
 	steps = append(steps, c.generateGitConfigurationSteps()...)

--- a/pkg/workflow/push_to_pull_request_branch.go
+++ b/pkg/workflow/push_to_pull_request_branch.go
@@ -35,6 +35,13 @@ func (c *Compiler) buildCreateOutputPushToPullRequestBranchJob(data *WorkflowDat
 	steps = append(steps, "        uses: actions/checkout@v5\n")
 	steps = append(steps, "        with:\n")
 	steps = append(steps, "          fetch-depth: 0\n")
+	if c.trialMode {
+		steps = append(steps, "        with:\n")
+		if c.trialTargetRepo != "" {
+			steps = append(steps, fmt.Sprintf("          repository: %s\n", c.trialTargetRepo))
+		}
+		steps = append(steps, "          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
+	}
 
 	// Step 3: Configure Git credentials
 	steps = append(steps, c.generateGitConfigurationSteps()...)

--- a/pkg/workflow/trial_mode_test.go
+++ b/pkg/workflow/trial_mode_test.go
@@ -69,7 +69,7 @@ This is a test workflow for trial mode compilation.
 		}
 
 		// Checkout should not include github-token in normal mode
-		if strings.Contains(lockContent, "github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}") {
+		if strings.Contains(lockContent, "token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}") {
 			t.Error("Did not expect github-token in checkout step in normal mode")
 		}
 	})
@@ -101,7 +101,7 @@ This is a test workflow for trial mode compilation.
 		}
 
 		// Checkout should include github-token in trial mode
-		if !strings.Contains(lockContent, "github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}") {
+		if !strings.Contains(lockContent, "token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}") {
 			t.Error("Expected github-token in checkout step in trial mode")
 		}
 
@@ -213,7 +213,7 @@ This is a test workflow for trial mode compilation.
 
 			// In trial mode, checkout should always include github-token
 			if strings.Contains(lockContent, "uses: actions/checkout@v5") {
-				if !strings.Contains(lockContent, "github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}") {
+				if !strings.Contains(lockContent, "token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}") {
 					t.Error("Expected github-token in checkout step in trial mode")
 				}
 			}


### PR DESCRIPTION
## Summary

- Updated GitHub Actions checkout step to use `token` instead of `github-token`
- Added conditional token configuration for trial mode workflows
- Updated test cases to reflect new checkout configuration

## Details

The changes modify the checkout configuration in various workflow-related Go files to:
- Replace `github-token` with `token` in actions/checkout step
- Add support for specifying a repository and token in trial mode
- Ensure consistent token handling across different workflow compilation methods

These modifications improve the flexibility and reliability of GitHub Actions workflow checkouts.