### PR TITLE
Revise expected output in quick-start documentation

### DIFF
--- a/docs/src/content/docs/setup/quick-start.md
+++ b/docs/src/content/docs/setup/quick-start.md
@@ -93,9 +93,11 @@ gh aw status
 **Expected output:**
 
 ```text
-Workflow                 Engine    State     Enabled  Schedule
-──────────────────────────────────────────────────────────────
-daily-team-status        copilot   ✓         Yes      0 9 * * 1-5
+┌─────────────────┬───────┬────────┬──────┬──────────────┬──────┬──────────┬──────────────┐
+│Workflow         │Engine │Compiled│Status│Time Remaining│Labels│Run Status│Run Conclusion│
+├─────────────────┼───────┼────────┼──────┼──────────────┼──────┼──────────┼──────────────┤
+│daily-team-status│copilot│No      │active│30d 22h       │-     │-         │-             │
+└─────────────────┴───────┴────────┴──────┴──────────────┴──────┴──────────┴──────────────┘
 ```
 
 This confirms the workflow is compiled, enabled, and scheduled correctly.


### PR DESCRIPTION
Updated the expected output format for workflow status.

two issues:
- the format looks quite different than in the current doc (it is a table)
- the content is different (in my example, following the description i got a cron job which is sheduled at the time, i created the action

I will create also a issue for this, because the semantic of the cron job is quite different (using actual time insteadof 9am for weekdays)