### PR TITLE
[docs] Update documentation for features from 2025-10-19

### DIFF
--- a/docs/src/content/docs/guides/custom-safe-outputs.md
+++ b/docs/src/content/docs/guides/custom-safe-outputs.md
@@ -410,3 +410,42 @@ core.warning('Warning message');
 core.error('Error message');
 core.setFailed('Failure message that stops the job');
 ```
+
+## Example: MCP Diagnostic Reporting
+
+The `mcp-debug` shared workflow demonstrates a custom safe-output that posts diagnostic findings to pull requests:
+
+```yaml
+imports:
+  - shared/mcp-debug.md
+```
+
+This provides the `report_diagnostics_to_pull_request` safe-job that:
+- Accepts a `message` parameter with diagnostic information
+- Automatically finds the pull request associated with the current branch
+- Posts the diagnostic message as a PR comment
+- Handles cases where no PR exists gracefully
+
+**Usage in workflow:**
+```aw wrap
+---
+on:
+  pull_request:
+    types: [opened, synchronize]
+imports:
+  - shared/mcp-debug.md
+---
+
+# MCP Troubleshooting Agent
+
+Debug MCP server issues and report findings.
+Use the report_diagnostics_to_pull_request safe-job to post your diagnostic findings to the pull request.
+```
+
+This pattern enables workflows to report complex diagnostic information directly to pull requests without requiring write permissions in the main agentic job.
+
+## Related Documentation
+
+- [Safe Outputs](/gh-aw/reference/safe-outputs/) - Built-in safe output types
+- [MCPs](/gh-aw/guides/mcps/) - Model Context Protocol setup
+- [Frontmatter](/gh-aw/reference/frontmatter/) - All configuration options

--- a/docs/src/content/docs/guides/mcps.md
+++ b/docs/src/content/docs/guides/mcps.md
@@ -286,6 +286,36 @@ mcp-servers:
 
 Enforcement uses a [Squid proxy](https://www.squid-cache.org/) configured with `HTTP_PROXY`/`HTTPS_PROXY` and iptables rules to block non-allowed domains. Only applies to containerized stdio servers (not HTTP or non-container stdio).
 
+## Available Shared MCP Configurations
+
+The gh-aw repository includes pre-configured shared MCP server workflows in `.github/workflows/shared/mcp/`:
+
+### Jupyter Notebook Integration
+
+Execute code in Jupyter notebooks and visualize data:
+
+```yaml
+imports:
+  - shared/mcp/jupyter.md
+```
+
+Provides tools for executing cells, managing notebooks, and retrieving outputs. Includes self-hosted JupyterLab service with Docker services support.
+
+### Drain3 Log Analysis
+
+Mine log patterns and extract structured templates from unstructured log files:
+
+```yaml
+imports:
+  - shared/mcp/drain3.md
+```
+
+Provides 8 tools including `index_file`, `list_clusters`, `find_anomalies`, `compare_runs`, and `search_pattern` for log template mining and pattern analysis.
+
+### Other Available Servers
+
+Additional shared MCP configurations include: AST-Grep, Azure, Brave Search, Context7, DataDog, DeepWiki, Fabric RTI, MarkItDown, Microsoft Docs, Notion, Sentry, Serena, Server Memory, Slack, and Tavily. Browse `.github/workflows/shared/mcp/` for complete list with documentation.
+
 ## Debugging and Troubleshooting
 
 Use CLI commands to inspect and debug MCP configurations:
@@ -301,6 +331,15 @@ gh aw mcp list-tools notion my-workflow
 # Launch MCP inspector
 gh aw mcp inspect my-workflow --inspector
 ```
+
+For MCP server troubleshooting, import the mcp-debug shared workflow:
+
+```yaml
+imports:
+  - shared/mcp-debug.md
+```
+
+This provides diagnostic tools and the `report_diagnostics_to_pull_request` custom safe-output for posting diagnostic findings to pull requests.
 
 **Common issues**:
 - **Connection failures**: Verify configuration syntax, environment variables, and network connectivity

