### PR TITLE
chore: simplify campaign orchestrator core rules description

### DIFF
--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -804,7 +804,7 @@ jobs:
           cat << 'PROMPT_EOF' >> "$GH_AW_PROMPT"
           # Campaign Orchestrator Core Rules
           
-          These are generic orchestrator rules intended to be included via `{{#runtime-import ...}}`.
+          These are generic orchestrator rules.
           
           ## Operating Model
           

--- a/.github/workflows/shared/campaign.md
+++ b/.github/workflows/shared/campaign.md
@@ -14,7 +14,7 @@ safe-outputs:
 ---
 # Campaign Orchestrator Core Rules
 
-These are generic orchestrator rules intended to be included via `{{#runtime-import ...}}`.
+These are generic orchestrator rules.
 
 ## Operating Model
 


### PR DESCRIPTION
- Remove mention of runtime import which caused the workflow ti fail:
`Error: Failed to process runtime import for ...: `