### PR TITLE
🔧 Standardize item_number across GitHub workflows

### DIFF
--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -497,20 +497,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -620,7 +612,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1609,24 +1601,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1661,9 +1639,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/audit-workflows.lock.yml
+++ b/.github/workflows/audit-workflows.lock.yml
@@ -642,20 +642,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -765,7 +757,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2001,24 +1993,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2053,9 +2031,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -962,20 +962,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -1085,7 +1077,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2165,24 +2157,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2217,9 +2195,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -3789,16 +3767,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -3847,32 +3816,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -3880,7 +3848,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -3888,7 +3856,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -3897,7 +3865,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -3914,18 +3882,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;

--- a/.github/workflows/changeset-generator.lock.yml
+++ b/.github/workflows/changeset-generator.lock.yml
@@ -933,20 +933,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -1056,7 +1048,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2113,24 +2105,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2165,9 +2143,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -468,20 +468,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -591,7 +583,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1721,24 +1713,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1773,9 +1751,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -3576,16 +3554,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -3634,32 +3603,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -3667,7 +3635,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -3675,7 +3643,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -3684,7 +3652,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -3701,18 +3669,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;

--- a/.github/workflows/cli-version-checker.lock.yml
+++ b/.github/workflows/cli-version-checker.lock.yml
@@ -604,20 +604,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -727,7 +719,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1774,24 +1766,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1826,9 +1804,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/daily-news.lock.yml
+++ b/.github/workflows/daily-news.lock.yml
@@ -499,20 +499,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -622,7 +614,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1615,24 +1607,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1667,9 +1645,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -496,20 +496,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -619,7 +611,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1481,24 +1473,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1533,9 +1511,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/duplicate-code-detector.lock.yml
+++ b/.github/workflows/duplicate-code-detector.lock.yml
@@ -513,20 +513,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -636,7 +628,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1735,24 +1727,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1787,9 +1765,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/github-mcp-tools-report.lock.yml
+++ b/.github/workflows/github-mcp-tools-report.lock.yml
@@ -604,20 +604,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -727,7 +719,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1819,24 +1811,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1871,9 +1849,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -2639,6 +2617,19 @@ jobs:
                 throw new Error(`Failed to parse GITHUB_AW_ERROR_PATTERNS as JSON: ${e instanceof Error ? e.message : String(e)}`);
               }
             }
