### PR TITLE
chore: update token and secrets docs

### DIFF
--- a/docs/src/content/docs/examples/multi-repo.md
+++ b/docs/src/content/docs/examples/multi-repo.md
@@ -26,7 +26,7 @@ All multi-repo workflows require proper authentication:
 gh auth token
 
 # Store as repository or organization secret
-gh secret set CROSS_REPO_PAT --body "ghp_your_token_here"
+gh aw secret set CROSS_REPO_PAT --value "ghp_your_token_here"
 ```
 
 The PAT needs permissions **only on target repositories** (not the source repository where the workflow runs): `repo` for private repos, `contents: write` for commits, `issues: write` for issues, and `pull-requests: write` for PRs.

--- a/docs/src/content/docs/examples/multi-repo/feature-sync.md
+++ b/docs/src/content/docs/examples/multi-repo/feature-sync.md
@@ -262,7 +262,7 @@ Cross-repo sync workflows require authentication via PAT or GitHub App.
 Create a PAT with `repo`, `contents: write`, and `pull-requests: write` permissions, then store it as a repository secret:
 
 ```bash
-gh secret set CROSS_REPO_PAT --body "ghp_your_token_here"
+gh aw secret set CROSS_REPO_PAT --value "ghp_your_token_here"
 ```
 
 ### GitHub App Configuration

--- a/docs/src/content/docs/examples/multi-repo/issue-tracking.md
+++ b/docs/src/content/docs/examples/multi-repo/issue-tracking.md
@@ -287,7 +287,7 @@ Cross-repo issue tracking requires appropriate authentication:
 
 ```bash
 # Create PAT with issues and repository read permissions
-gh secret set CROSS_REPO_PAT --body "ghp_your_token_here"
+gh aw secret set CROSS_REPO_PAT --value "ghp_your_token_here"
 ```
 
 **Required Permissions:**

--- a/docs/src/content/docs/guides/siderepoops.md
+++ b/docs/src/content/docs/guides/siderepoops.md
@@ -54,7 +54,7 @@ Create a [fine-grained PAT](https://github.com/settings/personal-access-tokens/n
 For classic PATs, use the `repo` scope. Store the token as a secret:
 
 ```bash
-gh secret set MAIN_REPO_PAT -a actions --body "YOUR_PAT_HERE"
+gh aw secret set MAIN_REPO_PAT --value "YOUR_PAT_HERE"
 ```
 
 :::tip[Security Best Practice]

--- a/docs/src/content/docs/guides/web-search.md
+++ b/docs/src/content/docs/guides/web-search.md
@@ -34,7 +34,7 @@ Use the tavily search tool to find recent information.
 **Setup:**
 1. Sign up at [tavily.com](https://tavily.com/)
 2. Get your API key from the dashboard
-3. Add as repository secret: `gh secret set TAVILY_API_KEY -a actions --body "<your-api-key>"`
+3. Add as repository secret: `gh aw secret set TAVILY_API_KEY --value "<your-api-key>"`
 
 **Terms of Service:** [Tavily Terms](https://tavily.com/terms)
 

--- a/docs/src/content/docs/reference/engines.md
+++ b/docs/src/content/docs/reference/engines.md
@@ -56,7 +56,7 @@ To use the Copilot engine, you need a fine-grained Personal Access Token with th
 6. Add the token to your repository secrets as `COPILOT_GITHUB_TOKEN`:
 
 ```bash wrap
-gh secret set COPILOT_GITHUB_TOKEN -a actions --body "<your-github-pat>"
+gh aw secret set COPILOT_GITHUB_TOKEN --value "<your-github-pat>"
 ```
 
 :::caution[Legacy Tokens Removed]
@@ -68,7 +68,7 @@ The legacy secret name `GH_AW_GITHUB_TOKEN` is still supported for backward comp
 For GitHub Tools Remote Mode, also configure:
 
 ```bash wrap
-gh secret set GH_AW_GITHUB_TOKEN -a actions --body "<your-github-pat>"
+gh aw secret set GH_AW_GITHUB_TOKEN --value "<your-github-pat>"
 ```
 
 For more information about GitHub Copilot CLI authentication, see the [official documentation](https://github.com/github/copilot-cli?tab=readme-ov-file#authenticate-with-a-personal-access-token-pat).

--- a/docs/src/content/docs/reference/tokens.md
+++ b/docs/src/content/docs/reference/tokens.md
@@ -19,15 +19,22 @@ For GitHub Agentic Workflows, you only need to create a few **optional** secrets
 | Assigning agents/bots to issues or pull requests     | `GH_AW_AGENT_TOKEN`                    | Used by `assign-to-agent` and Copilot assignee/reviewer flows. |
 | Isolating MCP server permissions (advanced optional) | `GH_AW_GITHUB_MCP_SERVER_TOKEN`        | Only if you want MCP to use a different token than other jobs. |
 
-Create these as **repository or organization secrets in *your* repo**, for example with the GitHub CLI:
+Create these as **repository secrets in *your* repo**. The easiest way is to use the GitHub Agentic Workflows CLI:
 
 ```bash
