### PR TITLE
[tidy] Fix code formatting in compiler.go

### DIFF
--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -2417,6 +2417,7 @@ func (c *Compiler) buildMainJob(data *WorkflowData, activationJobCreated bool) (
 
 	return job, nil
 }
+
 // generateMainJobSteps generates the steps section for the main job
 func (c *Compiler) generateMainJobSteps(yaml *strings.Builder, data *WorkflowData) {
 	// Determine if we need to add a checkout step


### PR DESCRIPTION
## Summary

This PR addresses code formatting issues identified by running `make fmt` on the codebase.

## Changes Made

- **Fixed formatting in `pkg/workflow/compiler.go`**: Added a blank line between functions to comply with Go formatting standards

## Validation

✅ All formatting checks passed (`make fmt`)
✅ All linting checks passed (`make lint`)  
✅ All workflow files recompiled successfully (`make recompile`)
✅ All tests passed (`make test`)

## Details

The only change was adding a single blank line between the `buildMainJob` and `generateMainJobSteps` functions in `pkg/workflow/compiler.go`. This ensures consistent spacing between function definitions as per Go best practices.


> AI generated by [Tidy](https://github.com/githubnext/gh-aw/actions/runs/18610609509)