### PR TITLE
🔧 Fix repo name handling in trial mode configuration

### DIFF
--- a/cmd/gh-aw/main.go
+++ b/cmd/gh-aw/main.go
@@ -178,18 +178,18 @@ Examples:
 		// Also skip instructions when noEmit is true (validation-only mode)
 		skipInstructions := noInstructions || noEmit
 		config := cli.CompileConfig{
-			MarkdownFiles:    args,
-			Verbose:          verbose,
-			EngineOverride:   engineOverride,
-			Validate:         validate,
-			Watch:            watch,
-			WorkflowDir:      workflowDir,
-			SkipInstructions: skipInstructions,
-			NoEmit:           noEmit,
-			Purge:            purge,
-			TrialMode:        false,
-			TrialTargetRepo:  "",
-			Strict:           strict,
+			MarkdownFiles:       args,
+			Verbose:             verbose,
+			EngineOverride:      engineOverride,
+			Validate:            validate,
+			Watch:               watch,
+			WorkflowDir:         workflowDir,
+			SkipInstructions:    skipInstructions,
+			NoEmit:              noEmit,
+			Purge:               purge,
+			TrialMode:           false,
+			TrialTargetRepoSlug: "",
+			Strict:              strict,
 		}
 		if _, err := cli.CompileWorkflows(config); err != nil {
 			fmt.Fprintln(os.Stderr, console.FormatErrorMessage(err.Error()))

--- a/pkg/cli/audit.go
+++ b/pkg/cli/audit.go
@@ -234,7 +234,7 @@ func AuditWorkflowRun(runID int64, outputDir string, verbose bool) error {
 	}
 
 	// Generate and display report
-	report := generateAuditReport(processedRun, metrics, verbose)
+	report := generateAuditReport(processedRun, metrics)
 	fmt.Println(report)
 
 	// Display logs location
@@ -275,7 +275,7 @@ func fetchWorkflowRunMetadata(runID int64, verbose bool) (WorkflowRun, error) {
 }
 
 // generateAuditReport generates a concise markdown report for AI agent consumption
-func generateAuditReport(processedRun ProcessedRun, metrics LogMetrics, verbose bool) string {
+func generateAuditReport(processedRun ProcessedRun, metrics LogMetrics) string {
 	run := processedRun.Run
 	var report strings.Builder
 

--- a/pkg/cli/audit_test.go
+++ b/pkg/cli/audit_test.go
@@ -208,7 +208,7 @@ func TestGenerateAuditReport(t *testing.T) {
 	}
 
 	// Generate report
-	report := generateAuditReport(processedRun, metrics, false)
+	report := generateAuditReport(processedRun, metrics)
 
 	// Verify report contains expected sections
 	expectedSections := []string{
@@ -271,7 +271,7 @@ func TestGenerateAuditReportMinimal(t *testing.T) {
 	}
 
 	// Generate report
-	report := generateAuditReport(processedRun, metrics, false)
+	report := generateAuditReport(processedRun, metrics)
 
 	// Verify report contains basic sections even with minimal data
 	expectedSections := []string{
@@ -327,7 +327,7 @@ func TestGenerateAuditReportWithErrors(t *testing.T) {
 	}
 
 	// Generate report
-	report := generateAuditReport(processedRun, metrics, false)
+	report := generateAuditReport(processedRun, metrics)
 
 	// Verify issue summary is present
 	if !strings.Contains(report, "## Issue Summary") {
@@ -380,7 +380,7 @@ func TestGenerateAuditReportArtifacts(t *testing.T) {
 	}
 
 	// Generate report
-	report := generateAuditReport(processedRun, metrics, false)
+	report := generateAuditReport(processedRun, metrics)
 
 	// Verify all artifacts are listed
 	expectedArtifacts := []string{

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -598,18 +598,18 @@ func CompileWorkflowWithValidation(compiler *workflow.Compiler, filePath string,
 
 // CompileConfig holds configuration options for compiling workflows
 type CompileConfig struct {
-	MarkdownFiles    []string // Files to compile (empty for all files)
-	Verbose          bool     // Enable verbose output
-	EngineOverride   string   // Override AI engine setting
-	Validate         bool     // Enable schema validation
-	Watch            bool     // Enable watch mode
-	WorkflowDir      string   // Custom workflow directory
-	SkipInstructions bool     // Skip instruction validation
-	NoEmit           bool     // Validate without generating lock files
-	Purge            bool     // Remove orphaned lock files
-	TrialMode        bool     // Enable trial mode (suppress safe outputs)
-	TrialTargetRepo  string   // Target repository for trial mode
-	Strict           bool     // Enable strict mode validation
+	MarkdownFiles       []string // Files to compile (empty for all files)
+	Verbose             bool     // Enable verbose output
+	EngineOverride      string   // Override AI engine setting
+	Validate            bool     // Enable schema validation
+	Watch               bool     // Enable watch mode
+	WorkflowDir         string   // Custom workflow directory
+	SkipInstructions    bool     // Skip instruction validation
+	NoEmit              bool     // Validate without generating lock files
+	Purge               bool     // Remove orphaned lock files
+	TrialMode           bool     // Enable trial mode (suppress safe outputs)
+	TrialTargetRepoSlug string   // Target repository for trial mode
+	Strict              bool     // Enable strict mode validation
 }
 
 func CompileWorkflows(config CompileConfig) ([]*workflow.WorkflowData, error) {
@@ -623,7 +623,7 @@ func CompileWorkflows(config CompileConfig) ([]*workflow.WorkflowData, error) {
 	noEmit := config.NoEmit
 	purge := config.Purge
 	trialMode := config.TrialMode
-	trialTargetRepo := config.TrialTargetRepo
+	trialTargetRepoSlug := config.TrialTargetRepoSlug
 	strict := config.Strict
 	// Validate purge flag usage
 	if purge && len(markdownFiles) > 0 {
@@ -657,8 +657,8 @@ func CompileWorkflows(config CompileConfig) ([]*workflow.WorkflowData, error) {
 	// Set trial mode if specified
 	if trialMode {
 		compiler.SetTrialMode(true)
-		if trialTargetRepo != "" {
-			compiler.SetTrialTargetRepo(trialTargetRepo)
+		if trialTargetRepoSlug != "" {
+			compiler.SetTrialTargetRepo(trialTargetRepoSlug)
 		}
 	}
 

--- a/pkg/cli/commands_compile_workflow_test.go
+++ b/pkg/cli/commands_compile_workflow_test.go
@@ -513,17 +513,17 @@ This is a test workflow for backward compatibility.
 				args = []string{tt.workflowID}
 			}
 			config := CompileConfig{
-				MarkdownFiles:    args,
-				Verbose:          false,
-				EngineOverride:   "",
-				Validate:         false,
-				Watch:            false,
-				WorkflowDir:      "",
-				SkipInstructions: false,
-				NoEmit:           false,
-				Purge:            false,
-				TrialMode:        false,
-				TrialTargetRepo:  "",
+				MarkdownFiles:       args,
+				Verbose:             false,
+				EngineOverride:      "",
+				Validate:            false,
+				Watch:               false,
+				WorkflowDir:         "",
+				SkipInstructions:    false,
+				NoEmit:              false,
+				Purge:               false,
+				TrialMode:           false,
+				TrialTargetRepoSlug: "",
 			}
 			_, err = CompileWorkflows(config)
 

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -109,17 +109,17 @@ func TestCompileWorkflows(t *testing.T) {
 				args = []string{tt.markdownFile}
 			}
 			config := CompileConfig{
-				MarkdownFiles:    args,
-				Verbose:          false,
-				EngineOverride:   "",
-				Validate:         false,
-				Watch:            false,
-				WorkflowDir:      "",
-				SkipInstructions: false,
-				NoEmit:           false,
-				Purge:            false,
-				TrialMode:        false,
-				TrialTargetRepo:  "",
+				MarkdownFiles:       args,
+				Verbose:             false,
+				EngineOverride:      "",
+				Validate:            false,
+				Watch:               false,
+				WorkflowDir:         "",
+				SkipInstructions:    false,
+				NoEmit:              false,
+				Purge:               false,
+				TrialMode:           false,
+				TrialTargetRepoSlug: "",
 			}
 			_, err := CompileWorkflows(config)
 
@@ -136,17 +136,17 @@ func TestCompileWorkflowsPurgeFlag(t *testing.T) {
 	t.Run("purge flag validation with specific files", func(t *testing.T) {
 		// Test that purge flag is rejected when specific files are provided
 		config := CompileConfig{
-			MarkdownFiles:    []string{"test.md"},
-			Verbose:          false,
-			EngineOverride:   "",
-			Validate:         false,
-			Watch:            false,
-			WorkflowDir:      "",
-			SkipInstructions: false,
-			NoEmit:           false,
-			Purge:            true,
-			TrialMode:        false,
-			TrialTargetRepo:  "",
+			MarkdownFiles:       []string{"test.md"},
+			Verbose:             false,
+			EngineOverride:      "",
+			Validate:            false,
+			Watch:               false,
+			WorkflowDir:         "",
+			SkipInstructions:    false,
+			NoEmit:              false,
+			Purge:               true,
+			TrialMode:           false,
+			TrialTargetRepoSlug: "",
 		}
 		_, err := CompileWorkflows(config)
 
@@ -178,17 +178,17 @@ func TestCompileWorkflowsPurgeFlag(t *testing.T) {
 		// Note: This will still error because there are no .md files, but it shouldn't
 		// error specifically because of the purge flag validation
 		config := CompileConfig{
-			MarkdownFiles:    []string{},
-			Verbose:          false,
-			EngineOverride:   "",
-			Validate:         false,
-			Watch:            false,
-			WorkflowDir:      "",
-			SkipInstructions: false,
-			NoEmit:           false,
-			Purge:            true,
-			TrialMode:        false,
-			TrialTargetRepo:  "",
+			MarkdownFiles:       []string{},
+			Verbose:             false,
+			EngineOverride:      "",
+			Validate:            false,
+			Watch:               false,
+			WorkflowDir:         "",
+			SkipInstructions:    false,
+			NoEmit:              false,
+			Purge:               true,
+			TrialMode:           false,
+			TrialTargetRepoSlug: "",
 		}
 		_, err := CompileWorkflows(config)
 
@@ -229,17 +229,17 @@ This is a test workflow to verify the --no-emit flag functionality.`
 
 	// Test compilation with noEmit = false (should create lock file)
 	config := CompileConfig{
-		MarkdownFiles:    []string{"no-emit-test"},
-		Verbose:          false,
-		EngineOverride:   "",
-		Validate:         false,
-		Watch:            false,
-		WorkflowDir:      "",
-		SkipInstructions: false,
-		NoEmit:           false,
-		Purge:            false,
-		TrialMode:        false,
-		TrialTargetRepo:  "",
+		MarkdownFiles:       []string{"no-emit-test"},
+		Verbose:             false,
+		EngineOverride:      "",
+		Validate:            false,
+		Watch:               false,
+		WorkflowDir:         "",
+		SkipInstructions:    false,
+		NoEmit:              false,
+		Purge:               false,
+		TrialMode:           false,
+		TrialTargetRepoSlug: "",
 	}
 	_, err = CompileWorkflows(config)
 	if err != nil {
@@ -256,17 +256,17 @@ This is a test workflow to verify the --no-emit flag functionality.`
 
 	// Test compilation with noEmit = true (should NOT create lock file)
 	config2 := CompileConfig{
-		MarkdownFiles:    []string{"no-emit-test"},
-		Verbose:          false,
-		EngineOverride:   "",
-		Validate:         false,
-		Watch:            false,
-		WorkflowDir:      "",
-		SkipInstructions: false,
-		NoEmit:           true,
-		Purge:            false,
-		TrialMode:        false,
-		TrialTargetRepo:  "",
+		MarkdownFiles:       []string{"no-emit-test"},
+		Verbose:             false,
+		EngineOverride:      "",
+		Validate:            false,
+		Watch:               false,
+		WorkflowDir:         "",
+		SkipInstructions:    false,
+		NoEmit:              true,
+		Purge:               false,
+		TrialMode:           false,
+		TrialTargetRepoSlug: "",
 	}
 	_, err = CompileWorkflows(config2)
 	if err != nil {
@@ -460,17 +460,17 @@ func TestAllCommandsExist(t *testing.T) {
 		{func() error { return AddWorkflowWithTracking("", 1, false, "", "", false, nil) }, false, "AddWorkflowWithTracking (empty name)"}, // Shows help when empty, doesn't error
 		{func() error {
 			config := CompileConfig{
-				MarkdownFiles:    []string{},
-				Verbose:          false,
-				EngineOverride:   "",
-				Validate:         false,
-				Watch:            false,
-				WorkflowDir:      "",
-				SkipInstructions: false,
-				NoEmit:           false,
-				Purge:            false,
-				TrialMode:        false,
-				TrialTargetRepo:  "",
+				MarkdownFiles:       []string{},
+				Verbose:             false,
+				EngineOverride:      "",
+				Validate:            false,
+				Watch:               false,
+				WorkflowDir:         "",
+				SkipInstructions:    false,
+				NoEmit:              false,
+				Purge:               false,
+				TrialMode:           false,
+				TrialTargetRepoSlug: "",
 			}
 			_, err := CompileWorkflows(config)
 			return err

--- a/pkg/cli/interactive.go
+++ b/pkg/cli/interactive.go
@@ -72,7 +72,7 @@ func CreateWorkflowInteractively(workflowName string, verbose bool, force bool) 
 	}
 
 	// Generate the workflow
-	if err := builder.generateWorkflow(verbose, force); err != nil {
+	if err := builder.generateWorkflow(force); err != nil {
 		return fmt.Errorf("failed to generate workflow: %w", err)
 	}
 
@@ -245,7 +245,7 @@ func (b *InteractiveWorkflowBuilder) promptForIntent() error {
 }
 
 // generateWorkflow creates the markdown workflow file based on user selections
-func (b *InteractiveWorkflowBuilder) generateWorkflow(verbose bool, force bool) error {
+func (b *InteractiveWorkflowBuilder) generateWorkflow(force bool) error {
 	// Get current working directory for .github/workflows
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -470,17 +470,17 @@ func (b *InteractiveWorkflowBuilder) compileWorkflow(verbose bool) error {
 
 	// Use the existing compile functionality
 	config := CompileConfig{
-		MarkdownFiles:    []string{b.WorkflowName},
-		Verbose:          verbose,
-		EngineOverride:   "",
-		Validate:         true,
-		Watch:            false,
-		WorkflowDir:      "",
-		SkipInstructions: false,
-		NoEmit:           false,
-		Purge:            false,
-		TrialMode:        false,
-		TrialTargetRepo:  "",
+		MarkdownFiles:       []string{b.WorkflowName},
+		Verbose:             verbose,
+		EngineOverride:      "",
+		Validate:            true,
+		Watch:               false,
+		WorkflowDir:         "",
+		SkipInstructions:    false,
+		NoEmit:              false,
+		Purge:               false,
+		TrialMode:           false,
+		TrialTargetRepoSlug: "",
 	}
 	_, err := CompileWorkflows(config)
 	return err

--- a/pkg/cli/mcp_registry_improvements_test.go
+++ b/pkg/cli/mcp_registry_improvements_test.go
@@ -225,11 +225,12 @@ func TestMCPRegistryClient_GitHubRegistryAccessibility(t *testing.T) {
 
 	// We expect either 200 (success) or 403 (firewall/network restriction)
 	// Both indicate the endpoint exists and is reachable
-	if resp.StatusCode == http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
 		t.Logf("✓ GitHub MCP registry is accessible and returned 200 OK")
-	} else if resp.StatusCode == http.StatusForbidden {
+	case http.StatusForbidden:
 		t.Logf("✓ GitHub MCP registry is reachable but returned 403 (expected due to network restrictions)")
-	} else {
+	default:
 		t.Errorf("GitHub MCP registry returned unexpected status: %d", resp.StatusCode)
 	}
 

--- a/pkg/cli/workflow_dir_test.go
+++ b/pkg/cli/workflow_dir_test.go
@@ -59,17 +59,17 @@ This is a test workflow in a custom directory.
 
 	// Test 1: Compile with custom workflow directory should work
 	config := CompileConfig{
-		MarkdownFiles:    []string{},
-		Verbose:          false,
-		EngineOverride:   "",
-		Validate:         false,
-		Watch:            false,
-		WorkflowDir:      customDir,
-		SkipInstructions: false,
-		NoEmit:           false,
-		Purge:            false,
-		TrialMode:        false,
-		TrialTargetRepo:  "",
+		MarkdownFiles:       []string{},
+		Verbose:             false,
+		EngineOverride:      "",
+		Validate:            false,
+		Watch:               false,
+		WorkflowDir:         customDir,
+		SkipInstructions:    false,
+		NoEmit:              false,
+		Purge:               false,
+		TrialMode:           false,
+		TrialTargetRepoSlug: "",
 	}
 	_, err = CompileWorkflows(config)
 	if err != nil {
@@ -84,17 +84,17 @@ This is a test workflow in a custom directory.
 
 	// Test 2: Using absolute path should fail
 	config = CompileConfig{
-		MarkdownFiles:    []string{},
-		Verbose:          false,
-		EngineOverride:   "",
-		Validate:         false,
-		Watch:            false,
-		WorkflowDir:      "/absolute/path",
-		SkipInstructions: false,
-		NoEmit:           false,
-		Purge:            false,
-		TrialMode:        false,
-		TrialTargetRepo:  "",
+		MarkdownFiles:       []string{},
+		Verbose:             false,
+		EngineOverride:      "",
+		Validate:            false,
+		Watch:               false,
+		WorkflowDir:         "/absolute/path",
+		SkipInstructions:    false,
+		NoEmit:              false,
+		Purge:               false,
+		TrialMode:           false,
+		TrialTargetRepoSlug: "",
 	}
 	_, err = CompileWorkflows(config)
 	if err == nil {
@@ -116,17 +116,17 @@ This is a test workflow in a custom directory.
 	}
 
 	config = CompileConfig{
-		MarkdownFiles:    []string{},
-		Verbose:          false,
-		EngineOverride:   "",
-		Validate:         false,
-		Watch:            false,
-		WorkflowDir:      "",
-		SkipInstructions: false,
-		NoEmit:           false,
-		Purge:            false,
-		TrialMode:        false,
-		TrialTargetRepo:  "",
+		MarkdownFiles:       []string{},
+		Verbose:             false,
+		EngineOverride:      "",
+		Validate:            false,
+		Watch:               false,
+		WorkflowDir:         "",
+		SkipInstructions:    false,
+		NoEmit:              false,
+		Purge:               false,
+		TrialMode:           false,
+		TrialTargetRepoSlug: "",
 	}
 	_, err = CompileWorkflows(config)
 	if err != nil {
@@ -223,17 +223,17 @@ on: push
 
 			// Test the compilation
 			config := CompileConfig{
-				MarkdownFiles:    []string{},
-				Verbose:          false,
-				EngineOverride:   "",
-				Validate:         false,
-				Watch:            false,
-				WorkflowDir:      tt.workflowDir,
-				SkipInstructions: false,
-				NoEmit:           false,
-				Purge:            false,
-				TrialMode:        false,
-				TrialTargetRepo:  "",
+				MarkdownFiles:       []string{},
+				Verbose:             false,
+				EngineOverride:      "",
+				Validate:            false,
+				Watch:               false,
+				WorkflowDir:         tt.workflowDir,
+				SkipInstructions:    false,
+				NoEmit:              false,
+				Purge:               false,
+				TrialMode:           false,
+				TrialTargetRepoSlug: "",
 			}
 			_, err = CompileWorkflows(config)
 

--- a/pkg/workflow/create_pull_request.go
+++ b/pkg/workflow/create_pull_request.go
@@ -31,17 +31,7 @@ func (c *Compiler) buildCreateOutputPullRequestJob(data *WorkflowData, mainJobNa
 	steps = append(steps, "          path: /tmp/\n")
 
 	// Step 2: Checkout repository
-	steps = append(steps, "      - name: Checkout repository\n")
-	steps = append(steps, "        uses: actions/checkout@v5\n")
-	steps = append(steps, "        with:\n")
-	steps = append(steps, "          fetch-depth: 0\n")
-	if c.trialMode {
-		steps = append(steps, "        with:\n")
-		if c.trialTargetRepo != "" {
-			steps = append(steps, fmt.Sprintf("          repository: %s\n", c.trialTargetRepo))
-		}
-		steps = append(steps, "          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
-	}
+	steps = buildCheckoutRepository(steps, c)
 
 	// Step 3: Configure Git credentials
 	steps = append(steps, c.generateGitConfigurationSteps()...)

--- a/pkg/workflow/publish_assets.go
+++ b/pkg/workflow/publish_assets.go
@@ -103,17 +103,7 @@ func (c *Compiler) buildUploadAssetsJob(data *WorkflowData, mainJobName string, 
 	}
 
 	// Step 2: Checkout repository
-	steps = append(steps, "      - name: Checkout repository\n")
-	steps = append(steps, "        uses: actions/checkout@v5\n")
-	steps = append(steps, "        with:\n")
-	steps = append(steps, "          fetch-depth: 0\n")
-	if c.trialMode {
-		steps = append(steps, "        with:\n")
-		if c.trialTargetRepo != "" {
-			steps = append(steps, fmt.Sprintf("          repository: %s\n", c.trialTargetRepo))
-		}
-		steps = append(steps, "          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}\n")
-	}
+	steps = buildCheckoutRepository(steps, c)
 
 	// Step 3: Configure Git credentials
 	steps = append(steps, c.generateGitConfigurationSteps()...)


### PR DESCRIPTION
## Summary
- Renamed `TrialTargetRepo` to `TrialTargetRepoSlug` for clarity
- Updated multiple files to use the new field name consistently
- Added path handling for trial mode checkout when repository slug is provided

## Changes
- Refactored `CompileConfig` struct to use `TrialTargetRepoSlug`
- Updated function signatures and calls across multiple files
- Implemented repo name parsing for trial mode checkout step
- Removed verbose parameter from some function calls