### PR TITLE
chore: clean campaign generation

### DIFF
--- a/.github/aw/generate-agentic-campaign.md
+++ b/.github/aw/generate-agentic-campaign.md
@@ -91,7 +91,7 @@ allowed-safe-outputs: [create-issue, add-comment]
 safe-outputs:
   create-project:
     max: 1
-    github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
+    github-token: "<GH_AW_PROJECT_GITHUB_TOKEN>"  # Provide via workflow secret/env; avoid secrets expressions in runtime-import files
     target-owner: "${{ github.repository_owner }}"
     views:  # Views are created automatically when project is created
       - name: "Campaign Roadmap"
@@ -105,7 +105,7 @@ safe-outputs:
         filter: "is:issue is:pr"
   update-project:
     max: 10
-    github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
+    github-token: "<GH_AW_PROJECT_GITHUB_TOKEN>"  # Provide via workflow secret/env; avoid secrets expressions in runtime-import files
   update-issue:
   assign-to-agent:
 ```

--- a/.github/workflows/agentic-campaign-generator.lock.yml
+++ b/.github/workflows/agentic-campaign-generator.lock.yml
@@ -19,7 +19,7 @@
 #   gh aw compile
 # For more information: https://github.com/githubnext/gh-aw/blob/main/.github/aw/github-agentic-workflows.md
 #
-# Agentic Campaign generator that creates project board, discovers workflows, generates campaign spec, and assigns to Copilot agent for compilation
+# Agentic Campaign generator that discovers workflows, generates a campaign spec and a project board, and assigns to Copilot agent for compilation
 
 name: "Agentic Campaign Generator"
 "on":
@@ -83,7 +83,7 @@ jobs:
         env:
           GH_AW_WORKFLOW_NAME: "Agentic Campaign Generator"
           GH_AW_LOCK_FOR_AGENT: "true"
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator starting! [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete! [{workflow_name}]({run_url}) has successfully coordinated your campaign creation. Your project is ready!\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again...\"}"
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator started: [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete: This issue has been assigned to Copilot Coding Agent to compile the campaign and create a PR.\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again.\"}"
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -197,31 +197,10 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'EOF'
-          {"add_comment":{"max":10},"assign_to_agent":{},"create_project":{"max":1,"target_owner":"${{ github.repository_owner }}"},"missing_data":{},"missing_tool":{},"noop":{"max":1},"update_issue":{"max":1},"update_project":{"max":10}}
+          {"assign_to_agent":{},"create_project":{"max":1,"target_owner":"${{ github.repository_owner }}"},"missing_data":{},"missing_tool":{},"noop":{"max":1},"update_issue":{"max":1},"update_project":{"max":10}}
           EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'EOF'
           [
-            {
-              "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. CONSTRAINTS: Maximum 10 comment(s) can be added.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "The comment text in Markdown format. This is the 'body' field - do not use 'comment_body' or other variations. Provide helpful, relevant information that adds value to the conversation.",
-                    "type": "string"
-                  },
-                  "item_number": {
-                    "description": "The issue, pull request, or discussion number to comment on. This is the numeric ID from the GitHub URL (e.g., 123 in github.com/owner/repo/issues/123). If omitted, the tool will attempt to resolve the target from the current workflow context (triggering issue, PR, or discussion).",
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "add_comment"
-            },
             {
               "description": "Assign the GitHub Copilot coding agent to work on an issue or pull request. The agent will analyze the issue/PR and attempt to implement a solution, creating a pull request when complete. Use this to delegate coding tasks to Copilot. Example usage: assign_to_agent(issue_number=123, agent=\"copilot\") or assign_to_agent(pull_number=456, agent=\"copilot\")",
               "inputSchema": {
@@ -440,20 +419,6 @@ jobs:
           EOF
           cat > /opt/gh-aw/safeoutputs/validation.json << 'EOF'
           {
-            "add_comment": {
-              "defaultMax": 1,
-              "fields": {
-                "body": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
-                },
-                "item_number": {
-                  "issueOrPRNumber": true
-                }
-              }
-            },
             "assign_to_agent": {
               "defaultMax": 1,
               "fields": {
@@ -739,7 +704,7 @@ jobs:
           <instructions>
           To create or modify GitHub resources (issues, discussions, pull requests, etc.), you MUST call the appropriate safe output tool. Simply writing content will NOT work - the workflow requires actual tool calls.
           
-          **Available tools**: add_comment, assign_to_agent, create_project, missing_tool, noop, update_issue, update_project
+          **Available tools**: assign_to_agent, create_project, missing_tool, noop, update_issue, update_project
           
           **Critical**: Tool calls write structured data that downstream jobs process. Without tool calls, follow-up actions will be skipped.
           </instructions>
@@ -1103,7 +1068,7 @@ jobs:
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.agent.outputs.secret_verification_result }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator starting! [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete! [{workflow_name}]({run_url}) has successfully coordinated your campaign creation. Your project is ready!\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again...\"}"
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator started: [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete: This issue has been assigned to Copilot Coding Agent to compile the campaign and create a PR.\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again.\"}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1122,7 +1087,7 @@ jobs:
           GH_AW_WORKFLOW_NAME: "Agentic Campaign Generator"
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.result }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator starting! [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete! [{workflow_name}]({run_url}) has successfully coordinated your campaign creation. Your project is ready!\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again...\"}"
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator started: [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete: This issue has been assigned to Copilot Coding Agent to compile the campaign and create a PR.\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again.\"}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1181,7 +1146,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           WORKFLOW_NAME: "Agentic Campaign Generator"
-          WORKFLOW_DESCRIPTION: "Agentic Campaign generator that creates project board, discovers workflows, generates campaign spec, and assigns to Copilot agent for compilation"
+          WORKFLOW_DESCRIPTION: "Agentic Campaign generator that discovers workflows, generates a campaign spec and a project board, and assigns to Copilot agent for compilation"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1359,13 +1324,11 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
-      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_ENGINE_ID: "claude"
-      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator starting! [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete! [{workflow_name}]({run_url}) has successfully coordinated your campaign creation. Your project is ready!\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again...\"}"
+      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e *Campaign coordination by [{workflow_name}]({run_url})*\",\"runStarted\":\"Campaign Generator started: [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...\",\"runSuccess\":\"Campaign setup complete: This issue has been assigned to Copilot Coding Agent to compile the campaign and create a PR.\",\"runFailure\":\"Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again.\"}"
       GH_AW_WORKFLOW_ID: "agentic-campaign-generator"
       GH_AW_WORKFLOW_NAME: "Agentic Campaign Generator"
     outputs:
@@ -1410,7 +1373,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG: "{\"create_project\":{\"github-token\":\"${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}\",\"max\":1,\"target_owner\":\"${{ github.repository_owner }}\",\"views\":[{\"name\":\"Campaign Roadmap\",\"layout\":\"roadmap\",\"filter\":\"is:issue is:pr\"},{\"name\":\"Task Tracker\",\"layout\":\"table\",\"filter\":\"is:issue is:pr\"},{\"name\":\"Progress Board\",\"layout\":\"board\",\"filter\":\"is:issue is:pr\"}]},\"update_project\":{\"github-token\":\"${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}\",\"max\":10}}"
+          GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG: "{\"create_project\":{\"github-token\":\"${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}\",\"max\":1,\"target_owner\":\"${{ github.repository_owner }}\",\"views\":[{\"name\":\"Progress Board\",\"layout\":\"board\",\"filter\":\"is:issue is:pr\"},{\"name\":\"Task Tracker\",\"layout\":\"table\",\"filter\":\"is:issue is:pr\"},{\"name\":\"Campaign Roadmap\",\"layout\":\"roadmap\",\"filter\":\"is:issue is:pr\"}]},\"update_project\":{\"github-token\":\"${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}\",\"max\":10}}"
           GH_AW_PROJECT_GITHUB_TOKEN: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
@@ -1424,7 +1387,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"max\":1}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"missing_data\":{},\"missing_tool\":{},\"update_issue\":{\"max\":1}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/agentic-campaign-generator.md
+++ b/.github/workflows/agentic-campaign-generator.md
@@ -17,24 +17,12 @@ tools:
   github:
     toolsets: [default]
 safe-outputs:
-  add-comment:
-    max: 10
   update-issue:
   assign-to-agent:
   create-project:
     max: 1
     github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
     target-owner: "${{ github.repository_owner }}"
-    views:
-      - name: "Campaign Roadmap"
-        layout: "roadmap"
-        filter: "is:issue is:pr"
-      - name: "Task Tracker"
-        layout: "table"
-        filter: "is:issue is:pr"
-      - name: "Progress Board"
-        layout: "board"
-        filter: "is:issue is:pr"
   update-project:
     max: 10
     github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"

--- a/.github/workflows/agentic-campaign-generator.md
+++ b/.github/workflows/agentic-campaign-generator.md
@@ -1,6 +1,6 @@
 ---
 name: "Agentic Campaign Generator"
-description: "Agentic Campaign generator that creates project board, discovers workflows, generates campaign spec, and assigns to Copilot agent for compilation"
+description: "Agentic Campaign generator that discovers workflows, generates a campaign spec and a project board, and assigns to Copilot agent for compilation"
 on:
   issues:
     types: [labeled]
@@ -23,14 +23,27 @@ safe-outputs:
     max: 1
     github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
     target-owner: "${{ github.repository_owner }}"
+    views:
+      - name: "Progress Board"
+        layout: "board"
+        filter: "is:issue is:pr"
+      - name: "Task Tracker"
+        layout: "table"
+        filter: "is:issue is:pr"
+      - name: "Campaign Roadmap"
+        layout: "roadmap"
+        filter: "is:issue is:pr"
   update-project:
     max: 10
     github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
   messages:
     footer: "> *Campaign coordination by [{workflow_name}]({run_url})*"
-    run-started: "Campaign Generator starting! [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}..."
-    run-success: "Campaign setup complete! [{workflow_name}]({run_url}) has successfully coordinated your campaign creation. Your project is ready!"
-    run-failure: "Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again..."
+    run-started: "Campaign Generator started:
+[{workflow_name}]({run_url}) is processing your campaign request for this {event_type}..."
+    run-success: "Campaign setup complete:
+This issue has been assigned to Copilot Coding Agent to compile the campaign and create a PR."
+    run-failure: "Campaign setup interrupted!
+[{workflow_name}]({run_url}) {status}. Please check the details and try again."
 timeout-minutes: 10
 ---
 

--- a/pkg/campaign/generator.go
+++ b/pkg/campaign/generator.go
@@ -17,7 +17,7 @@ func BuildCampaignGenerator() *workflow.WorkflowData {
 
 	data := &workflow.WorkflowData{
 		Name:            "Agentic Campaign Generator",
-		Description:     "Agentic Campaign generator that creates project board, discovers workflows, generates campaign spec, and assigns to Copilot agent for compilation",
+		Description:     "Agentic Campaign generator that discovers workflows, generates a campaign spec and a project board, and assigns to Copilot agent for compilation",
 		On:              buildGeneratorTrigger(),
 		Permissions:     buildGeneratorPermissions(),
 		Concurrency:     "", // No concurrency control for this workflow
@@ -64,7 +64,6 @@ func buildGeneratorTools() map[string]any {
 // buildGeneratorSafeOutputs creates the safe-outputs configuration
 func buildGeneratorSafeOutputs() *workflow.SafeOutputsConfig {
 	return &workflow.SafeOutputsConfig{
-		AddComments:   &workflow.AddCommentsConfig{},
 		UpdateIssues:  &workflow.UpdateIssuesConfig{},
 		AssignToAgent: &workflow.AssignToAgentConfig{},
 		CreateProjects: &workflow.CreateProjectsConfig{
@@ -72,8 +71,8 @@ func buildGeneratorSafeOutputs() *workflow.SafeOutputsConfig {
 			TargetOwner: "${{ github.repository_owner }}",
 			Views: []workflow.ProjectView{
 				{
-					Name:   "Campaign Roadmap",
-					Layout: "roadmap",
+					Name:   "Progress Board",
+					Layout: "board",
 					Filter: "is:issue is:pr",
 				},
 				{
@@ -82,8 +81,8 @@ func buildGeneratorSafeOutputs() *workflow.SafeOutputsConfig {
 					Filter: "is:issue is:pr",
 				},
 				{
-					Name:   "Progress Board",
-					Layout: "board",
+					Name:   "Campaign Roadmap",
+					Layout: "roadmap",
 					Filter: "is:issue is:pr",
 				},
 			},
@@ -93,9 +92,9 @@ func buildGeneratorSafeOutputs() *workflow.SafeOutputsConfig {
 		},
 		Messages: &workflow.SafeOutputMessagesConfig{
 			Footer:     "> *Campaign coordination by [{workflow_name}]({run_url})*",
-			RunStarted: "Campaign Generator starting! [{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...",
-			RunSuccess: "Campaign setup complete! [{workflow_name}]({run_url}) has successfully coordinated your campaign creation. Your project is ready!",
-			RunFailure: "Campaign setup interrupted! [{workflow_name}]({run_url}) {status}. Please check the details and try again...",
+			RunStarted: "Campaign Generator started:\n[{workflow_name}]({run_url}) is processing your campaign request for this {event_type}...",
+			RunSuccess: "Campaign setup complete:\nThis issue has been assigned to Copilot Coding Agent to compile the campaign and create a PR.",
+			RunFailure: "Campaign setup interrupted!\n[{workflow_name}]({run_url}) {status}. Please check the details and try again.",
 		},
 	}
 }

--- a/pkg/cli/.github/aw/imports/.gitattributes
+++ b/pkg/cli/.github/aw/imports/.gitattributes
@@ -1,0 +1,5 @@
+# Mark all cached import files as generated
+* linguist-generated=true
+
+# Use 'ours' merge strategy to keep local cached versions
+* merge=ours

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -131,11 +131,11 @@ func InitRepository(verbose bool, mcp bool, campaign bool, tokens bool, engine s
 			fn   func(bool, bool) error
 			name string
 		}{
+			{ensureCampaignGeneratorInstructions, "campaign generator instructions"},
 			{ensureCampaignOrchestratorInstructions, "campaign orchestrator instructions"},
 			{ensureCampaignProjectUpdateInstructions, "campaign project update instructions"},
 			{ensureCampaignWorkflowExecution, "campaign workflow execution"},
 			{ensureCampaignClosingInstructions, "campaign closing instructions"},
-			{ensureCampaignGeneratorInstructions, "campaign generator instructions"},
 		}
 
 		for _, item := range campaignEnsureFuncs {

--- a/pkg/cli/templates/generate-agentic-campaign.md
+++ b/pkg/cli/templates/generate-agentic-campaign.md
@@ -91,9 +91,9 @@ allowed-safe-outputs: [create-issue, add-comment]
 safe-outputs:
   create-project:
     max: 1
-    github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
+    github-token: "<GH_AW_PROJECT_GITHUB_TOKEN>"
     target-owner: "${{ github.repository_owner }}"
-    views:  # Views are created automatically when project is created
+    views:
       - name: "Campaign Roadmap"
         layout: "roadmap"
         filter: "is:issue is:pr"
@@ -105,7 +105,7 @@ safe-outputs:
         filter: "is:issue is:pr"
   update-project:
     max: 10
-    github-token: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}"
+    github-token: "<GH_AW_PROJECT_GITHUB_TOKEN>"  # Provide via workflow secret/env; avoid secrets expressions in runtime-import files
   update-issue:
   assign-to-agent:
 ```


### PR DESCRIPTION
- Removed support for `add-comment` in favor of `update-issue` for status updates
- Standardize the safe outputs configuration, and clarify the order and naming of project views.