### PR TITLE
refactor: standardize short project field handling

### DIFF
--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -19,13 +19,11 @@
 #   gh aw compile
 # For more information: https://github.com/githubnext/gh-aw/blob/main/.github/aw/github-agentic-workflows.md
 #
-# Burns down open open dependabot pull requests.
+# Burns down open Dependabot pull requests.
 #
 # Resolved workflow manifest:
 #   Imports:
 #     - shared/campaign.md
-#
-# frontmatter-hash: 87fb3c6aeafc0b3c8f725e2c077bc0d87b98ffde05d2097a906446fbf2e05072
 
 name: "Dependabot Burner"
 "on":
@@ -919,13 +917,20 @@ jobs:
           
           # Dependabot Burner
           
-          - Project URL: https://github.com/orgs/githubnext/projects/144
-          - Campaign ID: dependabot-burner
-          
           - Find all open Dependabot PRs and add them to the project.
           - Create bundle issues, each for exactly **one runtime + one manifest file**.
           - Add bundle issues to the project, and assign them to Copilot.
           
+          
+          
+          ---
+          # ORCHESTRATOR INSTRUCTIONS
+          ---
+          Each time this orchestrator runs, generate a concise status report for this campaign.
+          ---
+          # CLOSING INSTRUCTIONS (HIGHEST PRIORITY)
+          ---
+          Use these details to coordinate workers and track progress.
           PROMPT_EOF
       - name: Substitute placeholders
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -1273,7 +1278,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           WORKFLOW_NAME: "Dependabot Burner"
-          WORKFLOW_DESCRIPTION: "Burns down open open dependabot pull requests."
+          WORKFLOW_DESCRIPTION: "Burns down open Dependabot pull requests."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -24,6 +24,8 @@
 # Resolved workflow manifest:
 #   Imports:
 #     - shared/campaign.md
+#
+# frontmatter-hash: f48a2486883d4faf3c46ee14f5e3450b6041dacb562f4a308be433ab5d29f941
 
 name: "Dependabot Burner"
 "on":
@@ -921,16 +923,6 @@ jobs:
           - Create bundle issues, each for exactly **one runtime + one manifest file**.
           - Add bundle issues to the project, and assign them to Copilot.
           
-          
-          
-          ---
-          # ORCHESTRATOR INSTRUCTIONS
-          ---
-          Each time this orchestrator runs, generate a concise status report for this campaign.
-          ---
-          # CLOSING INSTRUCTIONS (HIGHEST PRIORITY)
-          ---
-          Use these details to coordinate workers and track progress.
           PROMPT_EOF
       - name: Substitute placeholders
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -1477,6 +1469,7 @@ jobs:
           GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG: "{\"create_project_status_update\":{\"max\":1},\"update_project\":{\"max\":100}}"
           GH_AW_ASSIGN_COPILOT: "true"
           GH_AW_PROJECT_GITHUB_TOKEN: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
+          GH_AW_PROJECT_URL: "https://github.com/orgs/githubnext/projects/144"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/dependabot-burner.md
+++ b/.github/workflows/dependabot-burner.md
@@ -1,6 +1,6 @@
 ---
 name: Dependabot Burner
-description: Burns down open open dependabot pull requests.
+description: Burns down open Dependabot pull requests.
 
 on:
   schedule: daily
@@ -15,12 +15,11 @@ permissions:
 
 imports:
   - shared/campaign.md
+
+project: https://github.com/orgs/githubnext/projects/144
 ---
 
 # Dependabot Burner
-
-- Project URL: https://github.com/orgs/githubnext/projects/144
-- Campaign ID: dependabot-burner
 
 - Find all open Dependabot PRs and add them to the project.
 - Create bundle issues, each for exactly **one runtime + one manifest file**.

