### PR TITLE
🔧 Refactor GitHub Actions condition syntax for !cancelled()

### DIFF
--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -3329,7 +3329,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3805,7 +3805,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/audit-workflows.lock.yml
+++ b/.github/workflows/audit-workflows.lock.yml
@@ -3402,7 +3402,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3888,7 +3888,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/blog-auditor.lock.yml
+++ b/.github/workflows/blog-auditor.lock.yml
@@ -3314,7 +3314,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3852,7 +3852,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -578,7 +578,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -4516,7 +4516,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4788,8 +4788,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/changeset-generator.firewall.lock.yml
+++ b/.github/workflows/changeset-generator.firewall.lock.yml
@@ -4646,7 +4646,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4860,7 +4860,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
       (((github.event.issue.number) &&
       (github.event.issue.pull_request)) || (github.event.pull_request))
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -74,7 +74,7 @@ jobs:
       - create_issue
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -3857,7 +3857,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4386,7 +4386,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4522,8 +4522,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/cli-version-checker.lock.yml
+++ b/.github/workflows/cli-version-checker.lock.yml
@@ -3511,7 +3511,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4097,7 +4097,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/commit-changes-analyzer.lock.yml
+++ b/.github/workflows/commit-changes-analyzer.lock.yml
@@ -3206,7 +3206,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3693,7 +3693,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/copilot-agent-analysis.lock.yml
+++ b/.github/workflows/copilot-agent-analysis.lock.yml
@@ -3495,7 +3495,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3982,7 +3982,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-doc-updater.lock.yml
+++ b/.github/workflows/daily-doc-updater.lock.yml
@@ -3259,7 +3259,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -3976,7 +3976,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-firewall-report.lock.yml
+++ b/.github/workflows/daily-firewall-report.lock.yml
@@ -3361,7 +3361,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3837,7 +3837,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-news.lock.yml
+++ b/.github/workflows/daily-news.lock.yml
@@ -3503,7 +3503,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3979,7 +3979,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-perf-improver.lock.yml
+++ b/.github/workflows/daily-perf-improver.lock.yml
@@ -90,7 +90,7 @@ jobs:
       - create_discussion
       - create_pull_request
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3943,7 +3943,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4192,7 +4192,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4886,7 +4886,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -5023,8 +5023,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-repo-chronicle.lock.yml
+++ b/.github/workflows/daily-repo-chronicle.lock.yml
@@ -3307,7 +3307,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3783,7 +3783,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-test-improver.lock.yml
+++ b/.github/workflows/daily-test-improver.lock.yml
@@ -90,7 +90,7 @@ jobs:
       - create_discussion
       - create_pull_request
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3917,7 +3917,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4166,7 +4166,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4860,7 +4860,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4997,8 +4997,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dev-hawk.lock.yml
+++ b/.github/workflows/dev-hawk.lock.yml
@@ -69,7 +69,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3987,7 +3987,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4122,8 +4122,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dictation-prompt.lock.yml
+++ b/.github/workflows/dictation-prompt.lock.yml
@@ -3447,7 +3447,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4143,7 +4143,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/duplicate-code-detector.lock.yml
+++ b/.github/workflows/duplicate-code-detector.lock.yml
@@ -2869,7 +2869,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3449,7 +3449,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/example-workflow-analyzer.lock.yml
+++ b/.github/workflows/example-workflow-analyzer.lock.yml
@@ -2941,7 +2941,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3479,7 +3479,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/github-mcp-tools-report.lock.yml
+++ b/.github/workflows/github-mcp-tools-report.lock.yml
@@ -3525,7 +3525,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3773,7 +3773,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4490,7 +4490,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/go-logger.lock.yml
+++ b/.github/workflows/go-logger.lock.yml
@@ -3306,7 +3306,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4012,7 +4012,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/go-pattern-detector.lock.yml
+++ b/.github/workflows/go-pattern-detector.lock.yml
@@ -3110,7 +3110,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3646,7 +3646,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/instructions-janitor.lock.yml
+++ b/.github/workflows/instructions-janitor.lock.yml
@@ -3256,7 +3256,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -3962,7 +3962,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/issue-classifier.lock.yml
+++ b/.github/workflows/issue-classifier.lock.yml
@@ -570,7 +570,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_labels'))) && ((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_labels'))) && ((github.event.issue.number) ||
       (github.event.pull_request.number))
     runs-on: ubuntu-latest
     permissions:
