### PR TITLE
Potential fix for code scanning alert no. 36: Incorrect conversion between integer types

### DIFF
--- a/pkg/parser/github_urls.go
+++ b/pkg/parser/github_urls.go
@@ -127,7 +127,7 @@ func ParseGitHubURL(urlStr string) (*GitHubURLComponents, error) {
 		case "issues":
 			// Pattern: /owner/repo/issues/123
 			if len(pathParts) >= 4 {
-				issueNumber, err := strconv.ParseInt(pathParts[3], 10, 64)
+				issueNumber, err := strconv.ParseInt(pathParts[3], 10, 32)
 				if err != nil {
 					return nil, fmt.Errorf("invalid issue number: %s", pathParts[3])
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/githubnext/gh-aw/security/code-scanning/36](https://github.com/githubnext/gh-aw/security/code-scanning/36)

The best way to fix the problem is to parse PR/issue/run numbers (`pull`, `issues`) using `strconv.ParseInt` *with* bit size 32, since these are returned as (and cast into) smaller integer types such as `int` elsewhere. This means on line 130, change `strconv.ParseInt(pathParts[3], 10, 64)` to `strconv.ParseInt(pathParts[3], 10, 32)`. That way, any value outside the range of a signed 32-bit integer will immediately fail to parse and be rejected with an error. This prevents the risk of an oversized value flowing into code where it will later be downcast or used as a 32-bit value, and makes bounds checks in later code redundant.

You only need to update the parsing location of the PR/issue numbers, at line 130, since this affects the `Number` field in the returned components structure, which is later used and (potentially) cast to `int`.  
No need to add new imports since `strconv` is already present; no new methods or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