--- a/.github/workflows/test-project-url-default.lock.yml
+++ b/.github/workflows/test-project-url-default.lock.yml
@@ -746,7 +746,9 @@ jobs:
           }
           ```
           
-          This will automatically use `https://github.com/orgs/githubnext/projects/1` from the frontmatter.
+          This will automatically use `https://github.com/orgs/<ORG>/projects/<NUMBER>` from the frontmatter.
+          
+          Important: this is a placeholder. Replace it with a real GitHub Projects v2 URL before running the workflow.
           
           ```json
           {
@@ -1259,7 +1261,7 @@ jobs:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_SAFE_OUTPUTS_PROJECT_HANDLER_CONFIG: "{\"create_project_status_update\":{\"max\":1},\"update_project\":{\"max\":5}}"
           GH_AW_PROJECT_GITHUB_TOKEN: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
-          GH_AW_PROJECT_URL: "https://github.com/orgs/githubnext/projects/1"
+          GH_AW_PROJECT_URL: "https://github.com/orgs/<ORG>/projects/<NUMBER>"
         with:
           github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-project-url-default.md
+++ b/.github/workflows/test-project-url-default.md
@@ -4,8 +4,7 @@ engine: copilot
 on:
   workflow_dispatch:
 
-project:
-  url: "https://github.com/orgs/githubnext/projects/1"
+project: "https://github.com/orgs/<ORG>/projects/<NUMBER>"
 
 safe-outputs:
   update-project:
@@ -43,7 +42,9 @@ URL as a default when the message doesn't specify a project field.
 }
 ```
 
-This will automatically use `https://github.com/orgs/githubnext/projects/1` from the frontmatter.
+This will automatically use `https://github.com/orgs/<ORG>/projects/<NUMBER>` from the frontmatter.
+
+Important: this is a placeholder. Replace it with a real GitHub Projects v2 URL before running the workflow.
 
 ```json
 {

--- a/docs/src/content/docs/reference/frontmatter.md
+++ b/docs/src/content/docs/reference/frontmatter.md
@@ -244,8 +244,11 @@ network:
 Automatically enables project board management operations for tracking workflow-created items. See [Project Tracking](/gh-aw/examples/project-tracking/) for complete documentation.
 
 ```yaml wrap
-# Simple format - just the URL
+# Simple format - just the URL (quotes optional)
 project: https://github.com/orgs/github/projects/123
+
+# With placeholder values (quotes recommended for angle brackets)
+project: "https://github.com/orgs/<ORG>/projects/<NUMBER>"
 
 # Full configuration with custom settings
 project:
@@ -257,6 +260,9 @@ project:
   max-status-updates: 2
   github-token: ${{ secrets.GH_AW_PROJECT_GITHUB_TOKEN }}
 ```
+
+> [!NOTE]
+> Quotes are optional for plain URLs but recommended when using placeholder values with angle brackets (`<ORG>`, `<NUMBER>`) to ensure proper YAML parsing.
 
 When configured, automatically enables:
 - **update-project** - Add items to projects, update fields (status, priority, etc.)

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -3657,8 +3657,8 @@
         {
           "type": "string",
           "description": "GitHub Project URL for tracking workflow-created items. When configured, automatically enables project tracking operations (update-project, create-project-status-update) to manage project boards similar to campaign orchestrators.",
-          "pattern": "^https://github\\.com/(users|orgs)/[^/]+/projects/\\d+$",
-          "examples": ["https://github.com/orgs/github/projects/123", "https://github.com/users/username/projects/456"]
+          "pattern": "^https://github\\.com/(users|orgs)/([^/]+|<[A-Z_]+>)/projects/(\\d+|<[A-Z_]+>)$",
+          "examples": ["https://github.com/orgs/github/projects/123", "https://github.com/users/username/projects/456", "https://github.com/orgs/<ORG>/projects/<NUMBER>"]
         },
         {
           "type": "object",
@@ -3669,8 +3669,8 @@
             "url": {
               "type": "string",
               "description": "GitHub Project URL (required). Must be a valid GitHub Projects V2 URL.",
-              "pattern": "^https://github\\.com/(users|orgs)/[^/]+/projects/\\d+$",
-              "examples": ["https://github.com/orgs/github/projects/123", "https://github.com/users/username/projects/456"]
+              "pattern": "^https://github\\.com/(users|orgs)/([^/]+|<[A-Z_]+>)/projects/(\\d+|<[A-Z_]+>)$",
+              "examples": ["https://github.com/orgs/github/projects/123", "https://github.com/users/username/projects/456", "https://github.com/orgs/<ORG>/projects/<NUMBER>"]
             },
             "max-updates": {
               "type": "integer",

--- a/pkg/workflow/frontmatter_types_test.go
+++ b/pkg/workflow/frontmatter_types_test.go
@@ -146,10 +146,10 @@ func TestParseFrontmatterConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("parses project as URL string (short form)", func(t *testing.T) {
+	t.Run("parses project as URL string", func(t *testing.T) {
 		frontmatter := map[string]any{
-			"name":    "project-short-form",
-			"project": "https://github.com/orgs/githubnext/projects/144",
+			"name":    "project-string",
+			"project": "https://github.com/orgs/<ORG>/projects/<NUMBER>",
 		}
 
 		config, err := ParseFrontmatterConfig(frontmatter)
@@ -160,8 +160,25 @@ func TestParseFrontmatterConfig(t *testing.T) {
 		if config.Project == nil {
 			t.Fatal("Project should not be nil")
 		}
-		if config.Project.URL != "https://github.com/orgs/githubnext/projects/144" {
-			t.Errorf("Project.URL = %q, want %q", config.Project.URL, "https://github.com/orgs/githubnext/projects/144")
+		if config.Project.URL != "https://github.com/orgs/<ORG>/projects/<NUMBER>" {
+			t.Errorf("Project.URL = %q, want %q", config.Project.URL, "https://github.com/orgs/<ORG>/projects/<NUMBER>")
+		}
+	})
+
+	t.Run("rejects project as mapping", func(t *testing.T) {
+		frontmatter := map[string]any{
+			"name": "project-mapping",
+			"project": map[string]any{
+				"url": "https://github.com/orgs/<ORG>/projects/<NUMBER>",
+			},
+		}
+
+		_, err := ParseFrontmatterConfig(frontmatter)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "expected URL string") {
+			t.Fatalf("expected type error, got: %v", err)
 		}
 	})
 

--- a/pkg/workflow/project_safe_outputs_test.go
+++ b/pkg/workflow/project_safe_outputs_test.go
@@ -9,109 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseProjectConfig(t *testing.T) {
-	compiler := NewCompiler()
-
-	tests := []struct {
-		name           string
-		projectMap     map[string]any
-		expectedConfig *ProjectConfig
-	}{
-		{
-			name: "complete configuration",
-			projectMap: map[string]any{
-				"url":                         "https://github.com/orgs/github/projects/123",
-				"scope":                       []any{"owner/repo1", "owner/repo2", "org:github"},
-				"max-updates":                 50,
-				"max-status-updates":          2,
-				"github-token":                "${{ secrets.PROJECT_TOKEN }}",
-				"do-not-downgrade-done-items": true,
-			},
-			expectedConfig: &ProjectConfig{
-				URL:                     "https://github.com/orgs/github/projects/123",
-				Scope:                   []string{"owner/repo1", "owner/repo2", "org:github"},
-				MaxUpdates:              50,
-				MaxStatusUpdates:        2,
-				GitHubToken:             "${{ secrets.PROJECT_TOKEN }}",
-				DoNotDowngradeDoneItems: boolPtr(true),
-			},
-		},
-		{
-			name: "configuration with scope only",
-			projectMap: map[string]any{
-				"url":   "https://github.com/orgs/github/projects/999",
-				"scope": []any{"org:myorg", "owner/special-repo"},
-			},
-			expectedConfig: &ProjectConfig{
-				URL:   "https://github.com/orgs/github/projects/999",
-				Scope: []string{"org:myorg", "owner/special-repo"},
-			},
-		},
-		{
-			name: "minimal configuration with URL only",
-			projectMap: map[string]any{
-				"url": "https://github.com/users/username/projects/456",
-			},
-			expectedConfig: &ProjectConfig{
-				URL: "https://github.com/users/username/projects/456",
-			},
-		},
-		{
-			name: "URL with max-updates",
-			projectMap: map[string]any{
-				"url":         "https://github.com/orgs/github/projects/789",
-				"max-updates": 100,
-			},
-			expectedConfig: &ProjectConfig{
-				URL:        "https://github.com/orgs/github/projects/789",
-				MaxUpdates: 100,
-			},
-		},
-		{
-			name: "URL with custom token",
-			projectMap: map[string]any{
-				"url":          "https://github.com/orgs/github/projects/123",
-				"github-token": "${{ secrets.CUSTOM_TOKEN }}",
-			},
-			expectedConfig: &ProjectConfig{
-				URL:         "https://github.com/orgs/github/projects/123",
-				GitHubToken: "${{ secrets.CUSTOM_TOKEN }}",
-			},
-		},
-		{
-			name: "numeric max-updates as float64",
-			projectMap: map[string]any{
-				"url":         "https://github.com/orgs/github/projects/123",
-				"max-updates": 75.0,
-			},
-			expectedConfig: &ProjectConfig{
-				URL:        "https://github.com/orgs/github/projects/123",
-				MaxUpdates: 75,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config := compiler.parseProjectConfig(tt.projectMap)
-
-			require.NotNil(t, config, "parseProjectConfig() should not return nil")
-			assert.Equal(t, tt.expectedConfig.URL, config.URL, "URL should match")
-			assert.Equal(t, tt.expectedConfig.Scope, config.Scope, "Scope should match")
-			assert.Equal(t, tt.expectedConfig.MaxUpdates, config.MaxUpdates, "MaxUpdates should match")
-			assert.Equal(t, tt.expectedConfig.MaxStatusUpdates, config.MaxStatusUpdates, "MaxStatusUpdates should match")
-			assert.Equal(t, tt.expectedConfig.GitHubToken, config.GitHubToken, "GitHubToken should match")
-
-			if tt.expectedConfig.DoNotDowngradeDoneItems != nil {
-				require.NotNil(t, config.DoNotDowngradeDoneItems, "DoNotDowngradeDoneItems should not be nil")
-				assert.Equal(t, *tt.expectedConfig.DoNotDowngradeDoneItems, *config.DoNotDowngradeDoneItems, "DoNotDowngradeDoneItems should match")
-			} else {
-				assert.Nil(t, config.DoNotDowngradeDoneItems, "DoNotDowngradeDoneItems should be nil")
-			}
-		})
-	}
-}
-
 func TestApplyProjectSafeOutputs(t *testing.T) {
 	compiler := NewCompiler()
 
@@ -127,34 +24,18 @@ func TestApplyProjectSafeOutputs(t *testing.T) {
 		{
 			name: "project with URL string - creates safe-outputs",
 			frontmatter: map[string]any{
-				"project": "https://github.com/orgs/github/projects/123",
+				"project": "https://github.com/orgs/<ORG>/projects/<NUMBER>",
 			},
 			existingSafeOutputs: nil,
 			expectUpdateProject: true,
 			expectStatusUpdate:  true,
-			expectedMaxUpdates:  100, // default
-			expectedMaxStatus:   1,   // default
-		},
-		{
-			name: "project with full config object",
-			frontmatter: map[string]any{
-				"project": map[string]any{
-					"url":                "https://github.com/orgs/github/projects/456",
-					"max-updates":        50,
-					"max-status-updates": 2,
-					"github-token":       "${{ secrets.PROJECT_TOKEN }}",
-				},
-			},
-			existingSafeOutputs: nil,
-			expectUpdateProject: true,
-			expectStatusUpdate:  true,
-			expectedMaxUpdates:  50,
-			expectedMaxStatus:   2,
+			expectedMaxUpdates:  100,
+			expectedMaxStatus:   1,
 		},
 		{
 			name: "project with existing safe-outputs preserves existing",
 			frontmatter: map[string]any{
-				"project": "https://github.com/orgs/github/projects/789",
+				"project": "https://github.com/orgs/<ORG>/projects/<NUMBER>",
 			},
 			existingSafeOutputs: &SafeOutputsConfig{
 				UpdateProjects: &UpdateProjectConfig{
@@ -166,8 +47,8 @@ func TestApplyProjectSafeOutputs(t *testing.T) {
 			},
 			expectUpdateProject: true,
 			expectStatusUpdate:  true,
-			expectedMaxUpdates:  25, // preserved from existing
-			expectedMaxStatus:   3,  // preserved from existing
+			expectedMaxUpdates:  25,
+			expectedMaxStatus:   3,
 		},
 		{
 			name: "no project field - returns existing",
@@ -179,20 +60,9 @@ func TestApplyProjectSafeOutputs(t *testing.T) {
 			expectStatusUpdate:  false,
 		},
 		{
-			name: "empty project map - returns existing",
+			name: "project with blank URL string is ignored",
 			frontmatter: map[string]any{
-				"project": map[string]any{},
-			},
-			existingSafeOutputs: nil,
-			expectUpdateProject: false,
-			expectStatusUpdate:  false,
-		},
-		{
-			name: "project with no URL - returns existing",
-			frontmatter: map[string]any{
-				"project": map[string]any{
-					"max-updates": 50,
-				},
+				"project": "   ",
 			},
 			existingSafeOutputs: nil,
 			expectUpdateProject: false,
@@ -232,14 +102,9 @@ func TestApplyProjectSafeOutputs(t *testing.T) {
 func TestProjectConfigIntegration(t *testing.T) {
 	compiler := NewCompiler()
 
-	// Test full integration: frontmatter -> safe-outputs config
+	// Test integration: project string -> safe-outputs defaults
 	frontmatter := map[string]any{
-		"project": map[string]any{
-			"url":                "https://github.com/orgs/test/projects/100",
-			"max-updates":        75,
-			"max-status-updates": 2,
-			"github-token":       "${{ secrets.TEST_TOKEN }}",
-		},
+		"project": "https://github.com/orgs/<ORG>/projects/<NUMBER>",
 	}
 
 	result := compiler.applyProjectSafeOutputs(frontmatter, nil)
@@ -249,10 +114,8 @@ func TestProjectConfigIntegration(t *testing.T) {
 	require.NotNil(t, result.CreateProjectStatusUpdates, "CreateProjectStatusUpdates should be configured")
 
 	// Check update-project configuration
-	assert.Equal(t, 75, result.UpdateProjects.Max, "UpdateProjects max should match")
-	assert.Equal(t, "${{ secrets.TEST_TOKEN }}", result.UpdateProjects.GitHubToken, "UpdateProjects token should match")
+	assert.Equal(t, 100, result.UpdateProjects.Max, "UpdateProjects max should match")
 
 	// Check create-project-status-update configuration
-	assert.Equal(t, 2, result.CreateProjectStatusUpdates.Max, "CreateProjectStatusUpdates max should match")
-	assert.Equal(t, "${{ secrets.TEST_TOKEN }}", result.CreateProjectStatusUpdates.GitHubToken, "CreateProjectStatusUpdates token should match")
+	assert.Equal(t, 1, result.CreateProjectStatusUpdates.Max, "CreateProjectStatusUpdates max should match")
 }


### PR DESCRIPTION
- Standardizes and simplifies how the `project` field is handled in workflow frontmatter:
   - `project` field must now always be a URL string
      e.g. `"https://github.com/orgs/<ORG>/projects/<NUMBER>"`