@@ -3057,7 +3057,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lockfile-stats.lock.yml
+++ b/.github/workflows/lockfile-stats.lock.yml
@@ -3378,7 +3378,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3864,7 +3864,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -3884,7 +3884,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4360,7 +4360,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4492,7 +4492,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'notion_add_comment'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'notion_add_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4621,7 +4621,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'post_to_slack_channel'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'post_to_slack_channel'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/mergefest.lock.yml
+++ b/.github/workflows/mergefest.lock.yml
@@ -4277,7 +4277,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4547,7 +4547,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
       (((github.event.issue.number) &&
       (github.event.issue.pull_request)) || (github.event.pull_request))
     runs-on: ubuntu-latest

--- a/.github/workflows/notion-issue-summary.lock.yml
+++ b/.github/workflows/notion-issue-summary.lock.yml
@@ -3262,7 +3262,7 @@ jobs:
 
   notion_add_comment:
     needs: agent
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'notion_add_comment'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'notion_add_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -596,7 +596,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -4615,7 +4615,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4890,8 +4890,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -3884,7 +3884,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4410,7 +4410,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -612,7 +612,7 @@ jobs:
       - create_issue
       - create_pull_request
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1006,7 +1006,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_labels'))) && ((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_labels'))) && ((github.event.issue.number) ||
       (github.event.pull_request.number))
     runs-on: ubuntu-latest
     permissions:
@@ -4730,7 +4730,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -5032,7 +5032,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request_review_comment'))) &&
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request_review_comment'))) &&
       (((github.event.issue.number) && (github.event.issue.pull_request)) || (github.event.pull_request))
     runs-on: ubuntu-latest
     permissions:
@@ -5338,7 +5338,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -6044,7 +6044,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -6315,7 +6315,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
       (((github.event.issue.number) &&
       (github.event.issue.pull_request)) || (github.event.pull_request))
     runs-on: ubuntu-latest
@@ -6643,7 +6643,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'update_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'update_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -6867,8 +6867,8 @@ jobs:
       - missing_tool
       - upload_assets
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -6999,7 +6999,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'upload_asset'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'upload_asset'))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/q.lock.yml
+++ b/.github/workflows/q.lock.yml
@@ -614,7 +614,7 @@ jobs:
       - create_pull_request
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -4782,7 +4782,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -5487,7 +5487,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -5769,8 +5769,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/repo-tree-map.lock.yml
+++ b/.github/workflows/repo-tree-map.lock.yml
@@ -3361,7 +3361,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3837,7 +3837,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/research.lock.yml
+++ b/.github/workflows/research.lock.yml
@@ -3677,7 +3677,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4153,7 +4153,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/schema-consistency-checker.lock.yml
+++ b/.github/workflows/schema-consistency-checker.lock.yml
@@ -3345,7 +3345,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_discussion'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3832,7 +3832,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -621,7 +621,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -4559,7 +4559,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4844,8 +4844,8 @@ jobs:
       - add_comment
       - missing_tool
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/security-fix-pr.lock.yml
+++ b/.github/workflows/security-fix-pr.lock.yml
@@ -3202,7 +3202,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -3919,7 +3919,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/semantic-function-refactor.lock.yml
+++ b/.github/workflows/semantic-function-refactor.lock.yml
@@ -3383,7 +3383,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3921,7 +3921,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -2950,7 +2950,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: !(cancelled())
+    if: (!cancelled())
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3487,7 +3487,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-codex.lock.yml
+++ b/.github/workflows/smoke-codex.lock.yml
@@ -2606,7 +2606,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: !(cancelled())
+    if: (!cancelled())
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3127,7 +3127,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-copilot.firewall.lock.yml
+++ b/.github/workflows/smoke-copilot.firewall.lock.yml
@@ -3627,7 +3627,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4154,7 +4154,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -3234,7 +3234,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: !(cancelled())
+    if: (!cancelled())
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3761,7 +3761,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-detector.lock.yml
+++ b/.github/workflows/smoke-detector.lock.yml
@@ -3533,7 +3533,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4071,7 +4071,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-genaiscript.lock.yml
+++ b/.github/workflows/smoke-genaiscript.lock.yml
@@ -2096,7 +2096,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: !(cancelled())
+    if: (!cancelled())
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -2646,7 +2646,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke-opencode.lock.yml
+++ b/.github/workflows/smoke-opencode.lock.yml
@@ -2126,7 +2126,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: !(cancelled())
+    if: (!cancelled())
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -2705,7 +2705,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -79,7 +79,7 @@ jobs:
       - create_pull_request
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -3943,7 +3943,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4660,7 +4660,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4797,8 +4797,8 @@ jobs:
       - missing_tool
       - upload_assets
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4929,7 +4929,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'upload_asset'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'upload_asset'))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -3857,7 +3857,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4562,7 +4562,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4833,7 +4833,7 @@ jobs:
       - agent
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))) &&
       (((github.event.issue.number) &&
       (github.event.issue.pull_request)) || (github.event.pull_request))
     runs-on: ubuntu-latest

