### PR TITLE
fix: update security alert burndown workflow with token prereqs

### DIFF
--- a/.github/workflows/security-alert-burndown.lock.yml
+++ b/.github/workflows/security-alert-burndown.lock.yml
@@ -630,6 +630,16 @@ jobs:
           
           You need to discover and update security work items on the project board. Follow these steps:
           
+          ### Step 0: Token Prerequisite (for Secret Scanning)
+          
+          Secret scanning alerts frequently return `403 Resource not accessible by integration` when the workflow falls back to the built-in `GITHUB_TOKEN`.
+          
+          To enable secret scanning discovery, configure one of these repository secrets:
+          - `GH_AW_GITHUB_MCP_SERVER_TOKEN` (preferred)
+          - `GH_AW_GITHUB_TOKEN`
+          
+          Use a token that can read secret scanning alerts for `githubnext/gh-aw` (a fine-grained PAT with **Secret scanning alerts: Read** is the safest option).
+          
           ### Step 1: Discover Dependabot PRs
           
           Use the GitHub MCP server to search for pull requests in the `githubnext/gh-aw` repository with:
@@ -674,22 +684,40 @@ jobs:
           - Created date
           - URL
           
-          ### Step 4: Check for Work
+          If this step fails with a 403:
+          - Record it in the final report as "Secret scanning alerts not accessible" and continue.
+          - Do not fail the workflow.
+          
+          ### Step 4: Resolve Alerts to Issues (or Draft Issues)
+          
+          `update-project` can only add **issues**, **pull requests**, or **project draft issues**.
+          
+          For each code scanning / secret scanning alert you found:
+          - First, try to find an existing tracking issue in `githubnext/gh-aw`.
+            - Search issues for the alert URL (best) or the alert number/id.
+            - Prefer open issues.
+          - If you find a tracking issue, use that issue number when updating the project.
+          - If you do not find a tracking issue, create a **project draft issue** instead (so the work still appears on the board).
+          
+          ### Step 5: Check for Work
           
           If *no* items were found across all categories (Dependabot PRs, code scanning alerts, secret scanning alerts):
           - Call the `noop` tool with message: "No security alerts found to process"
           - Exit successfully
           
-          ### Step 5: Update Project Board
+          ### Step 6: Update Project Board
           
           For each discovered item (up to 100 total per run):
           - Add or update the corresponding work item on the project board: <https://github.com/orgs/githubnext/projects/144>
           - Use the `update-project` safe output tool
           - Always include the campaign project URL (this is what makes it a campaign):
-            - `project`: "<https://github.com/orgs/githubnext/projects/144>"
+            - `project`: "https://github.com/orgs/githubnext/projects/144"
           - Always include the content identity:
-            - `content_type`: `pull_request` (Dependabot PRs) or `issue` (tracking issues)
-            - `content_number`: PR/issue number
+            - `content_type`: `pull_request` (Dependabot PRs), `issue` (tracking issues), or `draft_issue` (project-only)
+            - `content_number`: PR/issue number (required for `pull_request` and `issue`)
+            - For `draft_issue`, omit `content_number` and include:
+              - `draft_title`: short title (include alert type + severity)
+              - `draft_body`: include alert URL + key details
           - Set fields:
             - `campaign_id`: "security-alert-burndown"
             - `status`: "Todo" (for open items)
@@ -705,9 +733,10 @@ jobs:
           
           Notes:
           - `update-project` requires an existing GitHub **issue** or **pull request** reference (`content_type` + `content_number`).
-          - For alerts, prefer updating an existing tracking issue/PR if one exists; otherwise, report that the alert has no tracking item yet.
+          - For alerts, prefer updating an existing tracking issue if one exists.
+          - If there is no tracking issue, create a `draft_issue` so the alert still lands on the project board.
           
-          ### Step 6: Report
+          ### Step 7: Report
           
           Summarize how many items were discovered and added/updated on the project board, broken down by category.
           
@@ -1073,6 +1102,8 @@ jobs:
           
           4) Discovery cursor is maintained automatically in repo-memory; do not modify it manually.
           
+          PROMPT_EOF
+          cat << 'PROMPT_EOF' >> "$GH_AW_PROMPT"
           ### Step 2 — Make Decisions (Planning) [NO WRITES]
           
           5) Determine desired `status` strictly from explicit GitHub state:
@@ -1109,8 +1140,6 @@ jobs:
               ## Most Important Findings
           
               1. **Critical accessibility gaps identified**: 3 high-severity accessibility issues discovered in mobile navigation, requiring immediate attention
