### PR TITLE
chore: increase max items for project updates and add fields

### DIFF
--- a/.github/workflows/security-alert-burndown.lock.yml
+++ b/.github/workflows/security-alert-burndown.lock.yml
@@ -155,7 +155,7 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'EOF'
-          {"create_project_status_update":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1},"update_project":{"max":10}}
+          {"create_project_status_update":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1},"update_project":{"max":100}}
           EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'EOF'
           [
@@ -784,13 +784,21 @@ jobs:
           ### Step 5: Update Project Board
           
           For each discovered item (up to 10 total per run):
-          - Add or update the corresponding work item on the project board: https://github.com/orgs/githubnext/projects/144
+          - Add or update the corresponding work item on the project board: <https://github.com/orgs/githubnext/projects/144>
           - Use the `update-project` safe output tool
+          - Always include the campaign project URL (this is what makes it a campaign):
+            - `project`: "<https://github.com/orgs/githubnext/projects/144>"
+          - Always include the content identity:
+            - `content_type`: `pull_request` (Dependabot PRs) or `issue` (tracking issues)
+            - `content_number`: PR/issue number
           - Set fields:
             - `campaign_id`: "security-alert-burndown"
-            - `status`: "Todo" (for open PRs)
+            - `status`: "Todo" (for open items)
             - `target_repo`: "githubnext/gh-aw"
-            - `worker_workflow`: "unknown"
+            - `worker_workflow`: who discovered it, using one of:
+              - "dependabot-pr"
+              - "code-scanning"
+              - "secret-scanning"
             - `priority`: "Medium"
             - `size`: "Small"
             - `start_date`: Item created date (YYYY-MM-DD format)
@@ -1202,6 +1210,8 @@ jobs:
               ## Most Important Findings
           
               1. **Critical accessibility gaps identified**: 3 high-severity accessibility issues discovered in mobile navigation, requiring immediate attention
+          PROMPT_EOF
+          cat << 'PROMPT_EOF' >> "$GH_AW_PROMPT"
               2. **Documentation coverage acceleration**: Achieved 5% improvement in one week (best velocity so far)
               3. **Worker efficiency improving**: daily-doc-updater now processing 40% more items per run
           
@@ -1209,8 +1219,6 @@ jobs:
           
               - Multi-device testing reveals issues that desktop-only testing misses - should be prioritized
               - Documentation updates tied to code changes have higher accuracy and completeness
-          PROMPT_EOF
-          cat << 'PROMPT_EOF' >> "$GH_AW_PROMPT"
               - Users report fewer issues when examples include error handling patterns
           
               ## Campaign Progress
@@ -2020,7 +2028,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG: "{\"create_project_status_update\":{\"max\":1},\"update_project\":{\"max\":10}}"
+          GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG: "{\"create_project_status_update\":{\"max\":1},\"update_project\":{\"max\":100}}"
           GH_AW_PROJECT_GITHUB_TOKEN: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}

--- a/.github/workflows/security-alert-burndown.md
+++ b/.github/workflows/security-alert-burndown.md
@@ -18,7 +18,7 @@ safe-outputs:
   noop:
     max: 1
   update-project:
-    max: 10
+    max: 100
 project:
   url: https://github.com/orgs/githubnext/projects/144
 ---
@@ -88,13 +88,21 @@ If *no* items were found across all categories (Dependabot PRs, code scanning al
 ### Step 5: Update Project Board
 
 For each discovered item (up to 10 total per run):
-- Add or update the corresponding work item on the project board: https://github.com/orgs/githubnext/projects/144
+- Add or update the corresponding work item on the project board: <https://github.com/orgs/githubnext/projects/144>
 - Use the `update-project` safe output tool
+- Always include the campaign project URL (this is what makes it a campaign):
+  - `project`: "<https://github.com/orgs/githubnext/projects/144>"
+- Always include the content identity:
+  - `content_type`: `pull_request` (Dependabot PRs) or `issue` (tracking issues)
+  - `content_number`: PR/issue number
 - Set fields:
   - `campaign_id`: "security-alert-burndown"
-  - `status`: "Todo" (for open PRs)
+  - `status`: "Todo" (for open items)
   - `target_repo`: "githubnext/gh-aw"
-  - `worker_workflow`: "unknown"
+  - `worker_workflow`: who discovered it, using one of:
+    - "dependabot-pr"
+    - "code-scanning"
+    - "secret-scanning"
   - `priority`: "Medium"
   - `size`: "Small"
   - `start_date`: Item created date (YYYY-MM-DD format)


### PR DESCRIPTION
- Increases the allowed number of project board updates per run for the "Security Alert Burndown" workflow and clarifies instructions for updating project board items.