### PR TITLE
fix: firewall log parser incorrectly skipping blocked requests

### DIFF
--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -3933,67 +3933,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/changeset.lock.yml
+++ b/.github/workflows/changeset.lock.yml
@@ -4708,67 +4708,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/cli-consistency-checker.lock.yml
+++ b/.github/workflows/cli-consistency-checker.lock.yml
@@ -3995,67 +3995,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/cli-version-checker.lock.yml
+++ b/.github/workflows/cli-version-checker.lock.yml
@@ -4323,67 +4323,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/copilot-pr-nlp-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-nlp-analysis.lock.yml
@@ -5388,67 +5388,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/copilot-pr-prompt-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-prompt-analysis.lock.yml
@@ -4558,67 +4558,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/daily-news.lock.yml
+++ b/.github/workflows/daily-news.lock.yml
@@ -5323,67 +5323,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/daily-repo-chronicle.lock.yml
+++ b/.github/workflows/daily-repo-chronicle.lock.yml
@@ -5050,67 +5050,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/docs-noob-tester.lock.yml
+++ b/.github/workflows/docs-noob-tester.lock.yml
@@ -3994,67 +3994,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/firewall.lock.yml
+++ b/.github/workflows/firewall.lock.yml
@@ -1917,67 +1917,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/glossary-maintainer.lock.yml
+++ b/.github/workflows/glossary-maintainer.lock.yml
@@ -4960,67 +4960,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -4597,67 +4597,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/python-data-charts.lock.yml
+++ b/.github/workflows/python-data-charts.lock.yml
@@ -5694,67 +5694,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/release-highlights.lock.yml
+++ b/.github/workflows/release-highlights.lock.yml
@@ -3908,67 +3908,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/research.lock.yml
+++ b/.github/workflows/research.lock.yml
@@ -3865,67 +3865,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -4196,67 +4196,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -4986,67 +4986,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/.github/workflows/weekly-issue-summary.lock.yml
+++ b/.github/workflows/weekly-issue-summary.lock.yml
@@ -4912,67 +4912,27 @@ jobs:
 
               }
 
-              const clientIpPort = fields[1];
-
-              if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-
-                return null;
-
-              }
-
-              const domain = fields[2];
-
-              if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-
-                return null;
-
-              }
-
-              const destIpPort = fields[3];
-
-              if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-
-                return null;
-
-              }
-
-              const status = fields[6];
-
-              if (status !== "-" && !/^\d+$/.test(status)) {
-
-                return null;
-
-              }
-
-              const decision = fields[7];
-
-              if (decision !== "-" && !decision.includes(":")) {
-
-                return null;
-
-              }
-
               return {
 
-                timestamp: timestamp,
+                timestamp,
 
-                clientIpPort: clientIpPort,
+                clientIpPort: fields[1],
 
-                domain: domain,
+                domain: fields[2],
 
-                destIpPort: destIpPort,
+                destIpPort: fields[3],
 
                 proto: fields[4],
 
                 method: fields[5],
 
-                status: status,
+                status: fields[6],
 
-                decision: decision,
+                decision: fields[7],
 
                 url: fields[8],
 
-                userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+                userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
 
               };
 