--- a/docs/src/content/docs/reference/imports.md
+++ b/docs/src/content/docs/reference/imports.md
@@ -48,9 +48,10 @@ Workflow instructions here...
 ## Frontmatter Merging
 
 When importing files, frontmatter fields are merged with the main workflow:
-- **Only `tools:` and `mcp-servers:` frontmatter** is allowed in imported files, other entries give a warning.
+- **Only `tools:`, `mcp-servers:`, and `services:` frontmatter** is allowed in imported files, other entries give a warning.
 - **Tool merging**: `allowed:` tools are merged across all imported files
 - **MCP server merging**: MCP servers defined in imported files are merged with the main workflow
+- **Services merging**: Docker services defined in imported files are merged with the main workflow
 
 ### Example MCP Server Merging
 
@@ -75,6 +76,39 @@ mcp-servers:
 ```
 
 **Result**: Final workflow has the Tavily MCP server configured and available to the AI engine.
+
+### Example Services Merging
+
+```aw wrap
+# Base workflow
+---
+on: issues
+engine: copilot
+imports:
+  - shared/mcp/jupyter.md
+---
+```
+
+```aw wrap
+# shared/mcp/jupyter.md
+---
+services:
+  jupyter:
+    image: jupyter/base-notebook:latest
+    ports:
+      - 8888:8888
+    env:
+      JUPYTER_TOKEN: ${{ github.run_id }}
+
+mcp-servers:
+  jupyter:
+    type: http
+    url: "http://jupyter:3000"
+    allowed: ["*"]
+---
+```
+
+**Result**: Final workflow has the Jupyter service and MCP server configured with shared networking.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Documentation Updates - 2025-10-19

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

#### 1. Services Support in Imports (from #1945)
- **File**: `docs/src/content/docs/reference/imports.md`
- **Changes**: 
  - Updated frontmatter merging section to include `services:` field
  - Added example demonstrating services merging with Jupyter MCP server
  - Shows how Docker services can be imported alongside MCP servers

#### 2. New Shared MCP Workflows (from #1949, #1945)
- **File**: `docs/src/content/docs/guides/mcps.md`
- **Changes**:
  - Added "Available Shared MCP Configurations" section
  - Documented Jupyter notebook integration (execute cells, manage notebooks)
  - Documented Drain3 log analysis (8 tools for log pattern mining)
  - Listed other available shared MCP servers
  - Added mcp-debug workflow mention in troubleshooting section

#### 3. Custom Safe-Output Example (from #1963)
- **File**: `docs/src/content/docs/guides/custom-safe-outputs.md`
- **Changes**:
  - Added "Example: MCP Diagnostic Reporting" section
  - Documented `report_diagnostics_to_pull_request` safe-job
  - Provided usage example for posting diagnostic findings to PRs
  - Added Related Documentation section

### Merged PRs Referenced

- #1963 - Add five new analysis tools to drain3 shared agentic workflow and PR diagnostic reporting
- #1949 - Add drain3 shared agentic workflow with error handling, diagnostics, and MCP debugging support
- #1945 - Add Jupyter notebook MCP server integration with self-hosted JupyterLab service and services import support

### Documentation Guidelines

All changes follow the documentation instructions in `.github/instructions/documentation.instructions.md`:
- Used neutral, technical tone
- Followed Diátaxis framework (Reference and How-to Guide categories)
- Used proper markdown headings (not bold text)
- Used `aw` language tag for agentic workflow code samples
- Kept components minimal, preferring standard markdown

### Notes

The features are already well-documented inline in their respective shared workflow files (`.github/workflows/shared/mcp/drain3.md`, `.github/workflows/shared/mcp/jupyter.md`, `.github/workflows/shared/mcp-debug.md`). This PR adds user-facing documentation in the main docs site to help users discover and understand these features.


> AI generated by [Daily Documentation Updater](https://github.com/githubnext/gh-aw/actions/runs/18628199959)