### PR TITLE
Fix Copilot Requests permissions in quick start guide

### DIFF
--- a/docs/src/content/docs/setup/quick-start.md
+++ b/docs/src/content/docs/setup/quick-start.md
@@ -108,7 +108,7 @@ Create a [Personal Access Token](/gh-aw/reference/glossary/#personal-access-toke
    - **Repository access**: "Public repositories" (required for Copilot Requests permission to appear)
 3. Add permissions:
    - In **"Account permissions"** (not Repository permissions), find **"Copilot Requests"**
-   - Set to **"Access: Read and write"**
+   - Set to **"Access: Read"**
 4. Click **"Generate token"** and copy it immediately (you won't see it again)
 
 :::tip[Can't find Copilot Requests permission?]


### PR DESCRIPTION
The Copilot Requests scope seems to only have "Read" permissions, which are sufficient to get the tutorial to work. The instructions currently say to set to "Read and write", which is confusing because the write permissions don't show up in the UI.