### PR TITLE
Add Claude AI and GitHub Copilot as authors across multiple blog posts

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,13 +10,13 @@ import { fileURLToPath } from 'node:url';
 
 /**
  * Creates blog authors config with GitHub profile pictures
- * @param {Record<string, {name: string, url: string}>} authors
+ * @param {Record<string, {name: string, url: string, picture?: string}>} authors
  */
 function createAuthors(authors) {
 	return Object.fromEntries(
 		Object.entries(authors).map(([key, author]) => [
 			key,
-			{ ...author, picture: `https://github.com/${key}.png?size=200` }
+			{ ...author, picture: author.picture ?? `https://github.com/${key}.png?size=200` }
 		])
 	);
 }
@@ -102,6 +102,15 @@ export default defineConfig({
 						'mnkiefer': {
 							name: 'Mara Kiefer',
 							url: 'https://github.com/mnkiefer',
+						},
+						'claude': {
+							name: 'Claude AI',
+							url: 'https://claude.ai',
+						},
+						'copilot': {
+							name: 'GitHub Copilot',
+							url: 'https://github.com/features/copilot',
+							picture: 'https://avatars.githubusercontent.com/in/1143301?s=64&amp;v=4',
 						},
 					}),
 				}),

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-advanced-analytics.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-advanced-analytics.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T15:00:00
 sidebar:
   label: "Advanced Analytics & ML"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-campaigns.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-campaigns.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T16:00:00
 sidebar:
   label: "Campaigns & Projects"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-code-quality.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-code-quality.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T02:00:00
 sidebar:
   label: "Code Quality & Refactoring"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-creative-culture.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-creative-culture.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T09:00:00
 sidebar:
   label: "Teamwork & Culture"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-documentation.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-documentation.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T03:00:00
 sidebar:
   label: "Documentation & Content"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-interactive-chatops.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-interactive-chatops.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T10:00:00
 sidebar:
   label: "Interactive & ChatOps"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-issue-management.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-issue-management.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T04:00:00
 sidebar:
   label: "Issue & PR Management"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-metrics-analytics.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-metrics-analytics.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T06:00:00
 sidebar:
   label: "Metrics & Analytics"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-multi-phase.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-multi-phase.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T13:00:00
 sidebar:
   label: "Multi-Phase Improvers"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-operations-release.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-operations-release.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T07:00:00
 sidebar:
   label: "Operations & Release"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-organization.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-organization.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T14:00:00
 sidebar:
   label: "Organization & Cross-Repo"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-quality-hygiene.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-quality-hygiene.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T05:00:00
 sidebar:
   label: "Fault Investigation"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-security-compliance.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-security-compliance.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T08:00:00
 sidebar:
   label: "Security-related"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-testing-validation.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-testing-validation.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T11:00:00
 sidebar:
   label: "Testing & Validation"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-tool-infrastructure.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows-tool-infrastructure.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T12:00:00
 sidebar:
   label: "Tool & Infrastructure"

--- a/docs/src/content/docs/blog/2026-01-13-meet-the-workflows.md
+++ b/docs/src/content/docs/blog/2026-01-13-meet-the-workflows.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-13T01:00:00
 sidebar:
   label: "Issue Triage"

--- a/docs/src/content/docs/blog/2026-01-21-twelve-lessons.md
+++ b/docs/src/content/docs/blog/2026-01-21-twelve-lessons.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-21
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-01-24-design-patterns.md
+++ b/docs/src/content/docs/blog/2026-01-24-design-patterns.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-24
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-01-27-operational-patterns.md
+++ b/docs/src/content/docs/blog/2026-01-27-operational-patterns.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-27
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-01-30-imports-and-sharing.md
+++ b/docs/src/content/docs/blog/2026-01-30-imports-and-sharing.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-01-30
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-02-02-security-lessons.md
+++ b/docs/src/content/docs/blog/2026-02-02-security-lessons.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-02-02
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-02-05-how-workflows-work.md
+++ b/docs/src/content/docs/blog/2026-02-05-how-workflows-work.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-02-05
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-02-08-authoring-workflows.md
+++ b/docs/src/content/docs/blog/2026-02-08-authoring-workflows.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-02-08
 draft: true
 prev:

--- a/docs/src/content/docs/blog/2026-02-11-getting-started.md
+++ b/docs/src/content/docs/blog/2026-02-11-getting-started.md
@@ -5,6 +5,8 @@ authors:
   - dsyme
   - pelikhan
   - mnkiefer
+  - claude
+  - copilot
 date: 2026-02-11
 draft: true
 prev:


### PR DESCRIPTION
- Updates the blog authors configuration and adds two new authors, "Claude AI" and "GitHub Copilot," to all blog post metadata in the documentation.
- Improves the handling of author profile pictures to support custom images.