### PR TITLE
docs: rearrange sections in campaigns guide

### DIFF
--- a/docs/src/content/docs/guides/campaigns/getting-started.mdx
+++ b/docs/src/content/docs/guides/campaigns/getting-started.mdx
@@ -12,7 +12,8 @@ banner:
 **Prerequisites:**
 - Repository with GitHub Agentic Workflows installed
 - GitHub Actions enabled
-- A GitHub Projects board (or create one during setup)
+- (Optional) GitHub Projects V2 board for tracking campaign progress
+
 
 **Create a campaign workflow:**
 
@@ -34,9 +35,6 @@ imports:
 ---
 
 # My Campaign
-
-- Project URL: https://github.com/orgs/myorg/projects/1
-- Campaign ID: my-campaign
 
 Your campaign instructions here...
 ```
@@ -66,9 +64,9 @@ git push
 
 The `imports: [shared/campaign.md]` includes standard agent coordination rules and safe-output defaults.
 
-## Example: Dependabot Burner (the smallest useful campaign)
+## Example: Dependabot Burner
 
-The [Dependabot Burner workflow](https://github.com/githubnext/gh-aw/blob/main/.github/workflows/dependabot-burner.md) is **the smallest useful campaign** - it demonstrates the essential campaign pattern with minimal complexity:
+The [Dependabot Burner workflow](https://github.com/githubnext/gh-aw/blob/main/.github/workflows/dependabot-burner.md) is a small but useful campaign - it demonstrates the essential campaign pattern with minimal complexity:
 
 ```yaml
 ---
@@ -84,12 +82,10 @@ permissions:
 
 imports:
   - shared/campaign.md
+
+project: https://github.com/orgs/githubnext/projects/144
 ---
-
 # Dependabot Burner
-
-- Project URL: https://github.com/orgs/githubnext/projects/144
-- Campaign ID: dependabot-burner
 
 - Find all open Dependabot PRs and add them to the project.
 - Create bundle issues for each runtime + manifest file.
@@ -97,15 +93,10 @@ imports:
 ```
 
 Key features:
-- **Imports coordination** - Uses `shared/campaign.md` for standard rules
+- **Imports orchestration** - Uses `shared/campaign.md` for standard rules
 - **Scheduled execution** - Runs daily to process new Dependabot PRs
 - **Smart discovery** - Only runs if matching PRs exist (`skip-if-no-match`)
 - **Project tracking** - Adds discovered items to GitHub Projects board
-
-## More Examples
-
-For a complete campaign workflow example, see:
-- [Security Scanner Campaign](/gh-aw/examples/campaigns/security-scanner/) - Demonstrates vulnerability scanning with safe-output limits
 
 ## How it works
 

--- a/docs/src/content/docs/guides/campaigns/index.mdx
+++ b/docs/src/content/docs/guides/campaigns/index.mdx
@@ -15,9 +15,9 @@ They run on a schedule and include:
 - **Natural language coordination** with defaults being imported from `shared/campaign.md`
 - **Progress tracking** with optional automatic [GitHub Projects](/gh-aw/reference/glossary/#github-projects-projects-v2)
 
-## Getting Started
+## When should this just be a workflow?
 
-To create your first campaign workflow with step-by-step instructions, see the [Getting Started guide](/gh-aw/guides/campaigns/getting-started/).
+**Rule of thumb:** If you're not tracking work items in a GitHub Project or coordinating multiple agents, you probably just need a regular workflow.
 
 ## How it works
 
@@ -27,6 +27,6 @@ The `shared/campaign.md` import provides:
 - **Coordination rules** - Best practices for discovery, deterministic execution, and reporting
 - **Project integration** - Standard patterns for tracking work in GitHub Projects
 
-## When should this just be a workflow?
+## Getting Started
 
-**Rule of thumb:** If you're not tracking work items in a GitHub Project or coordinating multiple agents, you probably just need a regular workflow.
+To create your first campaign workflow with step-by-step instructions, see the [Getting Started guide](/gh-aw/guides/campaigns/getting-started/).


### PR DESCRIPTION
- Updates the campaign docs to clarify the role of GitHub Projects, improve the organization of example content, and refine the explanation of when to use campaigns versus regular workflows.