+            function shouldSkipLine(line) {
+              const GITHUB_ACTIONS_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+/;
+              if (new RegExp(GITHUB_ACTIONS_TIMESTAMP.source + "GITHUB_AW_ERROR_PATTERNS:").test(line)) {
+                return true;
+              }
+              if (/^\s+GITHUB_AW_ERROR_PATTERNS:\s*\[/.test(line)) {
+                return true;
+              }
+              if (new RegExp(GITHUB_ACTIONS_TIMESTAMP.source + "env:").test(line)) {
+                return true;
+              }
+              return false;
+            }
             function validateErrors(logContent, patterns) {
               const lines = logContent.split("\n");
               let hasErrors = false;
@@ -2657,6 +2648,9 @@ jobs:
                 }
                 for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
                   const line = lines[lineIndex];
+                  if (shouldSkipLine(line)) {
+                    continue;
+                  }
                   let match;
                   let iterationCount = 0;
                   let lastIndex = -1;
@@ -2728,6 +2722,7 @@ jobs:
                 extractMessage,
                 getErrorPatternsFromEnv,
                 truncateString,
+                shouldSkipLine,
               };
             }
             if (typeof module === "undefined" || require.main === module) {

--- a/.github/workflows/go-pattern-detector.lock.yml
+++ b/.github/workflows/go-pattern-detector.lock.yml
@@ -611,20 +611,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -734,7 +726,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1828,24 +1820,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1880,9 +1858,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/issue-classifier.lock.yml
+++ b/.github/workflows/issue-classifier.lock.yml
@@ -820,20 +820,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -943,7 +935,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1849,24 +1841,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1901,9 +1879,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -2432,8 +2410,8 @@ jobs:
               if (process.env.GITHUB_AW_SAFE_OUTPUTS_STAGED === "true") {
                 let summaryContent = "## 🎭 Staged Mode: Add Labels Preview\n\n";
                 summaryContent += "The following labels would be added if staged mode was disabled:\n\n";
-                if (labelsItem.issue_number) {
-                  summaryContent += `**Target Issue:** #${labelsItem.issue_number}\n\n`;
+                if (labelsItem.item_number) {
+                  summaryContent += `**Target Issue:** #${labelsItem.item_number}\n\n`;
                 } else {
                   summaryContent += `**Target:** Current issue/PR\n\n`;
                 }
@@ -2474,23 +2452,23 @@ jobs:
                 core.info('Target is "triggering" but not running in issue or pull request context, skipping label addition');
                 return;
               }
-              let issueNumber;
+              let itemNumber;
               let contextType;
               if (labelsTarget === "*") {
-                if (labelsItem.issue_number) {
-                  issueNumber = typeof labelsItem.issue_number === "number" ? labelsItem.issue_number : parseInt(String(labelsItem.issue_number), 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
-                    core.setFailed(`Invalid issue number specified: ${labelsItem.issue_number}`);
+                if (labelsItem.item_number) {
+                  itemNumber = typeof labelsItem.item_number === "number" ? labelsItem.item_number : parseInt(String(labelsItem.item_number), 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
+                    core.setFailed(`Invalid item_number specified: ${labelsItem.item_number}`);
                     return;
                   }
                   contextType = "issue";
                 } else {
-                  core.setFailed('Target is "*" but no issue_number specified in labels item');
+                  core.setFailed('Target is "*" but no item_number specified in labels item');
                   return;
                 }
               } else if (labelsTarget && labelsTarget !== "triggering") {
-                issueNumber = parseInt(labelsTarget, 10);
-                if (isNaN(issueNumber) || issueNumber <= 0) {
+                itemNumber = parseInt(labelsTarget, 10);
+                if (isNaN(itemNumber) || itemNumber <= 0) {
                   core.setFailed(`Invalid issue number in target configuration: ${labelsTarget}`);
                   return;
                 }
@@ -2498,7 +2476,7 @@ jobs:
               } else {
                 if (isIssueContext) {
                   if (context.payload.issue) {
-                    issueNumber = context.payload.issue.number;
+                    itemNumber = context.payload.issue.number;
                     contextType = "issue";
                   } else {
                     core.setFailed("Issue context detected but no issue found in payload");
@@ -2506,7 +2484,7 @@ jobs:
                   }
                 } else if (isPRContext) {
                   if (context.payload.pull_request) {
-                    issueNumber = context.payload.pull_request.number;
+                    itemNumber = context.payload.pull_request.number;
                     contextType = "pull request";
                   } else {
                     core.setFailed("Pull request context detected but no pull request found in payload");
@@ -2514,7 +2492,7 @@ jobs:
                   }
                 }
               }
-              if (!issueNumber) {
+              if (!itemNumber) {
                 core.setFailed("Could not determine issue or pull request number");
                 return;
               }
@@ -2557,22 +2535,22 @@ jobs:
                   .write();
                 return;
               }
-              core.info(`Adding ${uniqueLabels.length} labels to ${contextType} #${issueNumber}: ${JSON.stringify(uniqueLabels)}`);
+              core.info(`Adding ${uniqueLabels.length} labels to ${contextType} #${itemNumber}: ${JSON.stringify(uniqueLabels)}`);
               try {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issueNumber,
+                  issue_number: itemNumber,
                   labels: uniqueLabels,
                 });
-                core.info(`Successfully added ${uniqueLabels.length} labels to ${contextType} #${issueNumber}`);
+                core.info(`Successfully added ${uniqueLabels.length} labels to ${contextType} #${itemNumber}`);
                 core.setOutput("labels_added", uniqueLabels.join("\n"));
                 const labelsListMarkdown = uniqueLabels.map(label => `- \`${label}\``).join("\n");
                 await core.summary
                   .addRaw(
                     `
             ## Label Addition
-            Successfully added ${uniqueLabels.length} label(s) to ${contextType} #${issueNumber}:
+            Successfully added ${uniqueLabels.length} label(s) to ${contextType} #${itemNumber}:
             ${labelsListMarkdown}
             `
                   )

--- a/.github/workflows/lockfile-stats.lock.yml
+++ b/.github/workflows/lockfile-stats.lock.yml
@@ -624,20 +624,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -747,7 +739,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2063,24 +2055,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2115,9 +2093,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/notion-issue-summary.lock.yml
+++ b/.github/workflows/notion-issue-summary.lock.yml
@@ -766,20 +766,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -889,7 +881,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1897,24 +1889,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1949,9 +1927,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -876,20 +876,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -999,7 +991,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2142,24 +2134,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2194,9 +2172,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -3748,16 +3726,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -3806,32 +3775,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -3839,7 +3807,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -3847,7 +3815,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -3856,7 +3824,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -3873,18 +3841,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -831,20 +831,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -954,7 +946,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2025,24 +2017,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2077,9 +2055,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -861,20 +861,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -984,7 +976,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2117,24 +2109,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2169,9 +2147,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -4065,16 +4043,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -4123,32 +4092,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -4156,7 +4124,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -4164,7 +4132,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -4173,7 +4141,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -4190,18 +4158,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;
@@ -5002,8 +4970,8 @@ jobs:
               if (process.env.GITHUB_AW_SAFE_OUTPUTS_STAGED === "true") {
                 let summaryContent = "## 🎭 Staged Mode: Add Labels Preview\n\n";
                 summaryContent += "The following labels would be added if staged mode was disabled:\n\n";
-                if (labelsItem.issue_number) {
-                  summaryContent += `**Target Issue:** #${labelsItem.issue_number}\n\n`;
+                if (labelsItem.item_number) {
+                  summaryContent += `**Target Issue:** #${labelsItem.item_number}\n\n`;
                 } else {
                   summaryContent += `**Target:** Current issue/PR\n\n`;
                 }
@@ -5044,23 +5012,23 @@ jobs:
                 core.info('Target is "triggering" but not running in issue or pull request context, skipping label addition');
                 return;
               }
-              let issueNumber;
+              let itemNumber;
               let contextType;
               if (labelsTarget === "*") {
-                if (labelsItem.issue_number) {
-                  issueNumber = typeof labelsItem.issue_number === "number" ? labelsItem.issue_number : parseInt(String(labelsItem.issue_number), 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
-                    core.setFailed(`Invalid issue number specified: ${labelsItem.issue_number}`);
+                if (labelsItem.item_number) {
+                  itemNumber = typeof labelsItem.item_number === "number" ? labelsItem.item_number : parseInt(String(labelsItem.item_number), 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
+                    core.setFailed(`Invalid item_number specified: ${labelsItem.item_number}`);
                     return;
                   }
                   contextType = "issue";
                 } else {
-                  core.setFailed('Target is "*" but no issue_number specified in labels item');
+                  core.setFailed('Target is "*" but no item_number specified in labels item');
                   return;
                 }
               } else if (labelsTarget && labelsTarget !== "triggering") {
-                issueNumber = parseInt(labelsTarget, 10);
-                if (isNaN(issueNumber) || issueNumber <= 0) {
+                itemNumber = parseInt(labelsTarget, 10);
+                if (isNaN(itemNumber) || itemNumber <= 0) {
                   core.setFailed(`Invalid issue number in target configuration: ${labelsTarget}`);
                   return;
                 }
@@ -5068,7 +5036,7 @@ jobs:
               } else {
                 if (isIssueContext) {
                   if (context.payload.issue) {
-                    issueNumber = context.payload.issue.number;
+                    itemNumber = context.payload.issue.number;
                     contextType = "issue";
                   } else {
                     core.setFailed("Issue context detected but no issue found in payload");
@@ -5076,7 +5044,7 @@ jobs:
                   }
                 } else if (isPRContext) {
                   if (context.payload.pull_request) {
-                    issueNumber = context.payload.pull_request.number;
+                    itemNumber = context.payload.pull_request.number;
                     contextType = "pull request";
                   } else {
                     core.setFailed("Pull request context detected but no pull request found in payload");
@@ -5084,7 +5052,7 @@ jobs:
                   }
                 }
               }
-              if (!issueNumber) {
+              if (!itemNumber) {
                 core.setFailed("Could not determine issue or pull request number");
                 return;
               }
@@ -5127,22 +5095,22 @@ jobs:
                   .write();
                 return;
               }
-              core.info(`Adding ${uniqueLabels.length} labels to ${contextType} #${issueNumber}: ${JSON.stringify(uniqueLabels)}`);
+              core.info(`Adding ${uniqueLabels.length} labels to ${contextType} #${itemNumber}: ${JSON.stringify(uniqueLabels)}`);
               try {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issueNumber,
+                  issue_number: itemNumber,
                   labels: uniqueLabels,
                 });
-                core.info(`Successfully added ${uniqueLabels.length} labels to ${contextType} #${issueNumber}`);
+                core.info(`Successfully added ${uniqueLabels.length} labels to ${contextType} #${itemNumber}`);
                 core.setOutput("labels_added", uniqueLabels.join("\n"));
                 const labelsListMarkdown = uniqueLabels.map(label => `- \`${label}\``).join("\n");
                 await core.summary
                   .addRaw(
                     `
             ## Label Addition
-            Successfully added ${uniqueLabels.length} label(s) to ${contextType} #${issueNumber}:
+            Successfully added ${uniqueLabels.length} label(s) to ${contextType} #${itemNumber}:
             ${labelsListMarkdown}
             `
                   )

--- a/.github/workflows/repo-tree-map.lock.yml
+++ b/.github/workflows/repo-tree-map.lock.yml
@@ -495,20 +495,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -618,7 +610,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1666,24 +1658,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1718,9 +1696,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -1142,20 +1142,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -1265,7 +1257,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2451,24 +2443,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2503,9 +2481,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -4082,16 +4060,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -4140,32 +4109,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -4173,7 +4141,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -4181,7 +4149,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -4190,7 +4158,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -4207,18 +4175,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;

--- a/.github/workflows/security-fix-pr.lock.yml
+++ b/.github/workflows/security-fix-pr.lock.yml
@@ -623,20 +623,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -746,7 +738,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1862,24 +1854,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1914,9 +1892,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -600,20 +600,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -723,7 +715,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1671,24 +1663,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1723,9 +1701,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/smoke-codex.lock.yml
+++ b/.github/workflows/smoke-codex.lock.yml
@@ -491,20 +491,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -614,7 +606,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1488,24 +1480,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1540,9 +1518,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -493,20 +493,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -616,7 +608,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1555,24 +1547,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1607,9 +1585,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/smoke-genaiscript.lock.yml
+++ b/.github/workflows/smoke-genaiscript.lock.yml
@@ -496,20 +496,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -619,7 +611,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1485,24 +1477,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1537,9 +1515,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -639,20 +639,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -762,7 +754,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1945,24 +1937,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1997,9 +1975,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -3280,16 +3258,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -3338,32 +3307,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -3371,7 +3339,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -3379,7 +3347,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -3388,7 +3356,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -3405,18 +3373,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -704,20 +704,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -827,7 +819,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -1888,24 +1880,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -1940,9 +1918,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));

--- a/.github/workflows/unbloat-docs.lock.yml
+++ b/.github/workflows/unbloat-docs.lock.yml
@@ -812,20 +812,12 @@ jobs:
                 description: "Add a comment to a GitHub issue, pull request, or discussion",
                 inputSchema: {
                   type: "object",
-                  required: ["body"],
+                  required: ["body", "item_number"],
                   properties: {
                     body: { type: "string", description: "Comment body/content" },
-                    issue_number: {
+                    item_number: {
                       type: "number",
-                      description: "Issue number (optional for current context)",
-                    },
-                    pull_number: {
-                      type: "number",
-                      description: "Pull request number (optional, alternative to issue_number)",
-                    },
-                    discussion_number: {
-                      type: "number",
-                      description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+                      description: "Issue, pull request or discussion number",
                     },
                   },
                   additionalProperties: false,
@@ -935,7 +927,7 @@ jobs:
                       items: { type: "string" },
                       description: "Labels to add",
                     },
-                    issue_number: {
+                    item_number: {
                       type: "number",
                       description: "Issue or PR number (optional for current context)",
                     },
@@ -2189,24 +2181,10 @@ jobs:
                         errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
                         continue;
                       }
-                      if (item.issue_number !== undefined) {
-                        const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-                        if (!issueNumValidation.isValid) {
-                          if (issueNumValidation.error) errors.push(issueNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.discussion_number !== undefined) {
-                        const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-                        if (!discussionNumValidation.isValid) {
-                          if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-                          continue;
-                        }
-                      }
-                      if (item.pull_number !== undefined) {
-                        const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-                        if (!pullNumValidation.isValid) {
-                          if (pullNumValidation.error) errors.push(pullNumValidation.error);
+                      if (item.item_number !== undefined) {
+                        const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+                        if (!itemNumberValidation.isValid) {
+                          if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
                           continue;
                         }
                       }
@@ -2241,9 +2219,9 @@ jobs:
                         errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
                         continue;
                       }
-                      const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-                      if (!labelsIssueNumValidation.isValid) {
-                        if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+                      const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+                      if (!labelsItemNumberValidation.isValid) {
+                        if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
                         continue;
                       }
                       item.labels = item.labels.map(label => sanitizeContent(label));
@@ -3517,16 +3495,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                if (item.issue_number !== undefined) {
-                  return item.issue_number;
-                }
-                if (item.pull_number !== undefined) {
-                  return item.pull_number;
-                }
-                if (item.discussion_number !== undefined) {
-                  return item.discussion_number;
-                }
-                return undefined;
+                return item.number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";
@@ -3575,32 +3544,31 @@ jobs:
               for (let i = 0; i < commentItems.length; i++) {
                 const commentItem = commentItems[i];
                 core.info(`Processing add-comment item ${i + 1}/${commentItems.length}: bodyLength=${commentItem.body.length}`);
-                let issueNumber;
+                let itemNumber;
                 let commentEndpoint;
                 if (commentTarget === "*") {
                   const targetNumber = getTargetNumber(commentItem);
                   if (targetNumber) {
-                    issueNumber = parseInt(targetNumber, 10);
-                    if (isNaN(issueNumber) || issueNumber <= 0) {
+                    itemNumber = parseInt(targetNumber, 10);
+                    if (isNaN(itemNumber) || itemNumber <= 0) {
                       core.info(`Invalid target number specified: ${targetNumber}`);
                       continue;
                     }
                     commentEndpoint = isDiscussion ? "discussions" : "issues";
                   } else {
-                    const expectedFields = isDiscussion ? "discussion_number" : "issue_number or pull_number";
-                    core.info(`Target is "*" but no ${expectedFields} specified in comment item`);
+                    core.info(`Target is "*" but no number specified in comment item`);
                     continue;
                   }
                 } else if (commentTarget && commentTarget !== "triggering") {
-                  issueNumber = parseInt(commentTarget, 10);
-                  if (isNaN(issueNumber) || issueNumber <= 0) {
+                  itemNumber = parseInt(commentTarget, 10);
+                  if (isNaN(itemNumber) || itemNumber <= 0) {
                     core.info(`Invalid target number in target configuration: ${commentTarget}`);
                     continue;
                   }
                   commentEndpoint = isDiscussion ? "discussions" : "issues";
                 } else {
                   if (isIssueContext) {
-                    issueNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.issue?.number || context.payload.pull_request?.number || context.payload.discussion?.number;
                     if (context.payload.issue) {
                       commentEndpoint = "issues";
                     } else {
@@ -3608,7 +3576,7 @@ jobs:
                       continue;
                     }
                   } else if (isPRContext) {
-                    issueNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
+                    itemNumber = context.payload.pull_request?.number || context.payload.issue?.number || context.payload.discussion?.number;
                     if (context.payload.pull_request) {
                       commentEndpoint = "issues"; 
                     } else {
@@ -3616,7 +3584,7 @@ jobs:
                       continue;
                     }
                   } else if (isDiscussionContext) {
-                    issueNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+                    itemNumber = context.payload.discussion?.number || context.payload.issue?.number || context.payload.pull_request?.number;
                     if (context.payload.discussion) {
                       commentEndpoint = "discussions"; 
                     } else {
@@ -3625,7 +3593,7 @@ jobs:
                     }
                   }
                 }
-                if (!issueNumber) {
+                if (!itemNumber) {
                   core.info("Could not determine issue, pull request, or discussion number");
                   continue;
                 }
@@ -3642,18 +3610,18 @@ jobs:
                 try {
                   let comment;
                   if (isDiscussion) {
-                    core.info(`Creating comment on discussion #${issueNumber}`);
+                    core.info(`Creating comment on discussion #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
-                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, issueNumber, body);
+                    comment = await commentOnDiscussion(github, context.repo.owner, context.repo.repo, itemNumber, body);
                     core.info("Created discussion comment #" + comment.id + ": " + comment.html_url);
                     comment.discussion_url = comment.discussion_url;
                   } else {
-                    core.info(`Creating comment on ${commentEndpoint} #${issueNumber}`);
+                    core.info(`Creating comment on ${commentEndpoint} #${itemNumber}`);
                     core.info(`Comment content length: ${body.length}`);
                     const { data: restComment } = await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      issue_number: issueNumber,
+                      issue_number: itemNumber,
                       body: body,
                     });
                     comment = restComment;

--- a/pkg/workflow/js/add_labels.cjs
+++ b/pkg/workflow/js/add_labels.cjs
@@ -43,8 +43,8 @@ async function main() {
   if (process.env.GITHUB_AW_SAFE_OUTPUTS_STAGED === "true") {
     let summaryContent = "## 🎭 Staged Mode: Add Labels Preview\n\n";
     summaryContent += "The following labels would be added if staged mode was disabled:\n\n";
-    if (labelsItem.issue_number) {
-      summaryContent += `**Target Issue:** #${labelsItem.issue_number}\n\n`;
+    if (labelsItem.item_number) {
+      summaryContent += `**Target Issue:** #${labelsItem.item_number}\n\n`;
     } else {
       summaryContent += `**Target:** Current issue/PR\n\n`;
     }
@@ -85,23 +85,23 @@ async function main() {
     core.info('Target is "triggering" but not running in issue or pull request context, skipping label addition');
     return;
   }
-  let issueNumber;
+  let itemNumber;
   let contextType;
   if (labelsTarget === "*") {
-    if (labelsItem.issue_number) {
-      issueNumber = typeof labelsItem.issue_number === "number" ? labelsItem.issue_number : parseInt(String(labelsItem.issue_number), 10);
-      if (isNaN(issueNumber) || issueNumber <= 0) {
-        core.setFailed(`Invalid issue number specified: ${labelsItem.issue_number}`);
+    if (labelsItem.item_number) {
+      itemNumber = typeof labelsItem.item_number === "number" ? labelsItem.item_number : parseInt(String(labelsItem.item_number), 10);
+      if (isNaN(itemNumber) || itemNumber <= 0) {
+        core.setFailed(`Invalid item_number specified: ${labelsItem.item_number}`);
         return;
       }
       contextType = "issue";
     } else {
-      core.setFailed('Target is "*" but no issue_number specified in labels item');
+      core.setFailed('Target is "*" but no item_number specified in labels item');
       return;
     }
   } else if (labelsTarget && labelsTarget !== "triggering") {
-    issueNumber = parseInt(labelsTarget, 10);
-    if (isNaN(issueNumber) || issueNumber <= 0) {
+    itemNumber = parseInt(labelsTarget, 10);
+    if (isNaN(itemNumber) || itemNumber <= 0) {
       core.setFailed(`Invalid issue number in target configuration: ${labelsTarget}`);
       return;
     }
@@ -109,7 +109,7 @@ async function main() {
   } else {
     if (isIssueContext) {
       if (context.payload.issue) {
-        issueNumber = context.payload.issue.number;
+        itemNumber = context.payload.issue.number;
         contextType = "issue";
       } else {
         core.setFailed("Issue context detected but no issue found in payload");
@@ -117,7 +117,7 @@ async function main() {
       }
     } else if (isPRContext) {
       if (context.payload.pull_request) {
-        issueNumber = context.payload.pull_request.number;
+        itemNumber = context.payload.pull_request.number;
         contextType = "pull request";
       } else {
         core.setFailed("Pull request context detected but no pull request found in payload");
@@ -125,7 +125,7 @@ async function main() {
       }
     }
   }
-  if (!issueNumber) {
+  if (!itemNumber) {
     core.setFailed("Could not determine issue or pull request number");
     return;
   }
@@ -169,15 +169,15 @@ No labels were added (no valid labels found in agent output).
       .write();
     return;
   }
-  core.info(`Adding ${uniqueLabels.length} labels to ${contextType} #${issueNumber}: ${JSON.stringify(uniqueLabels)}`);
+  core.info(`Adding ${uniqueLabels.length} labels to ${contextType} #${itemNumber}: ${JSON.stringify(uniqueLabels)}`);
   try {
     await github.rest.issues.addLabels({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      issue_number: issueNumber,
+      issue_number: itemNumber,
       labels: uniqueLabels,
     });
-    core.info(`Successfully added ${uniqueLabels.length} labels to ${contextType} #${issueNumber}`);
+    core.info(`Successfully added ${uniqueLabels.length} labels to ${contextType} #${itemNumber}`);
     core.setOutput("labels_added", uniqueLabels.join("\n"));
     const labelsListMarkdown = uniqueLabels.map(label => `- \`${label}\``).join("\n");
     await core.summary
@@ -185,7 +185,7 @@ No labels were added (no valid labels found in agent output).
         `
 ## Label Addition
 
-Successfully added ${uniqueLabels.length} label(s) to ${contextType} #${issueNumber}:
+Successfully added ${uniqueLabels.length} label(s) to ${contextType} #${itemNumber}:
 
 ${labelsListMarkdown}
 `

--- a/pkg/workflow/js/add_labels.test.cjs
+++ b/pkg/workflow/js/add_labels.test.cjs
@@ -975,13 +975,13 @@ describe("add_labels.cjs", () => {
       });
     });
 
-    it("should use issue_number from labels item when target is '*'", async () => {
+    it("should use item_number from labels item when target is '*'", async () => {
       process.env.GITHUB_AW_AGENT_OUTPUT = JSON.stringify({
         items: [
           {
             type: "add-labels",
             labels: ["documentation"],
-            issue_number: 555,
+            item_number: 555,
           },
         ],
       });
@@ -1005,7 +1005,7 @@ describe("add_labels.cjs", () => {
       });
     });
 
-    it("should fail when target is '*' but no issue_number in labels item", async () => {
+    it("should fail when target is '*' but no item_number in labels item", async () => {
       process.env.GITHUB_AW_AGENT_OUTPUT = JSON.stringify({
         items: [
           {
@@ -1019,7 +1019,7 @@ describe("add_labels.cjs", () => {
       // Execute the script
       await eval(`(async () => { ${addLabelsScript} })()`);
 
-      expect(mockCore.setFailed).toHaveBeenCalledWith('Target is "*" but no issue_number specified in labels item');
+      expect(mockCore.setFailed).toHaveBeenCalledWith('Target is "*" but no item_number specified in labels item');
       expect(mockGithub.rest.issues.addLabels).not.toHaveBeenCalled();
     });
 
@@ -1047,7 +1047,7 @@ describe("add_labels.cjs", () => {
           {
             type: "add-labels",
             labels: ["bug"],
-            issue_number: -5,
+            item_number: -5,
           },
         ],
       });
@@ -1056,7 +1056,7 @@ describe("add_labels.cjs", () => {
       // Execute the script
       await eval(`(async () => { ${addLabelsScript} })()`);
 
-      expect(mockCore.setFailed).toHaveBeenCalledWith("Invalid issue number specified: -5");
+      expect(mockCore.setFailed).toHaveBeenCalledWith("Invalid item_number specified: -5");
       expect(mockGithub.rest.issues.addLabels).not.toHaveBeenCalled();
     });
   });

--- a/pkg/workflow/js/collect_ndjson_output.cjs
+++ b/pkg/workflow/js/collect_ndjson_output.cjs
@@ -437,25 +437,11 @@ async function main() {
             errors.push(`Line ${i + 1}: add_comment requires a 'body' string field`);
             continue;
           }
-          // Validate issue_number, discussion_number, or pull_number (all are optional but treated as synonyms)
-          if (item.issue_number !== undefined) {
-            const issueNumValidation = validateIssueOrPRNumber(item.issue_number, "add_comment 'issue_number'", i + 1);
-            if (!issueNumValidation.isValid) {
-              if (issueNumValidation.error) errors.push(issueNumValidation.error);
-              continue;
-            }
-          }
-          if (item.discussion_number !== undefined) {
-            const discussionNumValidation = validateIssueOrPRNumber(item.discussion_number, "add_comment 'discussion_number'", i + 1);
-            if (!discussionNumValidation.isValid) {
-              if (discussionNumValidation.error) errors.push(discussionNumValidation.error);
-              continue;
-            }
-          }
-          if (item.pull_number !== undefined) {
-            const pullNumValidation = validateIssueOrPRNumber(item.pull_number, "add_comment 'pull_number'", i + 1);
-            if (!pullNumValidation.isValid) {
-              if (pullNumValidation.error) errors.push(pullNumValidation.error);
+          // Validate number
+          if (item.item_number !== undefined) {
+            const itemNumberValidation = validateIssueOrPRNumber(item.item_number, "add_comment 'item_number'", i + 1);
+            if (!itemNumberValidation.isValid) {
+              if (itemNumberValidation.error) errors.push(itemNumberValidation.error);
               continue;
             }
           }
@@ -490,9 +476,9 @@ async function main() {
             errors.push(`Line ${i + 1}: add_labels labels array must contain only strings`);
             continue;
           }
-          const labelsIssueNumValidation = validateIssueOrPRNumber(item.issue_number, "add-labels 'issue_number'", i + 1);
-          if (!labelsIssueNumValidation.isValid) {
-            if (labelsIssueNumValidation.error) errors.push(labelsIssueNumValidation.error);
+          const labelsItemNumberValidation = validateIssueOrPRNumber(item.item_number, "add-labels 'item_number'", i + 1);
+          if (!labelsItemNumberValidation.isValid) {
+            if (labelsItemNumberValidation.error) errors.push(labelsItemNumberValidation.error);
             continue;
           }
           item.labels = item.labels.map(label => sanitizeContent(label));

--- a/pkg/workflow/js/safe_outputs_mcp_server.cjs
+++ b/pkg/workflow/js/safe_outputs_mcp_server.cjs
@@ -370,20 +370,12 @@ const ALL_TOOLS = [
     description: "Add a comment to a GitHub issue, pull request, or discussion",
     inputSchema: {
       type: "object",
-      required: ["body"],
+      required: ["body", "item_number"],
       properties: {
         body: { type: "string", description: "Comment body/content" },
-        issue_number: {
+        item_number: {
           type: "number",
-          description: "Issue number (optional for current context)",
-        },
-        pull_number: {
-          type: "number",
-          description: "Pull request number (optional, alternative to issue_number)",
-        },
-        discussion_number: {
-          type: "number",
-          description: "Discussion number for discussion comments (optional, alternative to issue_number)",
+          description: "Issue, pull request or discussion number",
         },
       },
       additionalProperties: false,
@@ -493,7 +485,7 @@ const ALL_TOOLS = [
           items: { type: "string" },
           description: "Labels to add",
         },
-        issue_number: {
+        item_number: {
           type: "number",
           description: "Issue or PR number (optional for current context)",
         },

--- a/pkg/workflow/safe_outputs_mcp_server_test.go
+++ b/pkg/workflow/safe_outputs_mcp_server_test.go
@@ -301,7 +301,8 @@ func TestSafeOutputsMCPServer_MultipleTools(t *testing.T) {
 		{
 			name: "add-comment",
 			args: map[string]any{
-				"body": "This is a comment",
+				"body":        "This is a comment",
+				"item_number": 1,
 			},
 			expectedType: "add-comment",
 		},


### PR DESCRIPTION
## Summary

- Replaced multiple number fields (`issue_number`, `pull_number`, `discussion_number`) with a single `item_number` field
- Updated validation and processing logic to use the new unified `item_number`
- Simplified target number retrieval in workflows

## Changes

- Modified multiple GitHub workflow files to use `item_number` instead of separate number fields
- Updated validation functions to check `item_number`
- Adjusted comment and label addition logic to work with the new field
- Updated related JavaScript and test files to reflect the changes