### PR TITLE
fix: ensure copilot assignment step

### DIFF
--- a/.github/workflows/security-alert-burndown.lock.yml
+++ b/.github/workflows/security-alert-burndown.lock.yml
@@ -2213,4 +2213,16 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/safe_output_handler_manager.cjs');
             await main();
+      - name: Assign copilot to created issues
+        if: steps.process_safe_outputs.outputs.issues_to_assign_copilot != ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          GH_AW_ISSUES_TO_ASSIGN_COPILOT: ${{ steps.process_safe_outputs.outputs.issues_to_assign_copilot }}
+        with:
+          github-token: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('/opt/gh-aw/actions/assign_copilot_to_created_issues.cjs');
+            await main();
 

--- a/actions/setup/js/assign_copilot_to_created_issues.cjs
+++ b/actions/setup/js/assign_copilot_to_created_issues.cjs
@@ -11,8 +11,10 @@ const { getErrorMessage } = require("./error_helpers.cjs");
  */
 
 async function main() {
-  // Get the issues to assign from step output
-  const issuesToAssignStr = "${{ steps.create_issue.outputs.issues_to_assign_copilot }}";
+  // Prefer explicit env var (works in consolidated safe_outputs mode where the
+  // handler manager step is `process_safe_outputs`). Fall back to the legacy
+  // step output template for backwards compatibility.
+  const issuesToAssignStr = (process.env.GH_AW_ISSUES_TO_ASSIGN_COPILOT ?? "").trim() || "${{ steps.create_issue.outputs.issues_to_assign_copilot }}";
 
   // Check if the template string wasn't replaced (test environment) or is empty
   if (!issuesToAssignStr || issuesToAssignStr.trim() === "" || issuesToAssignStr.includes("${{")) {


### PR DESCRIPTION
- Ensures that when `assignees: copilot` is set for `create-issue`, a dedicated step is added to assign Copilo and the assignment logic is robust to both new and legacy output mechanisms.