### PR TITLE
fix: remove cache memory instructions from 2 workflows

### DIFF
--- a/.github/workflows/secret-scanning-triage.lock.yml
+++ b/.github/workflows/secret-scanning-triage.lock.yml
@@ -890,10 +890,6 @@ jobs:
           - Wrap detailed steps in `<details><summary><b>Section</b></summary>` tags
           - Include workflow run reference at the end
           
-          ### 6) Record handling
-          
-          Append a JSON line to `/tmp/gh-aw/cache-memory/secret-scanning-triage.jsonl` for the alert you handled.
-          
           PROMPT_EOF
       - name: Substitute placeholders
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/secret-scanning-triage.md
+++ b/.github/workflows/secret-scanning-triage.md
@@ -167,7 +167,3 @@ After rotation and invalidation:
 - Keep critical info visible (alert link, secret type, immediate actions)
 - Wrap detailed steps in `<details><summary><b>Section</b></summary>` tags
 - Include workflow run reference at the end
-
-### 6) Record handling
-
-Append a JSON line to `/tmp/gh-aw/cache-memory/secret-scanning-triage.jsonl` for the alert you handled.

--- a/.github/workflows/security-fix-pr.lock.yml
+++ b/.github/workflows/security-fix-pr.lock.yml
@@ -725,17 +725,6 @@ jobs:
           
           Remember: Your goal is to provide secure, well-analyzed autofixes that address the root cause of vulnerabilities. Focus on quality and accuracy.
           
-          ## Cache Memory Format
-          
-          - Store recently fixed alert numbers to avoid duplicates
-          - Write to a file "fixed.jsonl" in the cache memory folder in JSONL format:
-          ```jsonl
-          {"alert_number": 123, "timestamp": "2024-01-14T10:30:00Z"}
-          {"alert_number": 124, "timestamp": "2024-01-14T10:35:00Z"}
-          ```
-          
-          Before processing an alert, check if it exists in the cache to avoid duplicate work.
-          
           PROMPT_EOF
       - name: Substitute placeholders
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/security-fix-pr.md
+++ b/.github/workflows/security-fix-pr.md
@@ -167,14 +167,3 @@ If any step fails:
 - **Fix Generation**: Document why the fix couldn't be automated and move to the next alert
 
 Remember: Your goal is to provide secure, well-analyzed autofixes that address the root cause of vulnerabilities. Focus on quality and accuracy.
-
-## Cache Memory Format
-
-- Store recently fixed alert numbers to avoid duplicates
-- Write to a file "fixed.jsonl" in the cache memory folder in JSONL format:
-```jsonl
-{"alert_number": 123, "timestamp": "2024-01-14T10:30:00Z"}
-{"alert_number": 124, "timestamp": "2024-01-14T10:35:00Z"}
-```
-
-Before processing an alert, check if it exists in the cache to avoid duplicate work.


### PR DESCRIPTION
- Remove left over cache memory instructions from workflows `Secret scanning triage` and `Security fix PR`.