### PR TITLE
🔧 Fix GitHub Actions job activation condition

### DIFF
--- a/.github/workflows/agent-performance-analyzer.lock.yml
+++ b/.github/workflows/agent-performance-analyzer.lock.yml
@@ -44,7 +44,7 @@ run-name: "Agent Performance Analyzer - Meta-Orchestrator"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/agent-persona-explorer.lock.yml
+++ b/.github/workflows/agent-persona-explorer.lock.yml
@@ -44,7 +44,7 @@ run-name: "Agent Persona Explorer"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/ai-moderator.lock.yml
+++ b/.github/workflows/ai-moderator.lock.yml
@@ -52,7 +52,7 @@ jobs:
       - check_external_user
       - pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'workflow_dispatch') || (needs.check_external_user.outputs.should_skip != 'true'))
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/archie.lock.yml
+++ b/.github/workflows/archie.lock.yml
@@ -51,7 +51,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/archie')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/archie')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'issue_comment') &&

--- a/.github/workflows/auto-triage-issues.lock.yml
+++ b/.github/workflows/auto-triage-issues.lock.yml
@@ -48,7 +48,7 @@ run-name: "Auto-Triage Issues"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -45,7 +45,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/brave')) && (github.event.issue.pull_request == null)))
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/breaking-change-checker.lock.yml
+++ b/.github/workflows/breaking-change-checker.lock.yml
@@ -40,7 +40,7 @@ run-name: "Breaking Change Checker"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/changeset.lock.yml
+++ b/.github/workflows/changeset.lock.yml
@@ -51,7 +51,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event.pull_request.base.ref == github.event.repository.default_branch) && ((github.event_name != 'pull_request') ||
       (github.event.pull_request.head.repo.id == github.repository_id))) && ((github.event_name != 'pull_request') ||
       ((github.event.action != 'labeled') || (github.event.label.name == 'changeset' || github.event.label.name == 'smoke'))))

--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -50,7 +50,7 @@ jobs:
     needs: pre_activation
     # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
     if: >
-      (((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      (((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (github.event.workflow_run.conclusion == 'failure')) && ((github.event_name != 'workflow_run') ||
       ((github.event.workflow_run.repository.id == github.repository_id) &&
       (!(github.event.workflow_run.repository.fork))))

--- a/.github/workflows/cloclo.lock.yml
+++ b/.github/workflows/cloclo.lock.yml
@@ -68,7 +68,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((((github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request' ||
       github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment') &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/cloclo')) || (github.event_name == 'issue_comment') &&

--- a/.github/workflows/code-scanning-fixer.lock.yml
+++ b/.github/workflows/code-scanning-fixer.lock.yml
@@ -38,7 +38,7 @@ run-name: "Code Scanning Fixer"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -45,7 +45,7 @@ run-name: "Code Simplifier"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/craft.lock.yml
+++ b/.github/workflows/craft.lock.yml
@@ -42,7 +42,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/craft')))
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/daily-file-diet.lock.yml
+++ b/.github/workflows/daily-file-diet.lock.yml
@@ -45,7 +45,7 @@ run-name: "Daily File Diet"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-issues-report.lock.yml
+++ b/.github/workflows/daily-issues-report.lock.yml
@@ -48,7 +48,7 @@ run-name: "Daily Issues Report Generator"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-observability-report.lock.yml
+++ b/.github/workflows/daily-observability-report.lock.yml
@@ -44,7 +44,7 @@ run-name: "Daily Observability Report for AWF Firewall and MCP Gateway"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-safe-output-optimizer.lock.yml
+++ b/.github/workflows/daily-safe-output-optimizer.lock.yml
@@ -47,7 +47,7 @@ run-name: "Daily Safe Output Tool Optimizer"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-team-status.lock.yml
+++ b/.github/workflows/daily-team-status.lock.yml
@@ -51,7 +51,7 @@ run-name: "Daily Team Status"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-testify-uber-super-expert.lock.yml
+++ b/.github/workflows/daily-testify-uber-super-expert.lock.yml
@@ -46,7 +46,7 @@ run-name: "Daily Testify Uber Super Expert"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/dependabot-bundler.lock.yml
+++ b/.github/workflows/dependabot-bundler.lock.yml
@@ -38,7 +38,7 @@ run-name: "Dependabot Bundler"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -45,7 +45,7 @@ run-name: "Dependabot Burner"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/dev-hawk.lock.yml
+++ b/.github/workflows/dev-hawk.lock.yml
@@ -50,7 +50,7 @@ jobs:
     needs: pre_activation
     # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
     if: >
-      (((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      (((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (github.event.workflow_run.event == 'workflow_dispatch')) && ((github.event_name != 'workflow_run') ||
       ((github.event.workflow_run.repository.id == github.repository_id) && (!(github.event.workflow_run.repository.fork))))
     runs-on: ubuntu-slim

--- a/.github/workflows/example-custom-error-patterns.lock.yml
+++ b/.github/workflows/example-custom-error-patterns.lock.yml
@@ -38,7 +38,7 @@ run-name: "Example: Custom Error Patterns"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/firewall-escape.lock.yml
+++ b/.github/workflows/firewall-escape.lock.yml
@@ -47,7 +47,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
       ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'firewall-escape-test'))))
     runs-on: ubuntu-slim

--- a/.github/workflows/grumpy-reviewer.lock.yml
+++ b/.github/workflows/grumpy-reviewer.lock.yml
@@ -45,7 +45,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/grumpy')) && (github.event.issue.pull_request != null)) ||
       (github.event_name == 'pull_request_review_comment') && (contains(github.event.comment.body, '/grumpy')))
     runs-on: ubuntu-slim

--- a/.github/workflows/issue-classifier.lock.yml
+++ b/.github/workflows/issue-classifier.lock.yml
@@ -43,7 +43,7 @@ run-name: "Issue Classifier"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -47,7 +47,7 @@ jobs:
       - pre_activation
       - search_issues
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (needs.search_issues.outputs.has_issues == 'true')
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/mergefest.lock.yml
+++ b/.github/workflows/mergefest.lock.yml
@@ -41,7 +41,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/mergefest')) && (github.event.issue.pull_request != null)))
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/metrics-collector.lock.yml
+++ b/.github/workflows/metrics-collector.lock.yml
@@ -40,7 +40,7 @@ run-name: "Metrics Collector - Infrastructure Agent"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -61,7 +61,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name == 'issue_comment' || github.event_name == 'issues') && ((github.event_name == 'issues') &&
       (contains(github.event.issue.body, '/summarize')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/summarize')) &&

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -45,7 +45,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/plan')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'discussion_comment') && (contains(github.event.comment.body, '/plan')))
     runs-on: ubuntu-slim

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -52,7 +52,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name == 'issues') && ((github.event_name == 'issues') && (contains(github.event.issue.body, '/poem-bot')))) ||
       (!(github.event_name == 'issues')))
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-nitpick-reviewer.lock.yml
+++ b/.github/workflows/pr-nitpick-reviewer.lock.yml
@@ -67,7 +67,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/nit')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/nit')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'issue_comment') &&

--- a/.github/workflows/q.lock.yml
+++ b/.github/workflows/q.lock.yml
@@ -67,7 +67,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/q')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/q')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'issue_comment') &&

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -46,7 +46,7 @@ run-name: "Release"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -78,7 +78,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request' ||
       github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment') &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/scout')) || (github.event_name == 'issue_comment') &&

