### PR TITLE
🚀 Add --repo option to workflow management commands

### DIFF
--- a/cmd/gh-aw/main.go
+++ b/cmd/gh-aw/main.go
@@ -128,9 +128,11 @@ var enableCmd = &cobra.Command{
 Examples:
   ` + constants.CLIExtensionPrefix + ` enable                    # Enable all workflows
   ` + constants.CLIExtensionPrefix + ` enable ci-doctor         # Enable specific workflow
-  ` + constants.CLIExtensionPrefix + ` enable ci-doctor daily   # Enable multiple workflows`,
+  ` + constants.CLIExtensionPrefix + ` enable ci-doctor daily   # Enable multiple workflows
+  ` + constants.CLIExtensionPrefix + ` enable ci-doctor --repo owner/repo  # Enable workflow in specific repository`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := cli.EnableWorkflowsByNames(args); err != nil {
+		repoOverride, _ := cmd.Flags().GetString("repo")
+		if err := cli.EnableWorkflowsByNames(args, repoOverride); err != nil {
 			fmt.Fprintln(os.Stderr, console.FormatErrorMessage(err.Error()))
 			os.Exit(1)
 		}
@@ -145,9 +147,11 @@ var disableCmd = &cobra.Command{
 Examples:
   ` + constants.CLIExtensionPrefix + ` disable                    # Disable all workflows
   ` + constants.CLIExtensionPrefix + ` disable ci-doctor         # Disable specific workflow
-  ` + constants.CLIExtensionPrefix + ` disable ci-doctor daily   # Disable multiple workflows`,
+  ` + constants.CLIExtensionPrefix + ` disable ci-doctor daily   # Disable multiple workflows
+  ` + constants.CLIExtensionPrefix + ` disable ci-doctor --repo owner/repo  # Disable workflow in specific repository`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := cli.DisableWorkflowsByNames(args); err != nil {
+		repoOverride, _ := cmd.Flags().GetString("repo")
+		if err := cli.DisableWorkflowsByNames(args, repoOverride); err != nil {
 			fmt.Fprintln(os.Stderr, console.FormatErrorMessage(err.Error()))
 			os.Exit(1)
 		}
@@ -430,6 +434,10 @@ Use "` + constants.CLIExtensionPrefix + ` help all" to show help for all command
 
 	// Add flags to remove command
 	removeCmd.Flags().Bool("keep-orphans", false, "Skip removal of orphaned include files that are no longer referenced by any workflow")
+
+	// Add flags to enable/disable commands
+	enableCmd.Flags().StringP("repo", "r", "", "Repository to enable workflows in (owner/repo format)")
+	disableCmd.Flags().StringP("repo", "r", "", "Repository to disable workflows in (owner/repo format)")
 
 	// Add flags to run command
 	runCmd.Flags().Int("repeat", 0, "Number of times to repeat running workflows (0 = run once)")

--- a/pkg/cli/logs.go
+++ b/pkg/cli/logs.go
@@ -339,7 +339,8 @@ Examples:
   ` + constants.CLIExtensionPrefix + ` logs --tool-graph              # Generate Mermaid tool sequence graph
   ` + constants.CLIExtensionPrefix + ` logs --parse                   # Parse logs and generate markdown reports
   ` + constants.CLIExtensionPrefix + ` logs --json                    # Output metrics in JSON format
-  ` + constants.CLIExtensionPrefix + ` logs --parse --json            # Generate both markdown and JSON`,
+  ` + constants.CLIExtensionPrefix + ` logs --parse --json            # Generate both markdown and JSON
+  ` + constants.CLIExtensionPrefix + ` logs weekly-research --repo owner/repo  # Download logs from specific repository`,
 		Run: func(cmd *cobra.Command, args []string) {
 			var workflowName string
 			if len(args) > 0 && args[0] != "" {
@@ -387,6 +388,7 @@ Examples:
 			parse, _ := cmd.Flags().GetBool("parse")
 			jsonOutput, _ := cmd.Flags().GetBool("json")
 			timeout, _ := cmd.Flags().GetInt("timeout")
+			repoOverride, _ := cmd.Flags().GetString("repo")
 
 			// Resolve relative dates to absolute dates for GitHub CLI
 			now := time.Now()
@@ -435,7 +437,7 @@ Examples:
 				os.Exit(1)
 			}
 
-			if err := DownloadWorkflowLogs(workflowName, count, startDate, endDate, outputDir, engine, branch, beforeRunID, afterRunID, verbose, toolGraph, noStaged, firewallOnly, noFirewall, parse, jsonOutput, timeout); err != nil {
+			if err := DownloadWorkflowLogs(workflowName, count, startDate, endDate, outputDir, engine, branch, beforeRunID, afterRunID, repoOverride, verbose, toolGraph, noStaged, firewallOnly, noFirewall, parse, jsonOutput, timeout); err != nil {
 				fmt.Fprintln(os.Stderr, console.FormatError(console.CompilerError{
 					Type:    "error",
 					Message: err.Error(),
@@ -454,6 +456,7 @@ Examples:
 	logsCmd.Flags().String("branch", "", "Filter runs by branch name (e.g., main, feature-branch)")
 	logsCmd.Flags().Int64("before-run-id", 0, "Filter runs with database ID before this value (exclusive)")
 	logsCmd.Flags().Int64("after-run-id", 0, "Filter runs with database ID after this value (exclusive)")
+	logsCmd.Flags().StringP("repo", "r", "", "Repository to download logs from (owner/repo format)")
 	logsCmd.Flags().Bool("tool-graph", false, "Generate Mermaid tool sequence graph from agent logs")
 	logsCmd.Flags().Bool("no-staged", false, "Filter out staged workflow runs (exclude runs with staged: true in aw_info.json)")
 	logsCmd.Flags().Bool("firewall", false, "Filter to only runs with firewall enabled")
@@ -466,7 +469,7 @@ Examples:
 }
 
 // DownloadWorkflowLogs downloads and analyzes workflow logs with metrics
-func DownloadWorkflowLogs(workflowName string, count int, startDate, endDate, outputDir, engine, branch string, beforeRunID, afterRunID int64, verbose bool, toolGraph bool, noStaged bool, firewallOnly bool, noFirewall bool, parse bool, jsonOutput bool, timeout int) error {
+func DownloadWorkflowLogs(workflowName string, count int, startDate, endDate, outputDir, engine, branch string, beforeRunID, afterRunID int64, repoOverride string, verbose bool, toolGraph bool, noStaged bool, firewallOnly bool, noFirewall bool, parse bool, jsonOutput bool, timeout int) error {
 	logsLog.Printf("Starting workflow log download: workflow=%s, count=%d, startDate=%s, endDate=%s, outputDir=%s", workflowName, count, startDate, endDate, outputDir)
 	if verbose {
 		fmt.Fprintln(os.Stderr, console.FormatInfoMessage("Fetching workflow runs from GitHub Actions..."))
@@ -543,7 +546,7 @@ func DownloadWorkflowLogs(workflowName string, count int, startDate, endDate, ou
 			}
 		}
 
-		runs, totalFetched, err := listWorkflowRunsWithPagination(workflowName, batchSize, startDate, endDate, beforeDate, branch, beforeRunID, afterRunID, len(processedRuns), count, verbose)
+		runs, totalFetched, err := listWorkflowRunsWithPagination(workflowName, batchSize, startDate, endDate, beforeDate, branch, beforeRunID, afterRunID, repoOverride, len(processedRuns), count, verbose)
 		if err != nil {
 			return err
 		}
@@ -1032,7 +1035,7 @@ func downloadRunArtifactsConcurrent(runs []WorkflowRun, outputDir string, verbos
 // not the total number of matching runs the user wants to find.
 //
 // The processedCount and targetCount parameters are used to display progress in the spinner message.
-func listWorkflowRunsWithPagination(workflowName string, limit int, startDate, endDate, beforeDate, branch string, beforeRunID, afterRunID int64, processedCount, targetCount int, verbose bool) ([]WorkflowRun, int, error) {
+func listWorkflowRunsWithPagination(workflowName string, limit int, startDate, endDate, beforeDate, branch string, beforeRunID, afterRunID int64, repoOverride string, processedCount, targetCount int, verbose bool) ([]WorkflowRun, int, error) {
 	args := []string{"run", "list", "--json", "databaseId,number,url,status,conclusion,workflowName,createdAt,startedAt,updatedAt,event,headBranch,headSha,displayTitle"}
 
 	// Add filters
@@ -1055,6 +1058,10 @@ func listWorkflowRunsWithPagination(workflowName string, limit int, startDate, e
 	// Add branch filter
 	if branch != "" {
 		args = append(args, "--branch", branch)
+	}
+	// Add repo filter
+	if repoOverride != "" {
+		args = append(args, "--repo", repoOverride)
 	}
 
 	if verbose {

--- a/pkg/cli/logs_test.go
+++ b/pkg/cli/logs_test.go
@@ -19,7 +19,7 @@ func TestDownloadWorkflowLogs(t *testing.T) {
 	// Test the DownloadWorkflowLogs function
 	// This should either fail with auth error (if not authenticated)
 	// or succeed with no results (if authenticated but no workflows match)
-	err := DownloadWorkflowLogs("", 1, "", "", "./test-logs", "", "", 0, 0, false, false, false, false, false, false, false, 0)
+	err := DownloadWorkflowLogs("", 1, "", "", "./test-logs", "", "", 0, 0, "", false, false, false, false, false, false, false, 0)
 
 	// If GitHub CLI is authenticated, the function may succeed but find no results
 	// If not authenticated, it should return an auth error
@@ -342,7 +342,7 @@ func TestListWorkflowRunsWithPagination(t *testing.T) {
 
 	// This should fail with authentication error (if not authenticated)
 	// or succeed with empty results (if authenticated but no workflows match)
-	runs, _, err := listWorkflowRunsWithPagination("nonexistent-workflow", 5, "", "", "2024-01-01T00:00:00Z", "", 0, 0, 0, 5, false)
+	runs, _, err := listWorkflowRunsWithPagination("nonexistent-workflow", 5, "", "", "2024-01-01T00:00:00Z", "", 0, 0, "", 0, 5, false)
 
 	if err != nil {
 		// If there's an error, it should be an authentication error or workflow not found
@@ -915,7 +915,7 @@ func TestDownloadWorkflowLogsWithEngineFilter(t *testing.T) {
 			if !tt.expectError {
 				// For valid engines, test that the function can be called without panic
 				// It may still fail with auth errors, which is expected
-				err := DownloadWorkflowLogs("", 1, "", "", "./test-logs", tt.engine, "", 0, 0, false, false, false, false, false, false, false, 0)
+				err := DownloadWorkflowLogs("", 1, "", "", "./test-logs", tt.engine, "", 0, 0, "", false, false, false, false, false, false, false, 0)
 
 				// Clean up any created directories
 				os.RemoveAll("./test-logs")


### PR DESCRIPTION
## Summary
- Added `--repo` flag to enable, disable, and logs commands
- Allows specifying a specific repository for workflow operations
- Enhances flexibility of workflow management across different repositories

## Changes
- Updated `enable` and `disable` commands to support repository override
- Modified `logs` command to accept `--repo` flag for repository-specific log retrieval
- Updated related function signatures to include repository override parameter
- Added example usage in command documentation demonstrating the new `--repo` option