### PR TITLE
fix: update agent token management for `assign-to-agent`

### DIFF
--- a/.github/workflows/ai-triage-campaign.lock.yml
+++ b/.github/workflows/ai-triage-campaign.lock.yml
@@ -306,8 +306,6 @@
 
 name: "AI Triage Campaign"
 "on":
-  schedule:
-  - cron: "0 */4 * * *"
   workflow_dispatch:
     inputs:
       max_issues:
@@ -4184,7 +4182,7 @@ jobs:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_AGENT_DEFAULT: "copilot"
           GH_AW_AGENT_MAX_COUNT: 1
-          GH_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_AGENT_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN }}
           GH_AW_WORKFLOW_NAME: "AI Triage Campaign"
         with:
           github-token: ${{ secrets.COPILOT_GITHUB_TOKEN || secrets.COPILOT_CLI_TOKEN || secrets.GH_AW_COPILOT_TOKEN || secrets.GH_AW_GITHUB_TOKEN }}
@@ -4370,9 +4368,9 @@ jobs:
               `;
               try {
                 const { Octokit } = require("@octokit/rest");
-                const mutationToken = process.env.GH_TOKEN;
+                const mutationToken = process.env.GH_AW_AGENT_TOKEN;
                 if (!mutationToken) {
-                  core.error("GH_TOKEN environment variable is not set. Cannot perform assignment mutation.");
+                  core.error("GH_AW_AGENT_TOKEN environment variable is not set. Cannot perform assignment mutation.");
                   return false;
                 }
                 const mutationClient = new Octokit({ auth: mutationToken });
@@ -4415,9 +4413,9 @@ jobs:
                   core.info("Primary mutation replaceActorsForAssignable forbidden. Attempting fallback addAssigneesToAssignable...");
                   try {
                     const fallbackMutation = `mutation {\n  addAssigneesToAssignable(input:{assignableId:"${issueId}", assigneeIds:["${agentId}"]}) {\n    clientMutationId\n  }\n}`;
-                    const fallbackToken = process.env.GH_TOKEN;
+                    const fallbackToken = process.env.GH_AW_AGENT_TOKEN;
                     if (!fallbackToken) {
-                      core.error("GH_TOKEN environment variable is not set. Cannot perform fallback mutation.");
+                      core.error("GH_AW_AGENT_TOKEN environment variable is not set. Cannot perform fallback mutation.");
                     } else {
                       const fallbackClient = new Octokit({ auth: fallbackToken });
                       const fallbackResp = await fallbackClient.graphql(fallbackMutation);

--- a/.github/workflows/ai-triage-campaign.lock.yml
+++ b/.github/workflows/ai-triage-campaign.lock.yml
@@ -306,6 +306,8 @@
 
 name: "AI Triage Campaign"
 "on":
+  schedule:
+  - cron: "0 */4 * * *"
   workflow_dispatch:
     inputs:
       max_issues:
@@ -4185,7 +4187,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN }}
           GH_AW_WORKFLOW_NAME: "AI Triage Campaign"
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COPILOT_GITHUB_TOKEN || secrets.COPILOT_CLI_TOKEN || secrets.GH_AW_COPILOT_TOKEN || secrets.GH_AW_GITHUB_TOKEN }}
           script: |
             const fs = require("fs");
             function loadAgentOutput() {
@@ -4367,7 +4369,14 @@ jobs:
                 }
               `;
               try {
-                const response = await github.graphql(mutation);
+                const { Octokit } = require("@octokit/rest");
+                const mutationToken = process.env.GH_TOKEN;
+                if (!mutationToken) {
+                  core.error("GH_TOKEN environment variable is not set. Cannot perform assignment mutation.");
+                  return false;
+                }
+                const mutationClient = new Octokit({ auth: mutationToken });
+                const response = await mutationClient.graphql(mutation);
                 if (response.replaceActorsForAssignable && response.replaceActorsForAssignable.__typename) {
                   return true;
                 } else {
@@ -4406,12 +4415,18 @@ jobs:
                   core.info("Primary mutation replaceActorsForAssignable forbidden. Attempting fallback addAssigneesToAssignable...");
                   try {
                     const fallbackMutation = `mutation {\n  addAssigneesToAssignable(input:{assignableId:"${issueId}", assigneeIds:["${agentId}"]}) {\n    clientMutationId\n  }\n}`;
-                    const fallbackResp = await github.graphql(fallbackMutation);
-                    if (fallbackResp && fallbackResp.addAssigneesToAssignable) {
-                      core.info(`Fallback succeeded: agent '${agentName}' added via addAssigneesToAssignable.`);
-                      return true;
+                    const fallbackToken = process.env.GH_TOKEN;
+                    if (!fallbackToken) {
+                      core.error("GH_TOKEN environment variable is not set. Cannot perform fallback mutation.");
                     } else {
-                      core.warning("Fallback mutation returned unexpected response; proceeding with permission guidance.");
+                      const fallbackClient = new Octokit({ auth: fallbackToken });
+                      const fallbackResp = await fallbackClient.graphql(fallbackMutation);
+                      if (fallbackResp && fallbackResp.addAssigneesToAssignable) {
+                        core.info(`Fallback succeeded: agent '${agentName}' added via addAssigneesToAssignable.`);
+                        return true;
+                      } else {
+                        core.warning("Fallback mutation returned unexpected response; proceeding with permission guidance.");
+                      }
                     }
                   } catch (fallbackError) {
                     const fbMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);

--- a/.github/workflows/ai-triage-campaign.md
+++ b/.github/workflows/ai-triage-campaign.md
@@ -3,8 +3,8 @@ name: AI Triage Campaign
 description: Automatically identify, score, and assign issues to AI agents for efficient resolution
 
 on:
-  #schedule:
-    #- cron: "0 */4 * * *"  # Every 4 hours
+  schedule:
+    - cron: "0 */4 * * *"  # Every 4 hours
   workflow_dispatch:
     inputs:
       project_url:

--- a/.github/workflows/ai-triage-campaign.md
+++ b/.github/workflows/ai-triage-campaign.md
@@ -3,8 +3,8 @@ name: AI Triage Campaign
 description: Automatically identify, score, and assign issues to AI agents for efficient resolution
 
 on:
-  schedule:
-    - cron: "0 */4 * * *"  # Every 4 hours
+  #schedule:
+    #- cron: "0 */4 * * *"  # Every 4 hours
   workflow_dispatch:
     inputs:
       project_url:

--- a/docs/src/content/docs/reference/safe-outputs.md
+++ b/docs/src/content/docs/reference/safe-outputs.md
@@ -382,10 +382,12 @@ safe-outputs:
 
 **Token Requirements:**
 
-The default `GITHUB_TOKEN` lacks permission to assign agents. Create a fine-grained personal access token with these permissions and store it as the `COPILOT_GITHUB_TOKEN` secret:
+The default `GITHUB_TOKEN` lacks permission to assign agents. The `replaceActorsForAssignable` mutation requires elevated permissions. Create a fine-grained personal access token with these permissions and store it as the `GH_AW_AGENT_TOKEN` secret:
 
-- **Read** access to metadata
+- **Read** access to metadata (granted by default)
 - **Write** access to actions, contents, issues, and pull requests
+
+Without this token, agent assignment will fail with a clear error message
 
 ```yaml wrap
 safe-outputs:

--- a/docs/src/content/docs/reference/safe-outputs.md
+++ b/docs/src/content/docs/reference/safe-outputs.md
@@ -382,7 +382,7 @@ safe-outputs:
 
 **Token Requirements:**
 
-The GitHub Action lacks permissions to assign agents. Create a fine-grained personal access token with these permissions and store it as the `GH_AW_AGENT_TOKEN` secret:
+The default `GITHUB_TOKEN` lacks permission to assign agents. Create a fine-grained personal access token with these permissions and store it as the `COPILOT_GITHUB_TOKEN` secret:
 
 - **Read** access to metadata
 - **Write** access to actions, contents, issues, and pull requests

--- a/pkg/workflow/assign_to_agent.go
+++ b/pkg/workflow/assign_to_agent.go
@@ -71,16 +71,17 @@ func (c *Compiler) buildAssignToAgentJob(data *WorkflowData, mainJobName string)
 	// Use the shared builder function to create the job
 	// Note: replaceActorsForAssignable GraphQL mutation requires all four write permissions
 	return c.buildSafeOutputJob(data, SafeOutputJobConfig{
-		JobName:        "assign_to_agent",
-		StepName:       "Assign to Agent",
-		StepID:         "assign_to_agent",
-		MainJobName:    mainJobName,
-		CustomEnvVars:  customEnvVars,
-		Script:         getAssignToAgentScript(),
-		Permissions:    NewPermissionsActionsWriteContentsWriteIssuesWritePRWrite(),
-		Outputs:        outputs,
-		Token:          token,
-		Condition:      BuildSafeOutputType("assign_to_agent"),
-		TargetRepoSlug: data.SafeOutputs.AssignToAgent.TargetRepoSlug,
+		JobName:         "assign_to_agent",
+		StepName:        "Assign to Agent",
+		StepID:          "assign_to_agent",
+		MainJobName:     mainJobName,
+		CustomEnvVars:   customEnvVars,
+		Script:          getAssignToAgentScript(),
+		Permissions:     NewPermissionsActionsWriteContentsWriteIssuesWritePRWrite(),
+		Outputs:         outputs,
+		Token:           token,
+		UseCopilotToken: true,
+		Condition:       BuildSafeOutputType("assign_to_agent"),
+		TargetRepoSlug:  data.SafeOutputs.AssignToAgent.TargetRepoSlug,
 	})
 }

--- a/pkg/workflow/assign_to_agent.go
+++ b/pkg/workflow/assign_to_agent.go
@@ -50,7 +50,7 @@ func (c *Compiler) buildAssignToAgentJob(data *WorkflowData, mainJobName string)
 	} else {
 		tokenValue = "${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN }}"
 	}
-	customEnvVars = append(customEnvVars, fmt.Sprintf("          GH_TOKEN: %s\n", tokenValue))
+	customEnvVars = append(customEnvVars, fmt.Sprintf("          GH_AW_AGENT_TOKEN: %s\n", tokenValue))
 
 	// Pass the target configuration
 

--- a/pkg/workflow/js/assign_to_agent.cjs
+++ b/pkg/workflow/js/assign_to_agent.cjs
@@ -181,13 +181,13 @@ async function assignAgentToIssue(issueId, agentId, currentAssignees, agentName)
   `;
 
   try {
-    // SECURITY: Use GH_TOKEN environment variable (GH_AW_AGENT_TOKEN) for the mutation
+    // SECURITY: Use GH_AW_AGENT_TOKEN environment variable for the mutation
     // This is more privileged than the github-token parameter (GITHUB_TOKEN) used for read operations
     // The mutation requires: Write actions/contents/issues/pull-requests
     const { Octokit } = require("@octokit/rest");
-    const mutationToken = process.env.GH_TOKEN;
+    const mutationToken = process.env.GH_AW_AGENT_TOKEN;
     if (!mutationToken) {
-      core.error("GH_TOKEN environment variable is not set. Cannot perform assignment mutation.");
+      core.error("GH_AW_AGENT_TOKEN environment variable is not set. Cannot perform assignment mutation.");
       return false;
     }
     
@@ -242,12 +242,12 @@ async function assignAgentToIssue(issueId, agentId, currentAssignees, agentName)
       // Attempt fallback mutation addAssigneesToAssignable when replaceActorsForAssignable is forbidden
       core.info("Primary mutation replaceActorsForAssignable forbidden. Attempting fallback addAssigneesToAssignable...");
       try {
-        // SECURITY: Use same GH_TOKEN environment variable for fallback mutation
+        // SECURITY: Use same GH_AW_AGENT_TOKEN environment variable for fallback mutation
         const fallbackMutation = `mutation {\n  addAssigneesToAssignable(input:{assignableId:"${issueId}", assigneeIds:["${agentId}"]}) {\n    clientMutationId\n  }\n}`;
         const { Octokit } = require("@octokit/rest");
-        const fallbackToken = process.env.GH_TOKEN;
+        const fallbackToken = process.env.GH_AW_AGENT_TOKEN;
         if (!fallbackToken) {
-          core.error("GH_TOKEN environment variable is not set. Cannot perform fallback mutation.");
+          core.error("GH_AW_AGENT_TOKEN environment variable is not set. Cannot perform fallback mutation.");
         } else {
           const fallbackClient = new Octokit({ auth: fallbackToken });
           const fallbackResp = await fallbackClient.graphql(fallbackMutation);


### PR DESCRIPTION
# Agent assignment token permissions

- Agent assignment was failing because GraphQL mutations used `github.graphql()` which authenticates with the `github-token` parameter (`GITHUB_TOKEN`), but the `replaceActorsForAssignable` mutation requires elevated permissions (actions, contents, issues, and pull-requests write) only available in `GH_AW_AGENT_TOKEN`.
- Separated token usage by operation type:
   - **Queries** (read): Use `github.graphql()` with standard token via `github-token` parameter.
   - **Mutations** (write): Use `new Octokit({ auth: process.env.GH_AW_AGENT_TOKEN })` with privileged token.
- **Setup requirement:**
   - Users must create a fine-grained PAT with permissions: `actions: write`, `contents: write`, `issues: write`, `pull-requests: write`, `metadata: read` (granted by default).
   - Store the PAT as `GH_AW_AGENT_TOKEN` secret in their repository.
   - Without this, agent assignment will fail with a clear error message.