--- a/.github/workflows/security-fix-pr.lock.yml
+++ b/.github/workflows/security-fix-pr.lock.yml
@@ -43,7 +43,7 @@ run-name: "Security Fix PR"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/security-guard.lock.yml
+++ b/.github/workflows/security-guard.lock.yml
@@ -42,7 +42,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.draft == false)) && ((github.event_name != 'pull_request') ||
       (github.event.pull_request.head.repo.id == github.repository_id)))
     runs-on: ubuntu-slim

--- a/.github/workflows/security-review.lock.yml
+++ b/.github/workflows/security-review.lock.yml
@@ -45,7 +45,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/security-review')) &&
       (github.event.issue.pull_request != null)) || (github.event_name == 'pull_request_review_comment') &&
       (contains(github.event.comment.body, '/security-review')))

--- a/.github/workflows/slide-deck-maintainer.lock.yml
+++ b/.github/workflows/slide-deck-maintainer.lock.yml
@@ -45,7 +45,7 @@ run-name: "Slide Deck Maintainer"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -56,7 +56,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
       ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
     runs-on: ubuntu-slim

--- a/.github/workflows/smoke-codex.lock.yml
+++ b/.github/workflows/smoke-codex.lock.yml
@@ -53,7 +53,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
       ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
     runs-on: ubuntu-slim

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -52,7 +52,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
       ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
     runs-on: ubuntu-slim

--- a/.github/workflows/smoke-opencode.lock.yml
+++ b/.github/workflows/smoke-opencode.lock.yml
@@ -52,7 +52,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
       ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
     runs-on: ubuntu-slim

--- a/.github/workflows/smoke-test-tools.lock.yml
+++ b/.github/workflows/smoke-test-tools.lock.yml
@@ -47,7 +47,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
       ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
     runs-on: ubuntu-slim

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -53,7 +53,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/tidy')) &&
       (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment')))
     runs-on: ubuntu-slim

--- a/.github/workflows/ubuntu-image-analyzer.lock.yml
+++ b/.github/workflows/ubuntu-image-analyzer.lock.yml
@@ -41,7 +41,7 @@ run-name: "Ubuntu Actions Image Analyzer"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/unbloat-docs.lock.yml
+++ b/.github/workflows/unbloat-docs.lock.yml
@@ -49,7 +49,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/unbloat')) &&
       (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment')))
     runs-on: ubuntu-slim

--- a/.github/workflows/workflow-generator.lock.yml
+++ b/.github/workflows/workflow-generator.lock.yml
@@ -41,7 +41,7 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      ((needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')) &&
+      ((!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))) &&
       (startsWith(github.event.issue.title, '[Workflow]'))
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/workflow-health-manager.lock.yml
+++ b/.github/workflows/workflow-health-manager.lock.yml
@@ -44,7 +44,7 @@ run-name: "Workflow Health Manager - Meta-Orchestrator"
 jobs:
   activation:
     needs: pre_activation
-    if: (needs.pre_activation.result == 'skipped') || (needs.pre_activation.outputs.activated == 'true')
+    if: (!cancelled()) && ((!(needs.pre_activation.result)) || (needs.pre_activation.outputs.activated == 'true'))
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Updated activation job conditions across multiple GitHub Actions workflows
- Added `!cancelled()` check to ensure dependent jobs run correctly
- Modified pre-activation job result checking logic

## Details

The changes address an issue with job activation in GitHub Actions workflows by:
- Improving how skipped jobs are detected using `!(needs.pre_activation.result)`
- Ensuring jobs can run even when pre-activation is skipped
- Adding a `!cancelled()` check to prevent premature job skipping