--- a/.github/workflows/unbloat-docs.lock.yml
+++ b/.github/workflows/unbloat-docs.lock.yml
@@ -426,7 +426,7 @@ jobs:
       - create_pull_request
       - detection
     if: >
-      ((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
+      ((!cancelled()) && (contains(needs.agent.outputs.output_types, 'add_comment'))) && (((github.event.issue.number) ||
       (github.event.pull_request.number)) || (github.event.discussion.number))
     runs-on: ubuntu-latest
     permissions:
@@ -4182,7 +4182,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -4897,7 +4897,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -5172,8 +5172,8 @@ jobs:
       - missing_tool
       - upload_assets
     if: >
-      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!(contains(needs.agent.outputs.output_types, 'add_comment')))) &&
-      (!(contains(needs.agent.outputs.output_types, 'create_pull_request')))) && (!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')))
+      (((((always()) && (needs.agent.result != 'skipped')) && (needs.activation.outputs.comment_id)) && (!contains(needs.agent.outputs.output_types, 'add_comment'))) &&
+      (!contains(needs.agent.outputs.output_types, 'create_pull_request'))) && (!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -5304,7 +5304,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'upload_asset'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'upload_asset'))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/video-analyzer.lock.yml
+++ b/.github/workflows/video-analyzer.lock.yml
@@ -3529,7 +3529,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -4057,7 +4057,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/weekly-issue-summary.lock.yml
+++ b/.github/workflows/weekly-issue-summary.lock.yml
@@ -3252,7 +3252,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'create_issue'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'create_issue'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -3780,7 +3780,7 @@ jobs:
     needs:
       - agent
       - detection
