### PR TITLE
chore: disable scheduled trigger for AI Triage Campaign workflow

### DIFF
--- a/.github/workflows/ai-triage-campaign.lock.yml
+++ b/.github/workflows/ai-triage-campaign.lock.yml
@@ -35,8 +35,6 @@
 
 name: "AI Triage Campaign"
 "on":
-  schedule:
-  - cron: "0 */4 * * *"
   workflow_dispatch:
     inputs:
       max_issues:

--- a/.github/workflows/ai-triage-campaign.md
+++ b/.github/workflows/ai-triage-campaign.md
@@ -3,8 +3,8 @@ name: AI Triage Campaign
 description: Automatically identify, score, and assign issues to AI agents for efficient resolution
 
 on:
-  schedule:
-    - cron: "0 */4 * * *"  # Every 4 hours
+  #schedule:
+    #- cron: "0 */4 * * *"  # Every 4 hours
   workflow_dispatch:
     inputs:
       project_url:


### PR DESCRIPTION
- Works, but disable workflow running on schedule for now until we discuss what kind of issues should be considered.