### PR TITLE
🐛 Fix item number retrieval in workflows

### DIFF
--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -3773,7 +3773,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -3560,7 +3560,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -3732,7 +3732,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -4049,7 +4049,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -4066,7 +4066,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -3264,7 +3264,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/.github/workflows/unbloat-docs.lock.yml
+++ b/.github/workflows/unbloat-docs.lock.yml
@@ -3501,7 +3501,7 @@ jobs:
                 }
               }
               function getTargetNumber(item) {
-                return item.number;
+                return item.item_number;
               }
               if (isStaged) {
                 let summaryContent = "## 🎭 Staged Mode: Add Comments Preview\n\n";

--- a/pkg/workflow/js/add_comment.cjs
+++ b/pkg/workflow/js/add_comment.cjs
@@ -137,7 +137,7 @@ async function main() {
 
   // Helper function to get the target number (issue, discussion, or pull request)
   function getTargetNumber(item) {
-    return item.number;
+    return item.item_number;
   }
 
   // If in staged mode, emit step summary instead of creating comments


### PR DESCRIPTION
## Summary

- Updated multiple GitHub workflow files to use `item_number` instead of `number` when retrieving item identifiers
- Modified `getTargetNumber()` function in workflows and `add_comment.cjs` to correctly access item numbers
- Ensures consistent item number retrieval across different workflows

## Details

The changes replace `item.number` with `item.item_number` in several workflow files, including:
- `brave.lock.yml`
- `ci-doctor.lock.yml`
- `pdf-summary.lock.yml`
- `poem-bot.lock.yml`
- `scout.lock.yml`
- `technical-doc-writer.lock.yml`
- `unbloat-docs.lock.yml`

This modification fixes potential issues with item number identification in various workflow scripts.