### PR TITLE
🧹 Remove unused parameters across workflow and CLI packages

### DIFF
--- a/pkg/cli/trial_command.go
+++ b/pkg/cli/trial_command.go
@@ -723,27 +723,27 @@ func determineEngineSecret(workflowDataList []*workflow.WorkflowData, workflowNa
 		if verbose {
 			fmt.Fprintln(os.Stderr, console.FormatInfoMessage("Setting ANTHROPIC_API_KEY secret for Claude engine"))
 		}
-		return addEngineSecret("ANTHROPIC_API_KEY", "anthropic_api_key", trialRepoSlug, verbose)
+		return addEngineSecret("ANTHROPIC_API_KEY", trialRepoSlug, verbose)
 	case "codex", "openai":
 		if verbose {
 			fmt.Fprintln(os.Stderr, console.FormatInfoMessage("Setting OPENAI_API_KEY secret for OpenAI engine"))
 		}
-		return addEngineSecret("OPENAI_API_KEY", "openai_api_key", trialRepoSlug, verbose)
+		return addEngineSecret("OPENAI_API_KEY", trialRepoSlug, verbose)
 	case "copilot":
 		if verbose {
 			fmt.Fprintln(os.Stderr, console.FormatInfoMessage("Setting COPILOT_CLI_TOKEN secret for Copilot engine"))
 		}
-		return addEngineSecret("COPILOT_CLI_TOKEN", "copilot_cli_token", trialRepoSlug, verbose)
+		return addEngineSecret("COPILOT_CLI_TOKEN", trialRepoSlug, verbose)
 	default:
 		if verbose {
 			fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Unknown engine type '%s', defaulting to Copilot", engineType)))
 		}
-		return addEngineSecret("COPILOT_CLI_TOKEN", "copilot_cli_token", trialRepoSlug, verbose)
+		return addEngineSecret("COPILOT_CLI_TOKEN", trialRepoSlug, verbose)
 	}
 }
 
 // addEngineSecret adds an engine-specific secret to the repository
