### PR TITLE
🤖 Optimize workflow disabling in trial command

### DIFF
--- a/pkg/cli/trial_command.go
+++ b/pkg/cli/trial_command.go
@@ -344,15 +344,15 @@ func RunWorkflowTrials(workflowSpecs []string, logicalRepoSpec string, cloneRepo
 		if err := os.Chdir(tempDirForDisable); err != nil {
 			return fmt.Errorf("failed to change to temp directory: %w", err)
 		}
+		// Always attempt to change back to the original directory
+		defer func() {
+			if err := os.Chdir(originalDir); err != nil {
+				trialLog.Printf("Failed to change back to original directory: %v", err)
+			}
+		}()
 
 		// Disable workflows (pass empty string for repoSlug since we're working locally)
 		disableErr := DisableAllWorkflowsExcept("", workflowsToKeep, verbose)
-
-		// Change back to original directory
-		if err := os.Chdir(originalDir); err != nil {
-			return fmt.Errorf("failed to change back to original directory: %w", err)
-		}
-
 		// Check for disable errors after changing back
 		if disableErr != nil {
 			// Log warning but don't fail the trial - workflow disabling is not critical

--- a/pkg/cli/trial_command.go
+++ b/pkg/cli/trial_command.go
@@ -312,6 +312,54 @@ func RunWorkflowTrials(workflowSpecs []string, logicalRepoSpec string, cloneRepo
 		}
 	}
 
+	// Step 2.8: Disable all workflows except the ones being trialled (only in clone-repo mode, done once before all trials)
+	if cloneRepoSlug != "" {
+		// Build list of workflow names to keep enabled
+		var workflowsToKeep []string
+		for _, spec := range parsedSpecs {
+			workflowsToKeep = append(workflowsToKeep, spec.WorkflowName)
+		}
+
+		if verbose {
+			fmt.Fprintln(os.Stderr, console.FormatInfoMessage(fmt.Sprintf("Disabling workflows in cloned repository (keeping: %s)", strings.Join(workflowsToKeep, ", "))))
+		}
+
+		// Clone host repository temporarily to access workflows
+		tempDirForDisable, err := cloneTrialHostRepository(hostRepoSlug, verbose)
+		if err != nil {
+			return fmt.Errorf("failed to clone host repository for workflow disabling: %w", err)
+		}
+		defer func() {
+			if err := os.RemoveAll(tempDirForDisable); err != nil {
+				trialLog.Printf("Failed to cleanup temp directory for workflow disabling: %v", err)
+			}
+		}()
+
+		// Change to temp directory to access local .github/workflows
+		originalDir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+
+		if err := os.Chdir(tempDirForDisable); err != nil {
+			return fmt.Errorf("failed to change to temp directory: %w", err)
+		}
+
+		// Disable workflows (pass empty string for repoSlug since we're working locally)
+		disableErr := DisableAllWorkflowsExcept("", workflowsToKeep, verbose)
+
+		// Change back to original directory
+		if err := os.Chdir(originalDir); err != nil {
+			return fmt.Errorf("failed to change back to original directory: %w", err)
+		}
+
+		// Check for disable errors after changing back
+		if disableErr != nil {
+			// Log warning but don't fail the trial - workflow disabling is not critical
+			fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Failed to disable workflows: %v", disableErr)))
+		}
+	}
+
 	// Function to run all trials once
 	runAllTrials := func() error {
 		// Generate a unique datetime-ID for this trial session
@@ -337,43 +385,6 @@ func RunWorkflowTrials(workflowSpecs []string, logicalRepoSpec string, cloneRepo
 				fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Failed to cleanup local temp directory: %v", err)))
 			}
 		}()
-
-		// Step 3.5: Disable all workflows except the ones being trialled (only in clone-repo mode)
-		if cloneRepoSlug != "" {
-			// Build list of workflow names to keep enabled
-			var workflowsToKeep []string
-			for _, spec := range parsedSpecs {
-				workflowsToKeep = append(workflowsToKeep, spec.WorkflowName)
-			}
-
-			if verbose {
-				fmt.Fprintln(os.Stderr, console.FormatInfoMessage(fmt.Sprintf("Disabling workflows in cloned repository (keeping: %s)", strings.Join(workflowsToKeep, ", "))))
-			}
-
-			// Change to temp directory to access local .github/workflows
-			originalDir, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("failed to get current directory: %w", err)
-			}
-
-			if err := os.Chdir(tempDir); err != nil {
-				return fmt.Errorf("failed to change to temp directory: %w", err)
-			}
-
-			// Disable workflows (pass empty string for repoSlug since we're working locally)
-			disableErr := DisableAllWorkflowsExcept("", workflowsToKeep, verbose)
-
-			// Change back to original directory
-			if err := os.Chdir(originalDir); err != nil {
-				return fmt.Errorf("failed to change back to original directory: %w", err)
-			}
-
-			// Check for disable errors after changing back
-			if disableErr != nil {
-				// Log warning but don't fail the trial - workflow disabling is not critical
-				fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Failed to disable workflows: %v", disableErr)))
-			}
-		}
 
 		// Step 4: Create trials directory
 		if err := os.MkdirAll("trials", 0755); err != nil {


### PR DESCRIPTION
## Summary

- Moved workflow disabling logic earlier in the `RunWorkflowTrials` function
- Improved error handling and temporary directory management for workflow disabling
- Simplified workflow disabling process in clone-repo mode

## Changes

- Relocated workflow disabling step to occur before trial execution
- Added separate temporary directory clone for workflow disabling
- Maintained existing warning-level error handling for non-critical workflow disabling failures