### PR TITLE
[tidy] Format code: align struct fields in permissions_test.go

### DIFF
--- a/pkg/workflow/permissions_test.go
+++ b/pkg/workflow/permissions_test.go
@@ -656,16 +656,16 @@ func TestPermissionsMerge(t *testing.T) {
 			},
 		},
 		{
-			name:  "merge two maps - multiple scopes with conflicts",
+			name: "merge two maps - multiple scopes with conflicts",
 			base: NewPermissionsFromMap(map[PermissionScope]PermissionLevel{
 				PermissionContents:     PermissionRead,
 				PermissionIssues:       PermissionWrite,
 				PermissionPullRequests: PermissionRead,
 			}),
 			merge: NewPermissionsFromMap(map[PermissionScope]PermissionLevel{
-				PermissionContents:     PermissionWrite,
-				PermissionIssues:       PermissionRead,
-				PermissionDiscussions:  PermissionWrite,
+				PermissionContents:    PermissionWrite,
+				PermissionIssues:      PermissionRead,
+				PermissionDiscussions: PermissionWrite,
 			}),
 			want: map[PermissionScope]PermissionLevel{
 				PermissionContents:     PermissionWrite, // write wins
@@ -695,13 +695,13 @@ func TestPermissionsMerge(t *testing.T) {
 		{
 			name: "merge two maps - all permission scopes",
 			base: NewPermissionsFromMap(map[PermissionScope]PermissionLevel{
-				PermissionActions:        PermissionRead,
-				PermissionChecks:         PermissionRead,
-				PermissionContents:       PermissionRead,
-				PermissionDeployments:    PermissionRead,
-				PermissionDiscussions:    PermissionRead,
-				PermissionIssues:         PermissionRead,
-				PermissionPackages:       PermissionRead,
+				PermissionActions:     PermissionRead,
+				PermissionChecks:      PermissionRead,
+				PermissionContents:    PermissionRead,
+				PermissionDeployments: PermissionRead,
+				PermissionDiscussions: PermissionRead,
+				PermissionIssues:      PermissionRead,
+				PermissionPackages:    PermissionRead,
 			}),
 			merge: NewPermissionsFromMap(map[PermissionScope]PermissionLevel{
 				PermissionPages:          PermissionWrite,


### PR DESCRIPTION
## Summary

This PR addresses code formatting issues identified by `make fmt`.

## Changes Made

- **Code Formatting**: Ran `make fmt` to format all Go code according to project standards
- **Struct Field Alignment**: Fixed alignment of struct fields in `pkg/workflow/permissions_test.go` for better readability

## Details

The Go formatter (`gofmt`) automatically aligned struct field declarations in test cases to improve code consistency and readability. Specifically:

- Aligned field names and values in map literals within test cases
- Improved visual consistency across permission scope declarations
- No functional changes - purely cosmetic formatting improvements

## Validation

- ✅ `make fmt` - Code formatting completed successfully
- ✅ `make lint` - No linting issues found
- ✅ `make recompile` - All workflow files recompiled successfully
- ✅ `make test` - All tests passing (100% pass rate)

## Labels

This PR should be labeled with: `automation`


> AI generated by [Tidy](https://github.com/githubnext/gh-aw/actions/runs/18634009139)