### PR TITLE
🔧 Fix safe job output artifact filename handling

### DIFF
--- a/.github/workflows/daily-choice-test.lock.yml
+++ b/.github/workflows/daily-choice-test.lock.yml
@@ -1115,7 +1115,7 @@ jobs:
       - name: Setup Safe Job Environment Variables
         run: |
           find "/opt/gh-aw/safe-jobs/" -type f -print
-          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent-output" >> "$GITHUB_ENV"
+          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_ENV"
       - name: Display test configuration
         run: |-
           if [ -f "$GH_AW_AGENT_OUTPUT" ]; then

--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -1676,7 +1676,7 @@ jobs:
       - name: Setup Safe Job Environment Variables
         run: |
           find "/opt/gh-aw/safe-jobs/" -type f -print
-          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent-output" >> "$GITHUB_ENV"
+          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_ENV"
       - name: Add comment to Notion page
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
@@ -1806,7 +1806,7 @@ jobs:
       - name: Setup Safe Job Environment Variables
         run: |
           find "/opt/gh-aw/safe-jobs/" -type f -print
-          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent-output" >> "$GITHUB_ENV"
+          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_ENV"
       - name: Post message to Slack
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:

--- a/.github/workflows/notion-issue-summary.lock.yml
+++ b/.github/workflows/notion-issue-summary.lock.yml
@@ -975,7 +975,7 @@ jobs:
       - name: Setup Safe Job Environment Variables
         run: |
           find "/opt/gh-aw/safe-jobs/" -type f -print
-          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent-output" >> "$GITHUB_ENV"
+          echo "GH_AW_AGENT_OUTPUT=/opt/gh-aw/safe-jobs/agent_output.json" >> "$GITHUB_ENV"
       - name: Add comment to Notion page
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:

--- a/pkg/workflow/safe_jobs.go
+++ b/pkg/workflow/safe_jobs.go
@@ -229,11 +229,10 @@ func (c *Compiler) buildSafeJobs(data *WorkflowData, threatDetectionEnabled bool
 
 		// Add step to download agent output artifact using shared helper
 		downloadSteps := buildArtifactDownloadSteps(ArtifactDownloadConfig{
-			ArtifactName:     constants.AgentOutputArtifactName,
-			ArtifactFilename: artifactFileName, // Filename inside the artifact directory
-			DownloadPath:     "/opt/gh-aw/safe-jobs/",
-			SetupEnvStep:     false, // We'll handle env vars separately to add job-specific ones
-			StepName:         "Download agent output artifact",
+			ArtifactName: constants.AgentOutputArtifactName,
+			DownloadPath: "/opt/gh-aw/safe-jobs/",
+			SetupEnvStep: false, // We'll handle env vars separately to add job-specific ones
+			StepName:     "Download agent output artifact",
 		})
 		steps = append(steps, downloadSteps...)
 

--- a/pkg/workflow/safe_jobs.go
+++ b/pkg/workflow/safe_jobs.go
@@ -225,17 +225,20 @@ func (c *Compiler) buildSafeJobs(data *WorkflowData, threatDetectionEnabled bool
 		// Build job steps
 		var steps []string
 
+		artifactFileName := "agent_output.json"
+
 		// Add step to download agent output artifact using shared helper
 		downloadSteps := buildArtifactDownloadSteps(ArtifactDownloadConfig{
-			ArtifactName: constants.AgentOutputArtifactName,
-			DownloadPath: "/opt/gh-aw/safe-jobs/",
-			SetupEnvStep: false, // We'll handle env vars separately to add job-specific ones
-			StepName:     "Download agent output artifact",
+			ArtifactName:     constants.AgentOutputArtifactName,
+			ArtifactFilename: artifactFileName, // Filename inside the artifact directory
+			DownloadPath:     "/opt/gh-aw/safe-jobs/",
+			SetupEnvStep:     false, // We'll handle env vars separately to add job-specific ones
+			StepName:         "Download agent output artifact",
 		})
 		steps = append(steps, downloadSteps...)
 
 		// the download artifacts always creates a folder, then unpacks in that folder
-		agentOutputArtifactFilename := fmt.Sprintf("/opt/gh-aw/safe-jobs/%s", constants.AgentOutputArtifactName)
+		agentOutputArtifactFilename := fmt.Sprintf("/opt/gh-aw/safe-jobs/%s", artifactFileName)
 
 		// Add environment variables step with GH_AW_AGENT_OUTPUT and job-specific env vars
 		steps = append(steps, "      - name: Setup Safe Job Environment Variables\n")


### PR DESCRIPTION
## Summary

- Updated GitHub workflow files to use `agent_output.json` as the artifact filename
- Modified `safe_jobs.go` to support dynamic artifact filename generation
- Ensured consistent artifact download and environment variable setup

## Details

The changes modify how agent output artifacts are handled across multiple GitHub workflow files. The key modifications include:
- Renaming the artifact output from `agent-output` to `agent_output.json`
- Updating workflow files to reflect the new filename
- Updating the Go code to support more flexible artifact filename generation

## Motivation

Improve consistency and clarity in how agent output artifacts are processed and referenced in GitHub Actions workflows.