### PR TITLE
🔧 Add --force flag to PR transfer command

### DIFF
--- a/pkg/cli/pr_command_test.go
+++ b/pkg/cli/pr_command_test.go
@@ -181,4 +181,10 @@ func TestNewPRTransferSubcommand(t *testing.T) {
 	if verboseFlag == nil {
 		t.Error("Expected --verbose flag to exist")
 	}
+
+	// Check that --force flag exists
+	forceFlag := cmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Error("Expected --force flag to exist")
+	}
 }


### PR DESCRIPTION
## Summary

- Introduced a new `--force` flag for the PR transfer command
- Enables transferring PRs with conflicts by creating a PR with conflict markers
- Provides more flexibility when handling complex patch applications

## Changes

- Updated `transferPR` and `applyPatchToRepo` functions to support `--force` flag
- Added command-line flag and updated help text
- Implemented conflict handling mechanism with optional force mode
- Updated tests to validate new flag existence

## Behavior

- Without `--force`: Fail on conflicts and provide an error message
- With `--force`: 
  - Create a PR with conflict markers and .rej files
  - Allow manual conflict resolution
  - Include warning in commit message about existing conflicts