### PR TITLE
[tidy] Fix linting issues in notify_comment_error.test.cjs

### DIFF
--- a/pkg/workflow/js/notify_comment_error.test.cjs
+++ b/pkg/workflow/js/notify_comment_error.test.cjs
@@ -100,7 +100,7 @@ describe("notify_comment_error.cjs", () => {
 
   afterEach(() => {
     // Restore original environment
-    Object.keys(originalEnv).forEach((key) => {
+    Object.keys(originalEnv).forEach(key => {
       if (originalEnv[key] !== undefined) {
         process.env[key] = originalEnv[key];
       } else {
@@ -154,8 +154,7 @@ describe("notify_comment_error.cjs", () => {
           owner: "testowner",
           repo: "testrepo",
           comment_id: 123456,
-          body: expect.stringContaining("✅"),
-          body: expect.stringContaining("completed successfully"),
+          body: expect.stringMatching(/✅.*completed successfully/s),
         })
       );
       expect(mockCore.info).toHaveBeenCalledWith("Successfully updated comment");
@@ -175,9 +174,7 @@ describe("notify_comment_error.cjs", () => {
           owner: "testowner",
           repo: "testrepo",
           comment_id: 123456,
-          body: expect.stringContaining("❌"),
-          body: expect.stringContaining("failed"),
-          body: expect.stringContaining("wasn't able to produce a result"),
+          body: expect.stringMatching(/❌.*failed.*wasn't able to produce a result/s),
         })
       );
       expect(mockCore.info).toHaveBeenCalledWith("Successfully updated comment");
@@ -194,8 +191,7 @@ describe("notify_comment_error.cjs", () => {
       expect(mockGithub.request).toHaveBeenCalledWith(
         "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
         expect.objectContaining({
-          body: expect.stringContaining("🚫"),
-          body: expect.stringContaining("was cancelled"),
+          body: expect.stringMatching(/🚫.*was cancelled/s),
         })
       );
     });
@@ -211,8 +207,7 @@ describe("notify_comment_error.cjs", () => {
       expect(mockGithub.request).toHaveBeenCalledWith(
         "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
         expect.objectContaining({
-          body: expect.stringContaining("⏱️"),
-          body: expect.stringContaining("timed out"),
+          body: expect.stringMatching(/⏱️.*timed out/s),
         })
       );
     });
@@ -228,8 +223,7 @@ describe("notify_comment_error.cjs", () => {
       expect(mockGithub.request).toHaveBeenCalledWith(
         "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
         expect.objectContaining({
-          body: expect.stringContaining("⏭️"),
-          body: expect.stringContaining("was skipped"),
+          body: expect.stringMatching(/⏭️.*was skipped/s),
         })
       );
     });
@@ -266,8 +260,7 @@ describe("notify_comment_error.cjs", () => {
         expect.stringContaining("updateDiscussionComment"),
         expect.objectContaining({
           commentId: "DC_kwDOABCDEF4ABCDEF",
-          body: expect.stringContaining("✅"),
-          body: expect.stringContaining("completed successfully"),
+          body: expect.stringMatching(/✅.*completed successfully/s),
         })
       );
       expect(mockCore.info).toHaveBeenCalledWith("Successfully updated discussion comment");
@@ -285,8 +278,7 @@ describe("notify_comment_error.cjs", () => {
         expect.stringContaining("updateDiscussionComment"),
         expect.objectContaining({
           commentId: "DC_kwDOABCDEF4ABCDEF",
-          body: expect.stringContaining("❌"),
-          body: expect.stringContaining("failed"),
+          body: expect.stringMatching(/❌.*failed/s),
         })
       );
     });


### PR DESCRIPTION
## Summary

Fixed JavaScript linting issues in the test file `notify_comment_error.test.cjs` that were preventing the codebase from passing linting checks.

## Changes Made

### Fixed Duplicate Object Keys
- **Issue**: Multiple test cases had duplicate `body:` keys in `expect.objectContaining()` calls, which is invalid JavaScript syntax
- **Solution**: Converted to use `expect.stringMatching()` with regex patterns to match multiple string patterns in a single assertion

### Specific Changes
- Updated 7 test assertions from duplicate keys to regex patterns:
  - Success message: `✅.*completed successfully`
  - Failure message: `❌.*failed.*wasn't able to produce a result`
  - Cancelled message: `🚫.*was cancelled`
  - Timeout message: `⏱️.*timed out`
  - Skipped message: `⏭️.*was skipped`
  - GraphQL success: `✅.*completed successfully`
  - GraphQL failure: `❌.*failed`

## Validation

- ✅ `make fmt` - All code properly formatted
- ✅ `make lint` - All linting checks passing
- ✅ `make test` - All tests passing (including the modified test file)
- ✅ `make recompile` - All workflows recompiled successfully

## Before & After

**Before (Invalid - Duplicate Keys):**
```javascript
expect.objectContaining({
  owner: "testowner",
  repo: "testrepo",
  comment_id: 123456,
  body: expect.stringContaining("✅"),
  body: expect.stringContaining("completed successfully"), // Duplicate key!
})
```

**After (Valid - Regex Pattern):**
```javascript
expect.objectContaining({
  owner: "testowner",
  repo: "testrepo",
  comment_id: 123456,
  body: expect.stringMatching(/✅.*completed successfully/s),
})
```

## Impact

This change ensures the codebase passes all linting checks and maintains code quality standards. The test functionality remains identical - the assertions still verify the same behavior, just with cleaner syntax.


> AI generated by [Tidy](https://github.com/githubnext/gh-aw/actions/runs/18650905167)