### PR TITLE
feat: support field definitions in update_project config

### DIFF
--- a/actions/setup/js/safe_outputs_tools.json
+++ b/actions/setup/js/safe_outputs_tools.json
@@ -580,12 +580,36 @@
     "description": "Add or update items in GitHub Projects v2 boards. Can add issues/PRs to a project and update custom field values. Requires the project URL, content type (issue or pull_request), and content number. Use campaign_id to group related items.",
     "inputSchema": {
       "type": "object",
-      "required": ["project", "content_type"],
+      "oneOf": [
+        {
+          "title": "Create project fields",
+          "required": ["project", "operation", "field_definitions"],
+          "properties": {
+            "operation": { "const": "create_fields" }
+          }
+        },
+        {
+          "title": "Create project view",
+          "required": ["project", "operation", "view"],
+          "properties": {
+            "operation": { "const": "create_view" }
+          }
+        },
+        {
+          "title": "Add/update project item",
+          "required": ["project", "content_type"]
+        }
+      ],
       "properties": {
         "project": {
           "type": "string",
           "pattern": "^https://github\\.com/(orgs|users)/[^/]+/projects/\\d+$",
           "description": "Full GitHub project URL (e.g., 'https://github.com/orgs/myorg/projects/42' or 'https://github.com/users/username/projects/5'). Project names or numbers alone are NOT accepted."
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["create_fields", "create_view"],
+          "description": "Optional operation mode. Use create_fields to create required campaign fields up-front, or create_view to add a project view. When omitted, the tool adds/updates project items."
         },
         "content_type": {
           "type": "string",
@@ -607,6 +631,47 @@
         "fields": {
           "type": "object",
           "description": "Custom field values to set on the project item (e.g., {'Status': 'In Progress', 'Priority': 'High'}). Field names must match custom fields defined in the project."
+        },
+        "field_definitions": {
+          "type": "array",
+          "description": "Field definitions to create when operation is create_fields.",
+          "items": {
+            "type": "object",
+            "required": ["name", "data_type"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Field name to create (e.g., 'size', 'priority')."
+              },
+              "data_type": {
+                "type": "string",
+                "enum": ["TEXT", "NUMBER", "DATE", "SINGLE_SELECT", "ITERATION"],
+                "description": "Field type. Use SINGLE_SELECT with options for enumerated values."
+              },
+              "options": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Options for SINGLE_SELECT fields."
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "view": {
+          "type": "object",
+          "description": "View definition to create when operation is create_view.",
+          "required": ["name", "layout"],
+          "properties": {
+            "name": { "type": "string" },
+            "layout": { "type": "string", "enum": ["table", "board", "roadmap"] },
+            "filter": { "type": "string" },
+            "visible_fields": {
+              "type": "array",
+              "items": { "type": "number" },
+              "description": "Field IDs to show in the view (table/board only)."
+            }
+          },
+          "additionalProperties": false
         },
         "campaign_id": {
           "type": "string",

--- a/pkg/campaign/generator.go
+++ b/pkg/campaign/generator.go
@@ -89,6 +89,43 @@ func buildGeneratorSafeOutputs() *workflow.SafeOutputsConfig {
 		},
 		UpdateProjects: &workflow.UpdateProjectConfig{
 			GitHubToken: "${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}",
+			FieldDefinitions: []workflow.ProjectFieldDefinition{
+				{
+					Name:     "status",
+					DataType: "SINGLE_SELECT",
+					Options:  []string{"Todo", "In Progress", "Review required", "Blocked", "Done"},
+				},
+				{
+					Name:     "campaign_id",
+					DataType: "TEXT",
+				},
+				{
+					Name:     "worker_workflow",
+					DataType: "TEXT",
+				},
+				{
+					Name:     "repository",
+					DataType: "TEXT",
+				},
+				{
+					Name:     "priority",
+					DataType: "SINGLE_SELECT",
+					Options:  []string{"High", "Medium", "Low"},
+				},
+				{
+					Name:     "size",
+					DataType: "SINGLE_SELECT",
+					Options:  []string{"Small", "Medium", "Large"},
+				},
+				{
+					Name:     "start_date",
+					DataType: "DATE",
+				},
+				{
+					Name:     "end_date",
+					DataType: "DATE",
+				},
+			},
 		},
 		Messages: &workflow.SafeOutputMessagesConfig{
 			Footer:     "> *Campaign coordination by [{workflow_name}]({run_url})*",

--- a/pkg/cli/templates/generate-agentic-campaign.md
+++ b/pkg/cli/templates/generate-agentic-campaign.md
@@ -19,7 +19,7 @@ When creating or modifying GitHub resources, **use MCP tool calls directly** (no
 
 1. Create GitHub Project
 2. Create views: Roadmap (roadmap), Task Tracker (table), Progress Board (board)
-3. Create required campaign project fields (see “Project Fields (Required)”) using `update_project` with `operation: "create_fields"`
+3. Ensure required campaign project fields exist (see “Project Fields (Required)”). In the default campaign generator workflow, these are configured via safe-outputs and created automatically.
 4. Parse campaign requirements from the triggering issue (available via GitHub event context)
 5. Discover workflows: scan `.github/workflows/*.md` and check [agentics collection](https://github.com/githubnext/agentics)
 6. Generate `.campaign.md` spec in `.github/workflows/`
@@ -63,7 +63,9 @@ allowed-safe-outputs: [create-issue, add-comment]
 
 ## Project Fields (Required)
 
-Campaign orchestrators and project-updaters assume these fields exist. Create them up-front with `update_project` using `operation: "create_fields"` and `field_definitions` so single-select options are created correctly (GitHub does not support adding options later).
+Campaign orchestrators and project-updaters assume these fields exist.
+
+In the default campaign generator workflow, these fields are configured via safe-outputs and created automatically. If you are running a custom workflow without that configuration, create them up-front with `update_project` using `operation: "create_fields"` and `field_definitions` so single-select options are created correctly (GitHub does not support adding options later).
 
 Required fields:
 

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -3851,6 +3851,31 @@
                     },
                     "additionalProperties": false
                   }
+                },
+                "field-definitions": {
+                  "type": "array",
+                  "description": "Optional array of project custom fields to create up-front. Useful for campaign projects that require a fixed set of fields.",
+                  "items": {
+                    "type": "object",
+                    "required": ["name", "data-type"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "The field name to create (e.g., 'status', 'campaign_id')"
+                      },
+                      "data-type": {
+                        "type": "string",
+                        "enum": ["DATE", "TEXT", "NUMBER", "SINGLE_SELECT", "ITERATION"],
+                        "description": "The GitHub Projects v2 custom field type"
+                      },
+                      "options": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Options for SINGLE_SELECT fields. GitHub does not support adding options later."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
                 }
               },
               "additionalProperties": false,

--- a/pkg/workflow/compiler_safe_outputs_config.go
+++ b/pkg/workflow/compiler_safe_outputs_config.go
@@ -558,6 +558,9 @@ func (c *Compiler) addProjectHandlerManagerConfigEnvVar(steps *[]string, data *W
 		if len(cfg.Views) > 0 {
 			handlerConfig["views"] = cfg.Views
 		}
+		if len(cfg.FieldDefinitions) > 0 {
+			handlerConfig["field_definitions"] = cfg.FieldDefinitions
+		}
 		config["update_project"] = handlerConfig
 	}
 

--- a/pkg/workflow/js/safe_outputs_tools.json
+++ b/pkg/workflow/js/safe_outputs_tools.json
@@ -580,12 +580,36 @@
     "description": "Add or update items in GitHub Projects v2 boards. Can add issues/PRs to a project and update custom field values. Requires the project URL, content type (issue or pull_request), and content number. Use campaign_id to group related items.",
     "inputSchema": {
       "type": "object",
-      "required": ["project", "content_type"],
+      "oneOf": [
+        {
+          "title": "Create project fields",
+          "required": ["project", "operation", "field_definitions"],
+          "properties": {
+            "operation": { "const": "create_fields" }
+          }
+        },
+        {
+          "title": "Create project view",
+          "required": ["project", "operation", "view"],
+          "properties": {
+            "operation": { "const": "create_view" }
+          }
+        },
+        {
+          "title": "Add/update project item",
+          "required": ["project", "content_type"]
+        }
+      ],
       "properties": {
         "project": {
           "type": "string",
           "pattern": "^https://github\\.com/(orgs|users)/[^/]+/projects/\\d+$",
           "description": "Full GitHub project URL (e.g., 'https://github.com/orgs/myorg/projects/42' or 'https://github.com/users/username/projects/5'). Project names or numbers alone are NOT accepted."
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["create_fields", "create_view"],
+          "description": "Optional operation mode. Use create_fields to create required campaign fields up-front, or create_view to add a project view. When omitted, the tool adds/updates project items."
         },
         "content_type": {
           "type": "string",
@@ -607,6 +631,47 @@
         "fields": {
           "type": "object",
           "description": "Custom field values to set on the project item (e.g., {'Status': 'In Progress', 'Priority': 'High'}). Field names must match custom fields defined in the project."
+        },
+        "field_definitions": {
+          "type": "array",
+          "description": "Field definitions to create when operation is create_fields.",
+          "items": {
+            "type": "object",
+            "required": ["name", "data_type"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Field name to create (e.g., 'size', 'priority')."
+              },
+              "data_type": {
+                "type": "string",
+                "enum": ["TEXT", "NUMBER", "DATE", "SINGLE_SELECT", "ITERATION"],
+                "description": "Field type. Use SINGLE_SELECT with options for enumerated values."
+              },
+              "options": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Options for SINGLE_SELECT fields."
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "view": {
+          "type": "object",
+          "description": "View definition to create when operation is create_view.",
+          "required": ["name", "layout"],
+          "properties": {
+            "name": { "type": "string" },
+            "layout": { "type": "string", "enum": ["table", "board", "roadmap"] },
+            "filter": { "type": "string" },
+            "visible_fields": {
+              "type": "array",
+              "items": { "type": "number" },
+              "description": "Field IDs to show in the view (table/board only)."
+            }
+          },
+          "additionalProperties": false
         },
         "campaign_id": {
           "type": "string",

--- a/pkg/workflow/update_project_handler_config_test.go
+++ b/pkg/workflow/update_project_handler_config_test.go
@@ -1,0 +1,53 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/githubnext/gh-aw/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateProjectHandlerConfigIncludesFieldDefinitions(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "handler-config-test")
+
+	testContent := `---
+name: Test Update Project Handler Config
+on: workflow_dispatch
+engine: copilot
+safe-outputs:
+  update-project:
+    max: 1
+    field-definitions:
+      - name: "campaign_id"
+        data-type: "TEXT"
+---
+
+Test workflow
+`
+
+	mdFile := filepath.Join(tmpDir, "test-workflow.md")
+	err := os.WriteFile(mdFile, []byte(testContent), 0600)
+	require.NoError(t, err, "Failed to write test markdown file")
+
+	compiler := NewCompiler(false, "", "")
+	err = compiler.CompileWorkflow(mdFile)
+	require.NoError(t, err, "Failed to compile workflow")
+
+	lockFile := filepath.Join(tmpDir, "test-workflow.lock.yml")
+	compiledContent, err := os.ReadFile(lockFile)
+	require.NoError(t, err, "Failed to read compiled output")
+
+	compiledStr := string(compiledContent)
+	require.Contains(t, compiledStr, "GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG", "Expected project handler config env var")
+	require.Contains(t, compiledStr, "update_project", "Expected update_project in project handler config")
+
+	// field_definitions uses underscore naming in the JSON config passed to JS
+	require.True(
+		t,
+		strings.Contains(compiledStr, "field_definitions") || strings.Contains(compiledStr, "field-definitions"),
+		"Expected field definitions in update_project handler config",
+	)
+}

--- a/pkg/workflow/update_project_test.go
+++ b/pkg/workflow/update_project_test.go
@@ -71,6 +71,31 @@ func TestParseUpdateProjectConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "config with field-definitions",
+			outputMap: map[string]any{
+				"update-project": map[string]any{
+					"field-definitions": []any{
+						map[string]any{
+							"name":      "status",
+							"data-type": "SINGLE_SELECT",
+							"options":   []any{"Todo", "Done"},
+						},
+						map[string]any{
+							"name":      "campaign_id",
+							"data-type": "TEXT",
+						},
+					},
+				},
+			},
+			expectedConfig: &UpdateProjectConfig{
+				BaseSafeOutputConfig: BaseSafeOutputConfig{Max: 10},
+				FieldDefinitions: []ProjectFieldDefinition{
+					{Name: "status", DataType: "SINGLE_SELECT", Options: []string{"Todo", "Done"}},
+					{Name: "campaign_id", DataType: "TEXT"},
+				},
+			},
+		},
+		{
 			name: "no update-project config",
 			outputMap: map[string]any{
 				"create-issue": map[string]any{},
@@ -107,6 +132,7 @@ func TestParseUpdateProjectConfig(t *testing.T) {
 				require.NotNil(t, config, "Expected non-nil config")
 				assert.Equal(t, tt.expectedConfig.Max, config.Max, "Max should match")
 				assert.Equal(t, tt.expectedConfig.GitHubToken, config.GitHubToken, "GitHubToken should match")
+				assert.Equal(t, tt.expectedConfig.FieldDefinitions, config.FieldDefinitions, "FieldDefinitions should match")
 			}
 		})
 	}


### PR DESCRIPTION
- Introduces the automatic creation of required GitHub Project custom fields for campaign workflows, ensuring that all necessary fields exist up front and improving configuration flexibility.