### PR TITLE
fix: update project URL handling in AI triage campaign workflow

### DIFF
--- a/.github/workflows/ai-triage-campaign.lock.yml
+++ b/.github/workflows/ai-triage-campaign.lock.yml
@@ -88,7 +88,7 @@
 #
 # ## Project Board Fields
 #
-# For each issue with score ≥ 5, use the `update_project` tool to set these fields:
+# For each issue with score ≥ 5, use the `update_project` tool with `project: "${{ github.event.inputs.project_url }}"` to set these fields:
 #
 # | Field | Values |
 # |-------|--------|
@@ -109,8 +109,8 @@
 # 1. **Assessment**: Why is this suitable/unsuitable for AI? (1-2 sentences)
 # 2. **Scores**: AI-Readiness, Status, Effort, Type, Priority with brief rationale
 # 3. **Decision**: 
-#    - Score ≥ 9: "Assigning to @copilot" + use both `update_project` and `assign_to_agent` tools
-#    - Score 5-8: "Needs clarification: [specific questions]" + use `update_project` tool only
+#    - Score ≥ 9: "Assigning to @copilot" + use both `update_project` (with `project: "${{ github.event.inputs.project_url }}"`) and `assign_to_agent` tools
+#    - Score 5-8: "Needs clarification: [specific questions]" + use `update_project` tool only (with `project: "${{ github.event.inputs.project_url }}"`)
 #    - Score < 5: "Requires human review: [reasons]" + no tool calls
 #
 # ## Notes
@@ -1135,7 +1135,7 @@ jobs:
           
           ## Project Board Fields
           
-          For each issue with score ≥ 5, use the `update_project` tool to set these fields:
+          For each issue with score ≥ 5, use the `update_project` tool with `project: "${GH_AW_EXPR_7B9A5317}"` to set these fields:
           
           | Field | Values |
           |-------|--------|
@@ -1156,8 +1156,8 @@ jobs:
           1. **Assessment**: Why is this suitable/unsuitable for AI? (1-2 sentences)
           2. **Scores**: AI-Readiness, Status, Effort, Type, Priority with brief rationale
           3. **Decision**: 
-             - Score ≥ 9: "Assigning to @copilot" + use both `update_project` and `assign_to_agent` tools
-             - Score 5-8: "Needs clarification: [specific questions]" + use `update_project` tool only
+             - Score ≥ 9: "Assigning to @copilot" + use both `update_project` (with `project: "${GH_AW_EXPR_7B9A5317}"`) and `assign_to_agent` tools
+             - Score 5-8: "Needs clarification: [specific questions]" + use `update_project` tool only (with `project: "${GH_AW_EXPR_7B9A5317}"`)
              - Score < 5: "Requires human review: [reasons]" + no tool calls
           
           ## Notes

--- a/.github/workflows/ai-triage-campaign.md
+++ b/.github/workflows/ai-triage-campaign.md
@@ -73,7 +73,7 @@ You are an AI-focused issue triage bot. Analyze issues for AI agent suitability 
 
 ## Project Board Fields
 
-For each issue with score ≥ 5, use the `update_project` tool to set these fields:
+For each issue with score ≥ 5, use the `update_project` tool with `project: "${{ github.event.inputs.project_url }}"` to set these fields:
 
 | Field | Values |
 |-------|--------|
@@ -94,8 +94,8 @@ For each issue:
 1. **Assessment**: Why is this suitable/unsuitable for AI? (1-2 sentences)
 2. **Scores**: AI-Readiness, Status, Effort, Type, Priority with brief rationale
 3. **Decision**: 
-   - Score ≥ 9: "Assigning to @copilot" + use both `update_project` and `assign_to_agent` tools
-   - Score 5-8: "Needs clarification: [specific questions]" + use `update_project` tool only
+   - Score ≥ 9: "Assigning to @copilot" + use both `update_project` (with `project: "${{ github.event.inputs.project_url }}"`) and `assign_to_agent` tools
+   - Score 5-8: "Needs clarification: [specific questions]" + use `update_project` tool only (with `project: "${{ github.event.inputs.project_url }}"`)
    - Score < 5: "Requires human review: [reasons]" + no tool calls
 
 ## Notes


### PR DESCRIPTION
- Updates **AI Triage campaign** for `project` parameter to be set using the appropriate GitHub expression when updating project board fields for issues with a score ≥ 5.