--- a/pkg/workflow/js/parse_firewall_logs.cjs
+++ b/pkg/workflow/js/parse_firewall_logs.cjs
@@ -111,58 +111,27 @@ function parseFirewallLogLine(line) {
 
   // Split by whitespace but preserve quoted strings
   const fields = trimmed.match(/(?:[^\s"]+|"[^"]*")+/g);
-
   if (!fields || fields.length < 10) {
     return null;
   }
 
-  // Validate timestamp format (should be numeric with optional decimal point)
+  // Only validate timestamp (essential for log format detection)
   const timestamp = fields[0];
   if (!/^\d+(\.\d+)?$/.test(timestamp)) {
     return null;
   }
 
-  // Validate client IP:port format (should be IP:port or "-")
-  const clientIpPort = fields[1];
-  if (clientIpPort !== "-" && !/^[\d.]+:\d+$/.test(clientIpPort)) {
-    return null;
-  }
-
-  // Validate domain format (should be domain:port or "-")
-  const domain = fields[2];
-  if (domain !== "-" && !/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*:\d+$/.test(domain)) {
-    return null;
-  }
-
-  // Validate dest IP:port format (should be IP:port or "-")
-  const destIpPort = fields[3];
-  if (destIpPort !== "-" && !/^[\d.]+:\d+$/.test(destIpPort)) {
-    return null;
-  }
-
-  // Validate status code (should be numeric or "-")
-  const status = fields[6];
-  if (status !== "-" && !/^\d+$/.test(status)) {
-    return null;
-  }
-
-  // Validate decision format (should contain ":" or be "-")
-  const decision = fields[7];
-  if (decision !== "-" && !decision.includes(":")) {
-    return null;
-  }
-
   return {
-    timestamp: timestamp,
-    clientIpPort: clientIpPort,
-    domain: domain,
-    destIpPort: destIpPort,
+    timestamp,
+    clientIpPort: fields[1],
+    domain: fields[2],
+    destIpPort: fields[3],
     proto: fields[4],
     method: fields[5],
-    status: status,
-    decision: decision,
+    status: fields[6],
+    decision: fields[7],
     url: fields[8],
-    userAgent: fields[9] ? fields[9].replace(/^"|"$/g, "") : "-",
+    userAgent: fields[9]?.replace(/^"|"$/g, "") || "-",
   };
 }
 

--- a/pkg/workflow/js/parse_firewall_logs.test.cjs
+++ b/pkg/workflow/js/parse_firewall_logs.test.cjs
@@ -71,20 +71,22 @@ describe("parse_firewall_logs.cjs", () => {
       ).toBeNull();
     });
 
-    test("should return null for invalid client IP:port format", () => {
-      expect(
-        parseFirewallLogLine(
-          '1761332530.474 Accepting api.github.com:443 140.82.112.22:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
-        )
-      ).toBeNull();
+    test("should parse line with non-standard client IP:port format", () => {
+      const result = parseFirewallLogLine(
+        '1761332530.474 Accepting api.github.com:443 140.82.112.22:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
+      );
+      expect(result).not.toBeNull();
+      expect(result.clientIpPort).toBe("Accepting");
+      expect(result.domain).toBe("api.github.com:443");
     });
 
-    test("should return null for invalid domain format", () => {
-      expect(
-        parseFirewallLogLine(
-          '1761332530.474 172.30.0.20:35288 DNS 140.82.112.22:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
-        )
-      ).toBeNull();
+    test("should parse line with non-standard domain format", () => {
+      const result = parseFirewallLogLine(
+        '1761332530.474 172.30.0.20:35288 DNS 140.82.112.22:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
+      );
+      expect(result).not.toBeNull();
+      expect(result.domain).toBe("DNS");
+      expect(result.clientIpPort).toBe("172.30.0.20:35288");
     });
 
     test("should return null for lines with fewer than 10 fields", () => {
@@ -93,36 +95,40 @@ describe("parse_firewall_logs.cjs", () => {
       expect(parseFirewallLogLine("Accepting connection")).toBeNull();
     });
 
-    test("should return null for invalid dest IP:port format", () => {
-      expect(
-        parseFirewallLogLine(
-          '1761332530.474 172.30.0.20:35288 api.github.com:443 Local 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
-        )
-      ).toBeNull();
+    test("should parse line with non-standard dest IP:port format", () => {
+      const result = parseFirewallLogLine(
+        '1761332530.474 172.30.0.20:35288 api.github.com:443 Local 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
+      );
+      expect(result).not.toBeNull();
+      expect(result.destIpPort).toBe("Local");
+      expect(result.domain).toBe("api.github.com:443");
     });
 
-    test("should return null for invalid status code", () => {
-      expect(
-        parseFirewallLogLine(
-          '1761332530.474 172.30.0.20:35288 api.github.com:443 140.82.112.22:443 1.1 CONNECT Swap TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
-        )
-      ).toBeNull();
+    test("should parse line with non-numeric status code", () => {
+      const result = parseFirewallLogLine(
+        '1761332530.474 172.30.0.20:35288 api.github.com:443 140.82.112.22:443 1.1 CONNECT Swap TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
+      );
+      expect(result).not.toBeNull();
+      expect(result.status).toBe("Swap");
+      expect(result.decision).toBe("TCP_TUNNEL:HIER_DIRECT");
     });
 
-    test("should return null for invalid decision format", () => {
-      expect(
-        parseFirewallLogLine(
-          '1761332530.474 172.30.0.20:35288 api.github.com:443 140.82.112.22:443 1.1 CONNECT 200 Waiting api.github.com:443 "-"'
-        )
-      ).toBeNull();
+    test("should parse line with non-standard decision format", () => {
+      const result = parseFirewallLogLine(
+        '1761332530.474 172.30.0.20:35288 api.github.com:443 140.82.112.22:443 1.1 CONNECT 200 Waiting api.github.com:443 "-"'
+      );
+      expect(result).not.toBeNull();
+      expect(result.decision).toBe("Waiting");
+      expect(result.status).toBe("200");
     });
 
-    test("should return null for line with pipe character in domain position", () => {
-      expect(
-        parseFirewallLogLine(
-          '1761332530.474 172.30.0.20:35288 pinger|test 140.82.112.22:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
-        )
-      ).toBeNull();
+    test("should parse line with pipe character in domain position", () => {
+      const result = parseFirewallLogLine(
+        '1761332530.474 172.30.0.20:35288 pinger|test 140.82.112.22:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT api.github.com:443 "-"'
+      );
+      expect(result).not.toBeNull();
+      expect(result.domain).toBe("pinger|test");
+      expect(result.decision).toBe("TCP_TUNNEL:HIER_DIRECT");
     });
   });
 


### PR DESCRIPTION
## Problem

The firewall log parser was silently skipping all blocked requests, causing job summaries to show "No blocked requests detected" even when the firewall was actively blocking domains.

**Root cause**: The `parseFirewallLogLine()` function used overly-strict regex validation that rejected valid Squid log entries for blocked requests. Specifically, blocked requests have `-:-` in the `destIpPort` field (no backend resolved), but the regex only accepted `-` or `IP:port` format.

## Evidence

From the firewall escape test run (https://github.com/githubnext/gh-aw/actions/runs/19682136498):
- Squid access.log showed multiple blocked requests (example.com, google.com, amazon.com, microsoft.com)
- All had `403 TCP_DENIED` status with `-:-` in destIpPort field
- Job summary incorrectly reported: "✅ No blocked requests detected"

## Solution

Simplified `parseFirewallLogLine()` by removing fragile regex validations:
- Now only validates timestamp (essential for log format detection)
- Relies on `isRequestAllowed()` for robust classification logic
- The permissive parsing is safe because `isRequestAllowed()` defaults to "denied" for unknown patterns

## Impact

- **Before**: Job summaries always showed "No blocked requests detected" even when firewall was blocking domains
- **After**: Blocked domains are correctly detected and reported in job summaries
- **Code change**: -751 lines of fragile validation code

## Testing

Verified both formats parse correctly:
- ✅ Allowed: `1764100122.567 172.30.0.20:36586 api.github.com:443 140.82.116.6:443 1.1 CONNECT 200 TCP_TUNNEL:HIER_DIRECT`
- ✅ Blocked: `1764100149.267 172.30.0.20:35642 example.com:443 -:- 1.1 CONNECT 403 TCP_DENIED:HIER_NONE`

Reviewed by subagent - confirmed changes are correct and safe.

## Files Changed

- `pkg/workflow/js/parse_firewall_logs.cjs` (source)
- 18 auto-generated `.lock.yml` workflow files

Fixes the issue discovered in #4769