### PR TITLE
fix the bug where not all workspace is uploaded as squid logs

### DIFF
--- a/.changeset/patch-fix-squid-logs-upload.md
+++ b/.changeset/patch-fix-squid-logs-upload.md
@@ -1,0 +1,7 @@
+---
+"gh-aw": patch
+---
+
+Fix bug where not all workspace files were uploaded as squid logs.
+
+Signed-off-by: Mossaka

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -3590,7 +3590,7 @@ jobs:
 
           # Move preserved agent logs to expected location
           # Try new naming convention first (awf-agent-logs-*), fall back to legacy (copilot-logs-*) for backward compatibility
-          AGENT_LOGS_DIR="$(find /tmp -maxdepth 1 -type d \( -name 'awf-agent-logs-*' -o -name 'copilot-logs-*' \) -print0 2>/dev/null | xargs -0 ls -td 2>/dev/null | head -1)"
+          AGENT_LOGS_DIR="$(find /tmp -maxdepth 1 -type d \( -name 'awf-agent-logs-*' -o -name 'copilot-logs-*' \) -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)"
           if [ -n "$AGENT_LOGS_DIR" ] && [ -d "$AGENT_LOGS_DIR" ]; then
             echo "Moving agent logs from $AGENT_LOGS_DIR to /tmp/gh-aw/.agent/logs/"
             sudo mkdir -p /tmp/gh-aw/.agent/logs/
@@ -5901,8 +5901,12 @@ jobs:
       - name: Agent Firewall logs
         if: always()
         run: |
-          # Squid logs are preserved in timestamped directories
-          SQUID_LOGS_DIR="$(find /tmp -maxdepth 1 -type d -name 'squid-logs-*' -print0 2>/dev/null | xargs -0 ls -td 2>/dev/null | head -1)"
+          # First try preserved logs (from normal AWF cleanup)
+          SQUID_LOGS_DIR="$(find /tmp -maxdepth 1 -type d -name 'squid-logs-*' -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)"
+          # Fallback: try original AWF location (for timeout/crash cases where cleanup didn't run)
+          if [ -z "$SQUID_LOGS_DIR" ]; then
+            SQUID_LOGS_DIR="$(find /tmp -maxdepth 2 -type d -path '/tmp/awf-*/squid-logs' -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)"
+          fi
           if [ -n "$SQUID_LOGS_DIR" ] && [ -d "$SQUID_LOGS_DIR" ]; then
             echo "Found Squid logs at: $SQUID_LOGS_DIR"
             mkdir -p /tmp/gh-aw/squid-logs-smoke-copilot/

--- a/pkg/workflow/copilot_engine.go
+++ b/pkg/workflow/copilot_engine.go
@@ -331,7 +331,7 @@ sudo -E awf %s \
 
 # Move preserved agent logs to expected location
 # Try new naming convention first (awf-agent-logs-*), fall back to legacy (copilot-logs-*) for backward compatibility
-AGENT_LOGS_DIR="$(find /tmp -maxdepth 1 -type d \( -name 'awf-agent-logs-*' -o -name 'copilot-logs-*' \) -print0 2>/dev/null | xargs -0 ls -td 2>/dev/null | head -1)"
+AGENT_LOGS_DIR="$(find /tmp -maxdepth 1 -type d \( -name 'awf-agent-logs-*' -o -name 'copilot-logs-*' \) -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)"
 if [ -n "$AGENT_LOGS_DIR" ] && [ -d "$AGENT_LOGS_DIR" ]; then
   echo "Moving agent logs from $AGENT_LOGS_DIR to %s"
   sudo mkdir -p %s
@@ -1121,7 +1121,7 @@ SRT_WRAPPER_EOF
 node ./.srt-wrapper.js 2>&1 | tee %s
 
 # Move preserved Copilot logs to expected location
-COPILOT_LOGS_DIR="$(find /tmp -maxdepth 1 -type d -name 'copilot-logs-*' -print0 2>/dev/null | xargs -0 ls -td 2>/dev/null | head -1)"
+COPILOT_LOGS_DIR="$(find /tmp -maxdepth 1 -type d -name 'copilot-logs-*' -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)"
 if [ -n "$COPILOT_LOGS_DIR" ] && [ -d "$COPILOT_LOGS_DIR" ]; then
   echo "Moving Copilot logs from $COPILOT_LOGS_DIR to %s"
   mkdir -p %s
@@ -1141,8 +1141,12 @@ func generateSquidLogsCollectionStep(workflowName string) GitHubActionStep {
 		"      - name: Agent Firewall logs",
 		"        if: always()",
 		"        run: |",
-		"          # Squid logs are preserved in timestamped directories",
-		"          SQUID_LOGS_DIR=\"$(find /tmp -maxdepth 1 -type d -name 'squid-logs-*' -print0 2>/dev/null | xargs -0 ls -td 2>/dev/null | head -1)\"",
+		"          # First try preserved logs (from normal AWF cleanup)",
+		"          SQUID_LOGS_DIR=\"$(find /tmp -maxdepth 1 -type d -name 'squid-logs-*' -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)\"",
+		"          # Fallback: try original AWF location (for timeout/crash cases where cleanup didn't run)",
+		"          if [ -z \"$SQUID_LOGS_DIR\" ]; then",
+		"            SQUID_LOGS_DIR=\"$(find /tmp -maxdepth 2 -type d -path '/tmp/awf-*/squid-logs' -print0 2>/dev/null | xargs -0 -r ls -td 2>/dev/null | head -1)\"",
+		"          fi",
 		"          if [ -n \"$SQUID_LOGS_DIR\" ] && [ -d \"$SQUID_LOGS_DIR\" ]; then",
 		"            echo \"Found Squid logs at: $SQUID_LOGS_DIR\"",
 		fmt.Sprintf("            mkdir -p %s", squidLogsDir),


### PR DESCRIPTION
Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>


---

## Changeset

- **Type**: patch
- **Description**: Fix bug where not all workspace files were uploaded as squid logs.

> AI generated by [Changeset Generator](https://github.com/githubnext/gh-aw/actions/runs/19849933182)

---

---

## Smoke Test Results - 2025-12-02 06:55 UTC

**Status**: PASS  
All Copilot engine tests completed successfully.

> AI generated by [Smoke Copilot No Firewall](https://github.com/githubnext/gh-aw/actions/runs/19849933176)