### PR TITLE
🧹 Remove strange !integration test build tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
-          go test -v -parallel=8 -timeout=3m -tags '!integration' -run='^Test' -coverprofile=coverage.out -json ./... | tee test-result-unit.json
+          go test -v -parallel=8 -timeout=3m -run='^Test' -coverprofile=coverage.out -json ./... | tee test-result-unit.json
           go tool cover -html=coverage.out -o coverage.html
 
       # Coverage reports for recent builds only - 7 days is sufficient for debugging recent changes

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 # Test unit tests only (excludes integration tests)
 .PHONY: test-unit
 test-unit:
-	go test -v -timeout=3m -tags '!integration' -run='^Test' ./...
+	go test -v -timeout=3m -run='^Test' ./...
 
 # Update golden test files
 .PHONY: update-golden

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ build-darwin:
 build-windows:
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BINARY_NAME)-windows-amd64.exe ./cmd/gh-aw
 
-# Test the code (runs both unit and integration tests)
+# Test the code (runs both unlabelled unit tests and integration tests)
 .PHONY: test
 test:
 	go test -v -timeout=3m -tags 'integration' -run='^Test' ./...
 
-# Test unit tests only (excludes integration tests)
+# Test unit tests only (excludes labelled integration tests)
 .PHONY: test-unit
 test-unit:
 	go test -v -timeout=3m -run='^Test' ./...

--- a/pkg/cli/copilot_setup_test.go
+++ b/pkg/cli/copilot_setup_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package cli
 
 import (

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package cli
 
 import (

--- a/pkg/cli/init_command_test.go
+++ b/pkg/cli/init_command_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package cli
 
 import (

--- a/pkg/cli/mcp_config_file_test.go
+++ b/pkg/cli/mcp_config_file_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package cli
 
 import (

--- a/pkg/cli/mcp_secrets_test.go
+++ b/pkg/cli/mcp_secrets_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package cli
 
 import (

--- a/pkg/cli/test_main_test.go
+++ b/pkg/cli/test_main_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package cli
 
 import (

--- a/pkg/workflow/firewall_disable_integration_test.go
+++ b/pkg/workflow/firewall_disable_integration_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package workflow
 
 import (

--- a/pkg/workflow/github_token_test.go
+++ b/pkg/workflow/github_token_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package workflow
 
 import (

--- a/pkg/workflow/github_token_validation_test.go
+++ b/pkg/workflow/github_token_validation_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package workflow
 
 import (

--- a/pkg/workflow/jobs_secrets_validation_test.go
+++ b/pkg/workflow/jobs_secrets_validation_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package workflow
 
 import (

--- a/pkg/workflow/secrets_validation_test.go
+++ b/pkg/workflow/secrets_validation_test.go
@@ -1,5 +1,3 @@
-//go:build !integration
-
 package workflow
 
 import (


### PR DESCRIPTION
The `!integration` labelling is not standard at all.

* unit tests --> no labels
* integration tests --> integration label


--
## Summary

- Removed `//go:build !integration` build tags from multiple test files
- Updated CI workflow and Makefile to run all unit tests without integration tag filtering
- Simplified test configuration across different packages

## Details

This PR removes the integration test build tags from several test files in the `pkg/cli` and `pkg/workflow` packages. The changes streamline the test execution process by removing unnecessary build constraints and ensuring consistent test coverage.