-func addEngineSecret(secretName, userSecretName, trialRepoSlug string, verbose bool) error {
+func addEngineSecret(secretName, trialRepoSlug string, verbose bool) error {
 	// First try to get the secret from environment variables
 	secretValue := os.Getenv(secretName)
 	if secretValue == "" {

--- a/pkg/workflow/cache.go
+++ b/pkg/workflow/cache.go
@@ -178,7 +178,7 @@ func generateCacheSteps(builder *strings.Builder, data *WorkflowData, verbose bo
 
 // generateCacheMemorySteps generates cache steps for the cache-memory configuration
 // Cache-memory provides a simple file share that LLMs can read/write freely
-func generateCacheMemorySteps(builder *strings.Builder, data *WorkflowData, verbose bool) {
+func generateCacheMemorySteps(builder *strings.Builder, data *WorkflowData) {
 	if data.CacheMemoryConfig == nil || !data.CacheMemoryConfig.Enabled {
 		return
 	}

--- a/pkg/workflow/claude_engine.go
+++ b/pkg/workflow/claude_engine.go
@@ -603,10 +603,10 @@ func (e *ClaudeEngine) RenderMCPConfig(yaml *strings.Builder, tools map[string]a
 		switch toolName {
 		case "github":
 			githubTool := tools["github"]
-			e.renderGitHubClaudeMCPConfig(yaml, githubTool, isLast, workflowData)
+			e.renderGitHubClaudeMCPConfig(yaml, githubTool, isLast)
 		case "playwright":
 			playwrightTool := tools["playwright"]
-			e.renderPlaywrightMCPConfig(yaml, playwrightTool, isLast, workflowData.NetworkPermissions)
+			e.renderPlaywrightMCPConfig(yaml, playwrightTool, isLast)
 		case "cache-memory":
 			e.renderCacheMemoryMCPConfig(yaml, isLast, workflowData)
 		case "safe-outputs":
@@ -632,7 +632,7 @@ func (e *ClaudeEngine) RenderMCPConfig(yaml *strings.Builder, tools map[string]a
 
 // renderGitHubClaudeMCPConfig generates the GitHub MCP server configuration
 // Always uses Docker MCP as the default
-func (e *ClaudeEngine) renderGitHubClaudeMCPConfig(yaml *strings.Builder, githubTool any, isLast bool, workflowData *WorkflowData) {
+func (e *ClaudeEngine) renderGitHubClaudeMCPConfig(yaml *strings.Builder, githubTool any, isLast bool) {
 	githubDockerImageVersion := getGitHubDockerImageVersion(githubTool)
 	customArgs := getGitHubCustomArgs(githubTool)
 	readOnly := getGitHubReadOnly(githubTool)
@@ -671,8 +671,8 @@ func (e *ClaudeEngine) renderGitHubClaudeMCPConfig(yaml *strings.Builder, github
 
 // renderPlaywrightMCPConfig generates the Playwright MCP server configuration
 // Uses npx to launch Playwright MCP instead of Docker for better performance and simplicity
-func (e *ClaudeEngine) renderPlaywrightMCPConfig(yaml *strings.Builder, playwrightTool any, isLast bool, networkPermissions *NetworkPermissions) {
-	args := generatePlaywrightDockerArgs(playwrightTool, networkPermissions)
+func (e *ClaudeEngine) renderPlaywrightMCPConfig(yaml *strings.Builder, playwrightTool any, isLast bool) {
+	args := generatePlaywrightDockerArgs(playwrightTool)
 	customArgs := getPlaywrightCustomArgs(playwrightTool)
 
 	yaml.WriteString("              \"playwright\": {\n")

--- a/pkg/workflow/codex_engine.go
+++ b/pkg/workflow/codex_engine.go
@@ -255,7 +255,7 @@ func (e *CodexEngine) RenderMCPConfig(yaml *strings.Builder, tools map[string]an
 			e.renderGitHubCodexMCPConfig(yaml, githubTool, workflowData)
 		case "playwright":
 			playwrightTool := expandedTools["playwright"]
-			e.renderPlaywrightCodexMCPConfig(yaml, playwrightTool, workflowData.NetworkPermissions)
+			e.renderPlaywrightCodexMCPConfig(yaml, playwrightTool)
 		case "safe-outputs":
 			e.renderSafeOutputsCodexMCPConfig(yaml, workflowData)
 		case "web-fetch":
@@ -525,8 +525,8 @@ func (e *CodexEngine) renderGitHubCodexMCPConfig(yaml *strings.Builder, githubTo
 
 // renderPlaywrightCodexMCPConfig generates Playwright MCP server configuration for codex config.toml
 // Uses npx to launch Playwright MCP instead of Docker for better performance and simplicity
-func (e *CodexEngine) renderPlaywrightCodexMCPConfig(yaml *strings.Builder, playwrightTool any, networkPermissions *NetworkPermissions) {
-	args := generatePlaywrightDockerArgs(playwrightTool, networkPermissions)
+func (e *CodexEngine) renderPlaywrightCodexMCPConfig(yaml *strings.Builder, playwrightTool any) {
+	args := generatePlaywrightDockerArgs(playwrightTool)
 	customArgs := getPlaywrightCustomArgs(playwrightTool)
 
 	yaml.WriteString("          \n")

--- a/pkg/workflow/copilot_engine.go
+++ b/pkg/workflow/copilot_engine.go
@@ -216,10 +216,10 @@ func (e *CopilotEngine) RenderMCPConfig(yaml *strings.Builder, tools map[string]
 		switch toolName {
 		case "github":
 			githubTool := tools["github"]
-			e.renderGitHubCopilotMCPConfig(yaml, githubTool, isLast, workflowData)
+			e.renderGitHubCopilotMCPConfig(yaml, githubTool, isLast)
 		case "playwright":
 			playwrightTool := tools["playwright"]
-			e.renderPlaywrightCopilotMCPConfig(yaml, playwrightTool, isLast, workflowData.NetworkPermissions)
+			e.renderPlaywrightCopilotMCPConfig(yaml, playwrightTool, isLast)
 		case "safe-outputs":
 			e.renderSafeOutputsCopilotMCPConfig(yaml, isLast)
 		case "web-fetch":
@@ -253,7 +253,7 @@ func (e *CopilotEngine) RenderMCPConfig(yaml *strings.Builder, tools map[string]
 
 // renderGitHubCopilotMCPConfig generates the GitHub MCP server configuration for Copilot CLI
 // Uses Docker-based GitHub MCP server (similar to Claude engine)
-func (e *CopilotEngine) renderGitHubCopilotMCPConfig(yaml *strings.Builder, githubTool any, isLast bool, workflowData *WorkflowData) {
+func (e *CopilotEngine) renderGitHubCopilotMCPConfig(yaml *strings.Builder, githubTool any, isLast bool) {
 	githubDockerImageVersion := getGitHubDockerImageVersion(githubTool)
 	customArgs := getGitHubCustomArgs(githubTool)
 	readOnly := getGitHubReadOnly(githubTool)
@@ -291,8 +291,8 @@ func (e *CopilotEngine) renderGitHubCopilotMCPConfig(yaml *strings.Builder, gith
 }
 
 // renderPlaywrightCopilotMCPConfig generates the Playwright MCP server configuration for Copilot CLI
-func (e *CopilotEngine) renderPlaywrightCopilotMCPConfig(yaml *strings.Builder, playwrightTool any, isLast bool, networkPermissions *NetworkPermissions) {
-	args := generatePlaywrightDockerArgs(playwrightTool, networkPermissions)
+func (e *CopilotEngine) renderPlaywrightCopilotMCPConfig(yaml *strings.Builder, playwrightTool any, isLast bool) {
+	args := generatePlaywrightDockerArgs(playwrightTool)
 	customArgs := getPlaywrightCustomArgs(playwrightTool)
 
 	// Use the version from docker args (which handles version configuration)

--- a/pkg/workflow/copilot_engine_test.go
+++ b/pkg/workflow/copilot_engine_test.go
@@ -551,7 +551,8 @@ func TestCopilotEngineRenderGitHubMCPConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var yaml strings.Builder
 			workflowData := &WorkflowData{}
-			engine.renderGitHubCopilotMCPConfig(&yaml, tt.githubTool, tt.isLast, workflowData)
+			var _ *WorkflowData = workflowData
+			engine.renderGitHubCopilotMCPConfig(&yaml, tt.githubTool, tt.isLast)
 			output := yaml.String()
 
 			for _, expected := range tt.expectedStrs {

--- a/pkg/workflow/custom_engine.go
+++ b/pkg/workflow/custom_engine.go
@@ -159,7 +159,7 @@ func (e *CustomEngine) RenderMCPConfig(yaml *strings.Builder, tools map[string]a
 			e.renderGitHubMCPConfig(yaml, githubTool, isLast)
 		case "playwright":
 			playwrightTool := tools["playwright"]
-			e.renderPlaywrightMCPConfig(yaml, playwrightTool, isLast, workflowData.NetworkPermissions)
+			e.renderPlaywrightMCPConfig(yaml, playwrightTool, isLast)
 		case "cache-memory":
 			e.renderCacheMemoryMCPConfig(yaml, isLast, workflowData)
 		case "safe-outputs":
@@ -223,8 +223,8 @@ func (e *CustomEngine) renderGitHubMCPConfig(yaml *strings.Builder, githubTool a
 
 // renderPlaywrightMCPConfig generates the Playwright MCP server configuration using shared logic
 // Uses npx to launch Playwright MCP instead of Docker for better performance and simplicity
-func (e *CustomEngine) renderPlaywrightMCPConfig(yaml *strings.Builder, playwrightTool any, isLast bool, networkPermissions *NetworkPermissions) {
-	args := generatePlaywrightDockerArgs(playwrightTool, networkPermissions)
+func (e *CustomEngine) renderPlaywrightMCPConfig(yaml *strings.Builder, playwrightTool any, isLast bool) {
+	args := generatePlaywrightDockerArgs(playwrightTool)
 	customArgs := getPlaywrightCustomArgs(playwrightTool)
 
 	yaml.WriteString("              \"playwright\": {\n")

--- a/pkg/workflow/error_validation_test.go
+++ b/pkg/workflow/error_validation_test.go
@@ -184,27 +184,28 @@ func TestCodingAgentEngineErrorValidation(t *testing.T) {
 		foundNpmError := false
 
 		for _, pattern := range patterns {
-			if pattern.Description == "Copilot CLI timestamped ERROR messages" {
+			switch pattern.Description {
+			case "Copilot CLI timestamped ERROR messages":
 				foundTimestampedError = true
 				if pattern.LevelGroup != 2 || pattern.MessageGroup != 3 {
 					t.Errorf("Copilot timestamped error pattern has wrong groups: level=%d, message=%d", pattern.LevelGroup, pattern.MessageGroup)
 				}
-			} else if pattern.Description == "Copilot CLI timestamped WARNING messages" {
+			case "Copilot CLI timestamped WARNING messages":
 				foundTimestampedWarning = true
 				if pattern.LevelGroup != 2 || pattern.MessageGroup != 3 {
 					t.Errorf("Copilot timestamped warning pattern has wrong groups: level=%d, message=%d", pattern.LevelGroup, pattern.MessageGroup)
 				}
-			} else if pattern.Description == "Copilot CLI bracketed critical/error messages with timestamp" {
+			case "Copilot CLI bracketed critical/error messages with timestamp":
 				foundBracketedError = true
 				if pattern.LevelGroup != 2 || pattern.MessageGroup != 3 {
 					t.Errorf("Copilot bracketed error pattern has wrong groups: level=%d, message=%d", pattern.LevelGroup, pattern.MessageGroup)
 				}
-			} else if pattern.Description == "Generic error messages from Copilot CLI or Node.js" {
+			case "Generic error messages from Copilot CLI or Node.js":
 				foundGenericError = true
 				if pattern.LevelGroup != 1 || pattern.MessageGroup != 2 {
 					t.Errorf("Copilot generic error pattern has wrong groups: level=%d, message=%d", pattern.LevelGroup, pattern.MessageGroup)
 				}
-			} else if pattern.Description == "NPM error messages during Copilot CLI installation or execution" {
+			case "NPM error messages during Copilot CLI installation or execution":
 				foundNpmError = true
 				if pattern.LevelGroup != 0 || pattern.MessageGroup != 1 {
 					t.Errorf("Copilot npm error pattern has wrong groups: level=%d, message=%d", pattern.LevelGroup, pattern.MessageGroup)
@@ -235,7 +236,6 @@ func TestErrorPatternSerialization(t *testing.T) {
 		Pattern:      `\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\]\s+(ERROR):\s+(.+)`,
 		LevelGroup:   2,
 		MessageGroup: 3,
-		Description:  "Test pattern",
 	}
 
 	// Test JSON serialization - this would be used in the workflow compiler

--- a/pkg/workflow/expressions.go
+++ b/pkg/workflow/expressions.go
@@ -830,9 +830,10 @@ func BreakAtParentheses(expression string) []string {
 		char := expression[i]
 		current += string(char)
 
-		if char == '(' {
+		switch char {
+		case '(':
 			parenDepth++
-		} else if char == ')' {
+		case ')':
 			parenDepth--
 
 			// If we're back to zero depth and the line is getting long, consider a break

--- a/pkg/workflow/fetch.go
+++ b/pkg/workflow/fetch.go
@@ -45,7 +45,8 @@ func AddMCPFetchServerIfNeeded(tools map[string]any, engine CodingAgentEngine) (
 // This is a shared function that can be used by all engines
 // includeTools parameter adds "tools": ["*"] field for engines that require it (e.g., Copilot)
 func renderMCPFetchServerConfig(yaml *strings.Builder, format string, indent string, isLast bool, includeTools bool) {
-	if format == "json" {
+	switch format {
+	case "json":
 		// JSON format (for Claude, Copilot, Custom engines)
 		yaml.WriteString(indent + "\"web-fetch\": {\n")
 		yaml.WriteString(indent + "  \"command\": \"docker\",\n")
@@ -66,7 +67,7 @@ func renderMCPFetchServerConfig(yaml *strings.Builder, format string, indent str
 		} else {
 			yaml.WriteString(indent + "},\n")
 		}
-	} else if format == "toml" {
+	case "toml":
 		// TOML format (for Codex engine)
 		yaml.WriteString(indent + "\n")
 		yaml.WriteString(indent + "[mcp_servers.\"web-fetch\"]\n")

--- a/pkg/workflow/if_expression_clean_test.go
+++ b/pkg/workflow/if_expression_clean_test.go
@@ -138,10 +138,7 @@ func TestJobStructStoreSeparatesExpression(t *testing.T) {
 	expression := "github.event_name == 'push'"
 
 	job := &Job{
-		Name:   "test-job",
-		If:     expression, // Should be just the expression
-		RunsOn: "runs-on: ubuntu-latest",
-		Steps:  []string{"      - name: Test\n        run: echo test\n"},
+		If: expression, // Should be just the expression
 	}
 
 	// The job struct should store just the expression

--- a/pkg/workflow/mcp-config.go
+++ b/pkg/workflow/mcp-config.go
@@ -487,7 +487,7 @@ func ValidateMCPConfigs(tools map[string]any) error {
 	for toolName, toolConfig := range tools {
 		if config, ok := toolConfig.(map[string]any); ok {
 			// Extract raw MCP configuration (without transformation)
-			mcpConfig, err := getRawMCPConfig(config, toolName)
+			mcpConfig, err := getRawMCPConfig(config)
 			if err != nil {
 				return fmt.Errorf("tool '%s' has invalid MCP configuration: %w", toolName, err)
 			}
@@ -507,7 +507,7 @@ func ValidateMCPConfigs(tools map[string]any) error {
 }
 
 // getRawMCPConfig extracts MCP configuration without any transformations for validation
-func getRawMCPConfig(toolConfig map[string]any, toolName string) (map[string]any, error) {
+func getRawMCPConfig(toolConfig map[string]any) (map[string]any, error) {
 	result := make(map[string]any)
 
 	// List of MCP fields that can be direct children of the tool config

--- a/pkg/workflow/mcp_config_test.go
+++ b/pkg/workflow/mcp_config_test.go
@@ -158,7 +158,7 @@ func TestGenerateGitHubMCPConfig(t *testing.T) {
 
 			// Call the function under test using the Claude engine
 			engine := NewClaudeEngine()
-			engine.renderGitHubClaudeMCPConfig(&yamlBuilder, tt.githubTool, true, nil)
+			engine.renderGitHubClaudeMCPConfig(&yamlBuilder, tt.githubTool, true)
 
 			result := yamlBuilder.String()
 
@@ -209,7 +209,7 @@ func TestMCPConfigurationEdgeCases(t *testing.T) {
 
 			// Call the function under test using the Claude engine
 			engine := NewClaudeEngine()
-			engine.renderGitHubClaudeMCPConfig(&yamlBuilder, tt.githubTool, tt.isLast, nil)
+			engine.renderGitHubClaudeMCPConfig(&yamlBuilder, tt.githubTool, tt.isLast)
 
 			result := yamlBuilder.String()
 

--- a/pkg/workflow/mcps.go
+++ b/pkg/workflow/mcps.go
@@ -219,7 +219,7 @@ func getPlaywrightDockerImageVersion(playwrightTool any) string {
 
 // generatePlaywrightAllowedDomains extracts domain list from Playwright tool configuration with bundle resolution
 // Uses the same domain bundle resolution as top-level network configuration, defaulting to localhost only
-func generatePlaywrightAllowedDomains(playwrightTool any, networkPermissions *NetworkPermissions) []string {
+func generatePlaywrightAllowedDomains(playwrightTool any) []string {
 	// Default to localhost with all port variations (same as Copilot agent default)
 	allowedDomains := constants.DefaultAllowedDomains
 
@@ -264,9 +264,9 @@ type PlaywrightDockerArgs struct {
 }
 
 // generatePlaywrightDockerArgs creates the common Docker arguments for Playwright MCP server
-func generatePlaywrightDockerArgs(playwrightTool any, networkPermissions *NetworkPermissions) PlaywrightDockerArgs {
+func generatePlaywrightDockerArgs(playwrightTool any) PlaywrightDockerArgs {
 	return PlaywrightDockerArgs{
 		ImageVersion:   getPlaywrightDockerImageVersion(playwrightTool),
-		AllowedDomains: generatePlaywrightAllowedDomains(playwrightTool, networkPermissions),
+		AllowedDomains: generatePlaywrightAllowedDomains(playwrightTool),
 	}
 }


### PR DESCRIPTION
## Summary

- Removed unnecessary parameters from multiple function signatures in workflow and CLI packages
- Simplified function calls by eliminating redundant arguments
- Cleaned up code to improve readability and maintainability

## Changes

- Removed `userSecretName` parameter from `addEngineSecret()` function
- Removed `verbose` parameter from `generateCacheMemorySteps()` function
- Removed `workflowData` parameter from various rendering methods in different engine implementations
- Simplified function signatures without losing core functionality