-    if: (!(cancelled())) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
+    if: (!cancelled()) && (contains(needs.agent.outputs.output_types, 'missing_tool'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/pkg/workflow/compile_test.go
+++ b/pkg/workflow/compile_test.go
@@ -575,7 +575,7 @@ This workflow tests the add_comment job generation.
 
 	// Verify job has conditional execution using BuildSafeOutputType combined with base condition
 	expectedConditionParts := []string{
-		"!(cancelled())",
+		"!cancelled()",
 		"contains(needs.agent.outputs.output_types, 'add_comment')",
 		"github.event.issue.number",
 		"github.event.pull_request.number",
@@ -658,7 +658,7 @@ This workflow tests that issue comment job is skipped for non-issue/PR events.
 
 	// Verify job has conditional execution using BuildSafeOutputType combined with base condition
 	expectedConditionParts := []string{
-		"!(cancelled())",
+		"!cancelled()",
 		"contains(needs.agent.outputs.output_types, 'add_comment')",
 		"github.event.issue.number",
 		"github.event.pull_request.number",
@@ -1144,7 +1144,7 @@ This workflow tests the add_labels job generation.
 
 	// Verify job has conditional execution using BuildSafeOutputType combined with base condition
 	expectedConditionParts := []string{
-		"!(cancelled())",
+		"!cancelled()",
 		"contains(needs.agent.outputs.output_types, 'add_labels')",
 		"github.event.issue.number",
 		"github.event.pull_request.number",
@@ -1231,7 +1231,7 @@ Write your labels to ${{ env.GH_AW_SAFE_OUTPUTS }}, one per line.
 
 	// Verify job has conditional execution using BuildSafeOutputType combined with base condition
 	expectedConditionParts := []string{
-		"!(cancelled())",
+		"!cancelled()",
 		"contains(needs.agent.outputs.output_types, 'add_labels')",
 		"github.event.issue.number",
 		"github.event.pull_request.number",
@@ -1320,7 +1320,7 @@ Write your labels to ${{ env.GH_AW_SAFE_OUTPUTS }}, one per line.
 
 	// Verify job has conditional execution using BuildSafeOutputType combined with base condition
 	expectedConditionParts := []string{
-		"!(cancelled())",
+		"!cancelled()",
 		"contains(needs.agent.outputs.output_types, 'add_labels')",
 		"github.event.issue.number",
 		"github.event.pull_request.number",

--- a/pkg/workflow/create_pr_review_comment_test.go
+++ b/pkg/workflow/create_pr_review_comment_test.go
@@ -284,7 +284,7 @@ This workflow tests job generation for PR review comments.
 
 		// Verify job condition uses BuildSafeOutputType combined with pull request context
 		expectedConditionParts := []string{
-			"!(cancelled())",
+			"!cancelled()",
 			"contains(needs.agent.outputs.output_types, 'create_pull_request_review_comment')",
 			"github.event.issue.number",
 			"github.event.issue.pull_request",

--- a/pkg/workflow/expressions_cancelled_test.go
+++ b/pkg/workflow/expressions_cancelled_test.go
@@ -29,7 +29,7 @@ func TestBuildSafeOutputTypeWithCancelled(t *testing.T) {
 			outputType: "create_issue",
 			min:        0,
 			expectedContains: []string{
-				"!(cancelled())",
+				"!cancelled()",
 				"contains(needs.agent.outputs.output_types, 'create_issue')",
 			},
 			unexpectedContains: []string{
@@ -37,11 +37,11 @@ func TestBuildSafeOutputTypeWithCancelled(t *testing.T) {
 			},
 		},
 		{
-			name:       "min>0 should use !cancelled() without contains check",
+			name:       "min>0 should use (!cancelled()) without contains check",
 			outputType: "create_issue",
 			min:        1,
 			expectedContains: []string{
-				"!(cancelled())",
+				"(!cancelled())",
 			},
 			unexpectedContains: []string{
 				"always()",
@@ -53,7 +53,7 @@ func TestBuildSafeOutputTypeWithCancelled(t *testing.T) {
 			outputType: "push_to_pull_request_branch",
 			min:        0,
 			expectedContains: []string{
-				"!(cancelled())",
+				"!cancelled()",
 				"contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')",
 			},
 			unexpectedContains: []string{

--- a/pkg/workflow/notify_comment_test.go
+++ b/pkg/workflow/notify_comment_test.go
@@ -19,17 +19,17 @@ func TestUpdateReactionJob(t *testing.T) {
 		{
 			name:               "update_reaction job created when add-comment is configured",
 			addCommentConfig:   true,
-			safeOutputJobNames: []string{"add_comment", "missing_tool"},
+			safeOutputJobNames: []string{"add_comment", "create_issue", "missing_tool"},
 			expectJob:          true,
 			expectConditions: []string{
 				"always()",
 				"needs.agent.result != 'skipped'",
 				"needs.activation.outputs.comment_id",
-				"!(contains(needs.agent.outputs.output_types, 'add_comment'))",
-				"!(contains(needs.agent.outputs.output_types, 'create_pull_request'))",
-				"!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))",
+				"(!contains(needs.agent.outputs.output_types, 'add_comment'))",
+				"(!contains(needs.agent.outputs.output_types, 'create_pull_request'))",
+				"(!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))",
 			},
-			expectNeeds: []string{constants.AgentJobName, constants.ActivationJobName, "add_comment", "missing_tool"},
+			expectNeeds: []string{constants.AgentJobName, constants.ActivationJobName, "add_comment", "create_issue", "missing_tool"},
 		},
 		{
 			name:               "update_reaction job depends on all safe output jobs",
@@ -40,9 +40,9 @@ func TestUpdateReactionJob(t *testing.T) {
 				"always()",
 				"needs.agent.result != 'skipped'",
 				"needs.activation.outputs.comment_id",
-				"!(contains(needs.agent.outputs.output_types, 'add_comment'))",
-				"!(contains(needs.agent.outputs.output_types, 'create_pull_request'))",
-				"!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))",
+				"(!contains(needs.agent.outputs.output_types, 'add_comment'))",
+				"(!contains(needs.agent.outputs.output_types, 'create_pull_request'))",
+				"(!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))",
 			},
 			expectNeeds: []string{constants.AgentJobName, constants.ActivationJobName, "add_comment", "create_issue", "missing_tool"},
 		},
@@ -200,13 +200,13 @@ func TestUpdateReactionJobIntegration(t *testing.T) {
 	if !strings.Contains(job.If, "needs.activation.outputs.comment_id") {
 		t.Error("Expected comment_id check in update_reaction condition")
 	}
-	if !strings.Contains(job.If, "!(contains(needs.agent.outputs.output_types, 'add_comment'))") {
+	if !strings.Contains(job.If, "(!contains(needs.agent.outputs.output_types, 'add_comment'))") {
 		t.Error("Expected NOT contains add_comment check in update_reaction condition")
 	}
-	if !strings.Contains(job.If, "!(contains(needs.agent.outputs.output_types, 'create_pull_request'))") {
+	if !strings.Contains(job.If, "(!contains(needs.agent.outputs.output_types, 'create_pull_request'))") {
 		t.Error("Expected NOT contains create_pull_request check in update_reaction condition")
 	}
-	if !strings.Contains(job.If, "!(contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))") {
+	if !strings.Contains(job.If, "(!contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch'))") {
 		t.Error("Expected NOT contains push_to_pull_request_branch check in update_reaction condition")
 	}
 

--- a/pkg/workflow/safe_jobs_test.go
+++ b/pkg/workflow/safe_jobs_test.go
@@ -226,7 +226,7 @@ func TestBuildSafeJobs(t *testing.T) {
 	}
 
 	// Check if condition - should now combine safe output type check with user condition
-	expectedIf := "((!(cancelled())) && (contains(needs.agent.outputs.output_types, 'deploy'))) && (github.event.issue.number)"
+	expectedIf := "((!cancelled()) && (contains(needs.agent.outputs.output_types, 'deploy'))) && (github.event.issue.number)"
 	if job.If != expectedIf {
 		t.Errorf("Expected if condition to be '%s', got '%s'", expectedIf, job.If)
 	}
@@ -330,7 +330,7 @@ func TestBuildSafeJobsWithoutCustomIfCondition(t *testing.T) {
 	}
 
 	// Check if condition - should only have safe output type check (no custom condition)
-	expectedIf := "(!(cancelled())) && (contains(needs.agent.outputs.output_types, 'notify'))"
+	expectedIf := "(!cancelled()) && (contains(needs.agent.outputs.output_types, 'notify'))"
 	if job.If != expectedIf {
 		t.Errorf("Expected if condition to be '%s', got '%s'", expectedIf, job.If)
 	}
@@ -378,7 +378,7 @@ func TestBuildSafeJobsWithDashesInName(t *testing.T) {
 	}
 
 	// Check if condition - should check for underscore version in output_types
-	expectedIf := "(!(cancelled())) && (contains(needs.agent.outputs.output_types, 'send_notification'))"
+	expectedIf := "(!cancelled()) && (contains(needs.agent.outputs.output_types, 'send_notification'))"
 	if job.If != expectedIf {
 		t.Errorf("Expected if condition to be '%s', got '%s'", expectedIf, job.If)
 	}

--- a/pkg/workflow/safe_outputs_min_condition_test.go
+++ b/pkg/workflow/safe_outputs_min_condition_test.go
@@ -219,9 +219,9 @@ func TestMinConditionInCompiledWorkflow(t *testing.T) {
 		t.Fatalf("Failed to build job: %v", err)
 	}
 
-	// Verify that the condition only contains !cancelled() and not the contains check
-	if !strings.Contains(job.If, "!cancelled()") {
-		t.Error("Expected condition to contain '!cancelled()'")
+	// Verify that the condition only contains (!cancelled()) and not the contains check
+	if !strings.Contains(job.If, "(!cancelled())") {
+		t.Error("Expected condition to contain '(!cancelled())'")
 	}
 	if strings.Contains(job.If, "contains(needs.agent.outputs.output_types, 'missing-tool')") {
 		t.Error("Expected condition NOT to contain contains check when min > 0")

--- a/pkg/workflow/safe_outputs_min_condition_test.go
+++ b/pkg/workflow/safe_outputs_min_condition_test.go
@@ -28,7 +28,7 @@ func TestSafeOutputConditionWithMin(t *testing.T) {
 			unexpectedCondition: "",
 		},
 		{
-			name: "missing-tool with min > 0 should not check contains",
+			name: "missing-tool with min should not check contains",
 			frontmatter: map[string]any{
 				"name": "Test",
 				"safe-outputs": map[string]any{
@@ -38,7 +38,7 @@ func TestSafeOutputConditionWithMin(t *testing.T) {
 					},
 				},
 			},
-			expectedCondition:   "!(cancelled())",
+			expectedCondition:   "(!cancelled())",
 			unexpectedCondition: "contains(needs.agent.outputs.output_types, 'missing_tool')",
 		},
 		{
@@ -67,7 +67,7 @@ func TestSafeOutputConditionWithMin(t *testing.T) {
 					"missing-tool": false,
 				},
 			},
-			expectedCondition:   "!(cancelled())",
+			expectedCondition:   "(!cancelled())",
 			unexpectedCondition: "contains(needs.agent.outputs.output_types, 'create_issue')",
 		},
 		{
@@ -81,7 +81,7 @@ func TestSafeOutputConditionWithMin(t *testing.T) {
 					"missing-tool": false,
 				},
 			},
-			expectedCondition:   "!(cancelled())",
+			expectedCondition:   "(!cancelled())",
 			unexpectedCondition: "contains(needs.agent.outputs.output_types, 'add-comment')",
 		},
 	}
@@ -148,10 +148,10 @@ func TestBuildSafeOutputTypeWithMin(t *testing.T) {
 			unexpectedCondition: "",
 		},
 		{
-			name:                "with min>0 should only have !cancelled()",
+			name:                "with min>0 should only have (!cancelled())",
 			outputType:          "create-issue",
 			min:                 1,
-			expectedCondition:   "!(cancelled())",
+			expectedCondition:   "(!cancelled())",
 			unexpectedCondition: "contains(needs.agent.outputs.output_types, 'create-issue')",
 		},
 		{
@@ -165,7 +165,7 @@ func TestBuildSafeOutputTypeWithMin(t *testing.T) {
 			name:                "missing-tool with min>0",
 			outputType:          "missing-tool",
 			min:                 2,
-			expectedCondition:   "!(cancelled())",
+			expectedCondition:   "(!cancelled())",
 			unexpectedCondition: "contains(needs.agent.outputs.output_types, 'missing-tool')",
 		},
 	}
@@ -220,7 +220,7 @@ func TestMinConditionInCompiledWorkflow(t *testing.T) {
 	}
 
 	// Verify that the condition only contains !cancelled() and not the contains check
-	if !strings.Contains(job.If, "!(cancelled())") {
+	if !strings.Contains(job.If, "!cancelled()") {
 		t.Error("Expected condition to contain '!cancelled()'")
 	}
 	if strings.Contains(job.If, "contains(needs.agent.outputs.output_types, 'missing-tool')") {


### PR DESCRIPTION
## Summary
- Updated GitHub Actions workflow condition syntax to use `!cancelled()` instead of `!(cancelled())`
- Improved condition rendering to prevent GitHub Actions from misinterpreting nested parentheses
- Addressed potential parsing issues in complex workflow conditions

## Changes
- Modified `expressions.go` to handle function call negation more precisely
- Updated test cases to reflect new condition syntax
- Added `ParenthesesNode` to wrap complex conditions when needed
- Simplified condition rendering for function calls like `cancelled()`

## Rationale
The previous implementation of negating the `cancelled()` function could lead to unexpected behavior in GitHub Actions workflow parsing. By directly rendering `!cancelled()` for simple function calls, we ensure more consistent and predictable workflow execution.