### PR TITLE
chore: switch campaign orchestrator to use claude

### DIFF
--- a/pkg/campaign/orchestrator.go
+++ b/pkg/campaign/orchestrator.go
@@ -416,8 +416,8 @@ func BuildOrchestrator(spec *CampaignSpec, campaignFilePath string) (*workflow.W
 	// This runs before the agent to precompute campaign discovery
 	discoverySteps := buildDiscoverySteps(spec)
 
-	// Determine engine to use (default to copilot if not specified)
-	engineID := "copilot"
+	// Determine engine to use (default to claude if not specified)
+	engineID := "claude"
 	if spec.Engine != "" {
 		engineID = spec.Engine
 		orchestratorLog.Printf("Campaign orchestrator '%s' using specified engine: %s", spec.ID, engineID)


### PR DESCRIPTION
- Switching from engine `copilot` to `claude` to avoid error:
`Model call failed: "400 400 Bad Request\n" (Request ID: 6818:2E4FA9:134F57F:15A8C1C:696FE882)`