-          PROMPT_EOF
-          cat << 'PROMPT_EOF' >> "$GH_AW_PROMPT"
               2. **Documentation coverage acceleration**: Achieved 5% improvement in one week (best velocity so far)
               3. **Worker efficiency improving**: daily-doc-updater now processing 40% more items per run
           

--- a/.github/workflows/security-alert-burndown.md
+++ b/.github/workflows/security-alert-burndown.md
@@ -13,6 +13,7 @@ permissions:
 tools:
   github:
     read-only: true
+    github-token: "${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"
     toolsets: [repos, issues, pull_requests, code_security, secret_protection]
 project: https://github.com/orgs/githubnext/projects/144
 ---
@@ -28,6 +29,16 @@ This workflow discovers security alert work items in the githubnext/gh-aw reposi
 ## Task
 
 You need to discover and update security work items on the project board. Follow these steps:
+
+### Step 0: Token Prerequisite (for Secret Scanning)
+
+Secret scanning alerts frequently return `403 Resource not accessible by integration` when the workflow falls back to the built-in `GITHUB_TOKEN`.
+
+To enable secret scanning discovery, configure one of these repository secrets:
+- `GH_AW_GITHUB_MCP_SERVER_TOKEN` (preferred)
+- `GH_AW_GITHUB_TOKEN`
+
+Use a token that can read secret scanning alerts for `githubnext/gh-aw` (a fine-grained PAT with **Secret scanning alerts: Read** is the safest option).
 
 ### Step 1: Discover Dependabot PRs
 
@@ -73,22 +84,40 @@ From results, collect each alert’s:
 - Created date
 - URL
 
-### Step 4: Check for Work
+If this step fails with a 403:
+- Record it in the final report as "Secret scanning alerts not accessible" and continue.
+- Do not fail the workflow.
+
+### Step 4: Resolve Alerts to Issues (or Draft Issues)
+
+`update-project` can only add **issues**, **pull requests**, or **project draft issues**.
+
+For each code scanning / secret scanning alert you found:
+- First, try to find an existing tracking issue in `githubnext/gh-aw`.
+  - Search issues for the alert URL (best) or the alert number/id.
+  - Prefer open issues.
+- If you find a tracking issue, use that issue number when updating the project.
+- If you do not find a tracking issue, create a **project draft issue** instead (so the work still appears on the board).
+
+### Step 5: Check for Work
 
 If *no* items were found across all categories (Dependabot PRs, code scanning alerts, secret scanning alerts):
 - Call the `noop` tool with message: "No security alerts found to process"
 - Exit successfully
 
-### Step 5: Update Project Board
+### Step 6: Update Project Board
 
 For each discovered item (up to 100 total per run):
 - Add or update the corresponding work item on the project board: <https://github.com/orgs/githubnext/projects/144>
 - Use the `update-project` safe output tool
 - Always include the campaign project URL (this is what makes it a campaign):
-  - `project`: "<https://github.com/orgs/githubnext/projects/144>"
+  - `project`: "https://github.com/orgs/githubnext/projects/144"
 - Always include the content identity:
-  - `content_type`: `pull_request` (Dependabot PRs) or `issue` (tracking issues)
-  - `content_number`: PR/issue number
+  - `content_type`: `pull_request` (Dependabot PRs), `issue` (tracking issues), or `draft_issue` (project-only)
+  - `content_number`: PR/issue number (required for `pull_request` and `issue`)
+  - For `draft_issue`, omit `content_number` and include:
+    - `draft_title`: short title (include alert type + severity)
+    - `draft_body`: include alert URL + key details
 - Set fields:
   - `campaign_id`: "security-alert-burndown"
   - `status`: "Todo" (for open items)
@@ -104,9 +133,10 @@ For each discovered item (up to 100 total per run):
 
 Notes:
 - `update-project` requires an existing GitHub **issue** or **pull request** reference (`content_type` + `content_number`).
-- For alerts, prefer updating an existing tracking issue/PR if one exists; otherwise, report that the alert has no tracking item yet.
+- For alerts, prefer updating an existing tracking issue if one exists.
+- If there is no tracking issue, create a `draft_issue` so the alert still lands on the project board.
 
-### Step 6: Report
+### Step 7: Report
 
 Summarize how many items were discovered and added/updated on the project board, broken down by category.
 


### PR DESCRIPTION
- Updates "Security Alert Burndown" workflow to handle secret scanning alerts (accessible using the correct token).
- Also introduces draft issues to track alerts without existing issues.