-echo "YOUR_PAT" | gh secret set GH_AW_GITHUB_TOKEN -a actions
-echo "YOUR_COPILOT_PAT" | gh secret set COPILOT_GITHUB_TOKEN -a actions
-echo "YOUR_AGENT_PAT" | gh secret set GH_AW_AGENT_TOKEN -a actions
+# Current repository
+gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_PAT"
+gh aw secret set COPILOT_GITHUB_TOKEN --value "YOUR_COPILOT_PAT"
+gh aw secret set GH_AW_AGENT_TOKEN --value "YOUR_AGENT_PAT"
 ```
 
 After these are set, gh-aw will automatically pick the right token for each operation; you should not need per-workflow PATs in most cases.
+
+### CLI helpers for tokens and secrets
+
+- `gh aw tokens bootstrap` – checks which recommended token secrets (like `GH_AW_GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`) exist in a repository and prints suggested scopes plus copy‑pasteable `gh aw secret set` commands.
+- `gh aw init --tokens --engine <engine>` – runs token checks as part of repository initialization for a specific engine (`copilot`, `claude`, `codex`).
+- `gh aw secret set <NAME>` – creates or updates a repository secret. Values can come from `--value`, `--value-from-env`, or stdin (for example, `echo "PAT" | gh aw secret set NAME`).
 
 ### Security and scopes (least privilege)
 
@@ -109,7 +116,7 @@ A fine-grained or classic Personal Access Token providing enhanced capabilities 
 2. Add to repository secrets:
 
 ```bash wrap
-gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_PAT"
+gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_PAT"
 ```
 
 **Token precedence** (highest to lowest):
@@ -117,7 +124,7 @@ gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_PAT"
 1. Per-output `github-token:` (safe output level)
 2. Global `safe-outputs.github-token:` (all outputs)
 3. Workflow-level `github-token:` frontmatter (top-level)
-4. Default fallback: `${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`
+4. Default fallback: `${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`
 
 **Example**:
 
@@ -146,7 +153,7 @@ A specialized token for the GitHub MCP server that takes precedence over the sta
 **Setup**:
 
 ```bash wrap
-gh secret set GH_AW_GITHUB_MCP_SERVER_TOKEN -a actions --body "YOUR_PAT"
+gh aw secret set GH_AW_GITHUB_MCP_SERVER_TOKEN --value "YOUR_PAT"
 ```
 
 **Token precedence** for GitHub MCP server (highest to lowest):
@@ -196,7 +203,7 @@ The recommended token for all Copilot-related operations including the Copilot e
 2. Add to repository secrets:
 
 ```bash wrap
-gh secret set COPILOT_GITHUB_TOKEN -a actions --body "YOUR_COPILOT_PAT"
+gh aw secret set COPILOT_GITHUB_TOKEN --value "YOUR_COPILOT_PAT"
 ```
 
 **Copilot token precedence** (highest to lowest):
@@ -239,7 +246,7 @@ Specialized token for `assign-to-agent:` safe outputs that assign GitHub Copilot
 2. Add to repository secrets:
 
 ```bash wrap
-gh secret set GH_AW_AGENT_TOKEN -a actions --body "YOUR_AGENT_PAT"
+gh aw secret set GH_AW_AGENT_TOKEN --value "YOUR_AGENT_PAT"
 ```
 
 **Token precedence** (highest to lowest):
@@ -596,15 +603,15 @@ safe-outputs:
 
 1. **For cross-repository operations**: Configure `GH_AW_GITHUB_TOKEN` with access to the target repository:
 
-   ```bash wrap
-   gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_PAT"
-   ```
+  ```bash wrap
+  gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_PAT"
+  ```
 
 2. **For bot operations**: Use `COPILOT_GITHUB_TOKEN` with "Copilot Requests" permission:
 
-   ```bash wrap
-   gh secret set COPILOT_GITHUB_TOKEN -a actions --body "YOUR_COPILOT_PAT"
-   ```
+  ```bash wrap
+  gh aw secret set COPILOT_GITHUB_TOKEN --value "YOUR_COPILOT_PAT"
+  ```
 
 3. **Check token permissions**: Verify your PAT has the required scopes:
    - Issues: Read+Write for issue operations
@@ -633,9 +640,9 @@ safe-outputs:
 
 3. Set or update the secret:
 
-   ```bash wrap
-   gh secret set COPILOT_GITHUB_TOKEN -a actions --body "YOUR_PAT"
-   ```
+  ```bash wrap
+  gh aw secret set COPILOT_GITHUB_TOKEN --value "YOUR_PAT"
+  ```
 
 ### Remote GitHub Tools Failures
 
@@ -648,7 +655,7 @@ safe-outputs:
 **Option 1**: Add token (recommended for remote mode):
 
 ```bash wrap
-gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_PAT"
+gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_PAT"
 ```
 
 **Option 2**: Switch to local mode (uses Docker):
@@ -675,9 +682,9 @@ tools:
 
 2. Add to secrets:
 
-   ```bash wrap
-   gh secret set GH_AW_AGENT_TOKEN -a actions --body "YOUR_AGENT_PAT"
-   ```
+  ```bash wrap
+  gh aw secret set GH_AW_AGENT_TOKEN --value "YOUR_AGENT_PAT"
+  ```
 
 ### Token Not Being Used
 
@@ -720,14 +727,14 @@ tools:
 **Good practice**: Use one general-purpose PAT for multiple workflows with similar permissions:
 
 ```bash wrap
-gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_PAT"
+gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_PAT"
 ```
 
 **Better practice**: Use different tokens for different permission levels:
 
 ```bash wrap
-gh secret set READ_ONLY_TOKEN -a actions --body "YOUR_READ_PAT"
-gh secret set READ_WRITE_TOKEN -a actions --body "YOUR_WRITE_PAT"
+gh aw secret set READ_ONLY_TOKEN --value "YOUR_READ_PAT"
+gh aw secret set READ_WRITE_TOKEN --value "YOUR_WRITE_PAT"
 ```
 
 **Best practice**: Use GitHub Apps with automatic permission management.
@@ -744,9 +751,9 @@ gh secret set READ_WRITE_TOKEN -a actions --body "YOUR_WRITE_PAT"
 2. Regenerate or create new PAT
 3. Update secret:
 
-   ```bash wrap
-   gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_NEW_PAT"
-   ```
+  ```bash wrap
+  gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_NEW_PAT"
+  ```
 
 4. Consider shorter expiration periods with regular rotation schedule
 
@@ -767,19 +774,19 @@ gh secret set READ_WRITE_TOKEN -a actions --body "YOUR_WRITE_PAT"
 ### Token Setup Commands
 
 ```bash wrap
-# Enhanced GitHub token (most common)
-gh secret set GH_AW_GITHUB_TOKEN -a actions --body "YOUR_PAT"
+# Enhanced GitHub token (most common, current repository)
+gh aw secret set GH_AW_GITHUB_TOKEN --value "YOUR_PAT"
 
 # Copilot operations
-gh secret set COPILOT_GITHUB_TOKEN -a actions --body "YOUR_COPILOT_PAT"
+gh aw secret set COPILOT_GITHUB_TOKEN --value "YOUR_COPILOT_PAT"
 
 # Agent assignments
-gh secret set GH_AW_AGENT_TOKEN -a actions --body "YOUR_AGENT_PAT"
+gh aw secret set GH_AW_AGENT_TOKEN --value "YOUR_AGENT_PAT"
 
 # Custom MCP server token (optional)
-gh secret set GH_AW_GITHUB_MCP_SERVER_TOKEN -a actions --body "YOUR_PAT"
+gh aw secret set GH_AW_GITHUB_MCP_SERVER_TOKEN --value "YOUR_PAT"
 
-# List configured secrets
+# List configured secrets (GitHub CLI)
 gh secret list -a actions
 ```
 
@@ -790,7 +797,7 @@ gh secret list -a actions
 1. Per-output `github-token:` (highest)
 2. Global `safe-outputs.github-token:`
 3. Workflow-level `github-token:`
-4. `secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN` (lowest)
+4. `secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN` (lowest)
 
 **For Copilot operations** (create-agent-task, copilot assignee/reviewer):
 
@@ -836,7 +843,7 @@ The `COPILOT_CLI_TOKEN` and `GH_AW_COPILOT_TOKEN` secrets are **no longer suppor
 
 ```bash wrap
 # Add new secret
-gh secret set COPILOT_GITHUB_TOKEN -a actions --body "<your-github-pat>"
+gh aw secret set COPILOT_GITHUB_TOKEN --value "<your-github-pat>"
 ```
 
 :::
@@ -849,7 +856,7 @@ gh secret remove GH_AW_COPILOT_TOKEN -a actions
 gh secret remove COPILOT_CLI_TOKEN -a actions
 
 # Add new secret
-gh secret set COPILOT_GITHUB_TOKEN -a actions --body "YOUR_PAT"
+gh aw secret set COPILOT_GITHUB_TOKEN --value "YOUR_PAT"
 ```
 
 ## Related Documentation

--- a/docs/src/content/docs/reference/tools.md
+++ b/docs/src/content/docs/reference/tools.md
@@ -123,7 +123,7 @@ tools:
     mode: remote  # Default is "local" (Docker)
 ```
 
-Setup: `gh secret set GH_AW_GITHUB_TOKEN -a actions --body "<your-pat>"`
+Setup: `gh aw secret set GH_AW_GITHUB_TOKEN --value "<your-pat>"`
 
 **Read-Only Mode**: Restrict to read-only operations (default behavior unless write operations configured):
 


### PR DESCRIPTION
- Updated GitHub token docs to describe the new gh aw-based secrets workflow, including `gh aw secret set`, `gh aw tokens bootstrap`, and `gh aw init --tokens --engine <engine>`.
- Replaced all remaining `gh secret set ...` examples across reference, guides, and examples with `gh aw secret set … --value …`.
- Aligned documented token precedence (especially safe-outputs default fallback) with the actual implementation, including the `GH_AW_GITHUB_MCP_SERVER_TOKEN || GH_AW_GITHUB_TOKEN || GITHUB_TOKEN` chain.

/cc @pelikhan 