### PR TITLE
🔧 Disable optimization for workflow pre-activation

### DIFF
--- a/.github/workflows/agent-performance-analyzer.lock.yml
+++ b/.github/workflows/agent-performance-analyzer.lock.yml
@@ -1252,8 +1252,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/agent-persona-explorer.lock.yml
+++ b/.github/workflows/agent-persona-explorer.lock.yml
@@ -1123,8 +1123,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/ai-moderator.lock.yml
+++ b/.github/workflows/ai-moderator.lock.yml
@@ -937,8 +937,6 @@ jobs:
             await main();
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/archie.lock.yml
+++ b/.github/workflows/archie.lock.yml
@@ -1044,13 +1044,13 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issues') && (contains(github.event.issue.body, '/archie')) || (github.event_name == 'issue_comment') &&
+      (github.event_name == 'issues') && (contains(github.event.issue.body, '/archie')) ||
+      (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/archie')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/archie')) && (github.event.issue.pull_request != null)) ||
       (github.event_name == 'pull_request') &&
-      (contains(github.event.pull_request.body, '/archie')))
+      (contains(github.event.pull_request.body, '/archie'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/auto-triage-issues.lock.yml
+++ b/.github/workflows/auto-triage-issues.lock.yml
@@ -1114,8 +1114,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -1026,8 +1026,7 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/brave')) && (github.event.issue.pull_request == null)))
+      (github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/brave')) && (github.event.issue.pull_request == null))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/changeset.lock.yml
+++ b/.github/workflows/changeset.lock.yml
@@ -1235,10 +1235,9 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event.pull_request.base.ref == github.event.repository.default_branch) && ((github.event_name != 'pull_request') ||
+      ((github.event.pull_request.base.ref == github.event.repository.default_branch) && ((github.event_name != 'pull_request') ||
       (github.event.pull_request.head.repo.id == github.repository_id))) && ((github.event_name != 'pull_request') ||
-      ((github.event.action != 'labeled') || (github.event.label.name == 'changeset' || github.event.label.name == 'smoke'))))
+      ((github.event.action != 'labeled') || (github.event.label.name == 'changeset' || github.event.label.name == 'smoke')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/cloclo.lock.yml
+++ b/.github/workflows/cloclo.lock.yml
@@ -1408,8 +1408,7 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((((github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request' ||
+      (((github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request' ||
       github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment') &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/cloclo')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/cloclo')) && (github.event.issue.pull_request == null)) ||
@@ -1423,7 +1422,7 @@ jobs:
       (contains(github.event.comment.body, '/cloclo')))) || (!(github.event_name == 'issues' || github.event_name == 'issue_comment' ||
       github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' ||
       github.event_name == 'discussion_comment'))) && ((github.event_name != 'issues') || ((github.event.action != 'labeled') ||
-      (github.event.label.name == 'cloclo'))))
+      (github.event.label.name == 'cloclo')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/craft.lock.yml
+++ b/.github/workflows/craft.lock.yml
@@ -1059,9 +1059,7 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issues') && (contains(github.event.issue.body, '/craft')))
+    if: (github.event_name == 'issues') && (contains(github.event.issue.body, '/craft'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-issues-report.lock.yml
+++ b/.github/workflows/daily-issues-report.lock.yml
@@ -1820,8 +1820,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/daily-observability-report.lock.yml
+++ b/.github/workflows/daily-observability-report.lock.yml
@@ -1169,8 +1169,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/dev-hawk.lock.yml
+++ b/.github/workflows/dev-hawk.lock.yml
@@ -1039,9 +1039,7 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (${{ github.event.workflow_run.event == 'workflow_dispatch' }})
+    if: ${{ github.event.workflow_run.event == 'workflow_dispatch' }}
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/example-custom-error-patterns.lock.yml
+++ b/.github/workflows/example-custom-error-patterns.lock.yml
@@ -450,8 +450,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/firewall-escape.lock.yml
+++ b/.github/workflows/firewall-escape.lock.yml
@@ -1093,9 +1093,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
-      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'firewall-escape-test'))))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
+      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'firewall-escape-test')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/grumpy-reviewer.lock.yml
+++ b/.github/workflows/grumpy-reviewer.lock.yml
@@ -1107,9 +1107,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/grumpy')) && (github.event.issue.pull_request != null)) ||
-      (github.event_name == 'pull_request_review_comment') && (contains(github.event.comment.body, '/grumpy')))
+      (github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/grumpy')) && (github.event.issue.pull_request != null)) ||
+      (github.event_name == 'pull_request_review_comment') && (contains(github.event.comment.body, '/grumpy'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/issue-classifier.lock.yml
+++ b/.github/workflows/issue-classifier.lock.yml
@@ -922,8 +922,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/mergefest.lock.yml
+++ b/.github/workflows/mergefest.lock.yml
@@ -1048,8 +1048,7 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/mergefest')) && (github.event.issue.pull_request != null)))
+      (github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/mergefest')) && (github.event.issue.pull_request != null))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/metrics-collector.lock.yml
+++ b/.github/workflows/metrics-collector.lock.yml
@@ -534,8 +534,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -1116,11 +1116,10 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name == 'issue_comment' || github.event_name == 'issues') && ((github.event_name == 'issues') &&
+      ((github.event_name == 'issue_comment' || github.event_name == 'issues') && ((github.event_name == 'issues') &&
       (contains(github.event.issue.body, '/summarize')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/summarize')) &&
-      (github.event.issue.pull_request == null)))) || (!(github.event_name == 'issue_comment' || github.event_name == 'issues')))
+      (github.event.issue.pull_request == null)))) || (!(github.event_name == 'issue_comment' || github.event_name == 'issues'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -1103,9 +1103,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/plan')) && (github.event.issue.pull_request == null)) ||
-      (github.event_name == 'discussion_comment') && (contains(github.event.comment.body, '/plan')))
+      (github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/plan')) && (github.event.issue.pull_request == null)) ||
+      (github.event_name == 'discussion_comment') && (contains(github.event.comment.body, '/plan'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -1726,8 +1726,8 @@ jobs:
 
   pre_activation:
     if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (((github.event_name == 'issues') &&
-      ((github.event_name == 'issues') && (contains(github.event.issue.body, '/poem-bot')))) || (!(github.event_name == 'issues')))
+      ((github.event_name == 'issues') && ((github.event_name == 'issues') && (contains(github.event.issue.body, '/poem-bot')))) ||
+      (!(github.event_name == 'issues'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/pr-nitpick-reviewer.lock.yml
+++ b/.github/workflows/pr-nitpick-reviewer.lock.yml
@@ -1253,8 +1253,7 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issues') && (contains(github.event.issue.body, '/nit')) || (github.event_name == 'issue_comment') &&
+      (github.event_name == 'issues') && (contains(github.event.issue.body, '/nit')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/nit')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/nit')) && (github.event.issue.pull_request != null)) ||
@@ -1263,7 +1262,7 @@ jobs:
       (contains(github.event.pull_request.body, '/nit')) ||
       (github.event_name == 'discussion') && (contains(github.event.discussion.body, '/nit')) ||
       (github.event_name == 'discussion_comment') &&
-      (contains(github.event.comment.body, '/nit')))
+      (contains(github.event.comment.body, '/nit'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/q.lock.yml
+++ b/.github/workflows/q.lock.yml
@@ -1183,8 +1183,7 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issues') && (contains(github.event.issue.body, '/q')) || (github.event_name == 'issue_comment') &&
+      (github.event_name == 'issues') && (contains(github.event.issue.body, '/q')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/q')) && (github.event.issue.pull_request == null)) ||
       (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/q')) && (github.event.issue.pull_request != null)) ||
@@ -1193,7 +1192,7 @@ jobs:
       (contains(github.event.pull_request.body, '/q')) ||
       (github.event_name == 'discussion') && (contains(github.event.discussion.body, '/q')) ||
       (github.event_name == 'discussion_comment') &&
-      (contains(github.event.comment.body, '/q')))
+      (contains(github.event.comment.body, '/q'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1114,7 +1114,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: (github.event_name != 'schedule') && (github.event_name != 'merge_group')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -1376,8 +1376,7 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request' ||
+      ((github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request' ||
       github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment') &&
       ((github.event_name == 'issues') && (contains(github.event.issue.body, '/scout')) || (github.event_name == 'issue_comment') &&
       ((contains(github.event.comment.body, '/scout')) && (github.event.issue.pull_request == null)) ||
@@ -1390,7 +1389,7 @@ jobs:
       (github.event_name == 'discussion_comment') &&
       (contains(github.event.comment.body, '/scout')))) || (!(github.event_name == 'issues' || github.event_name == 'issue_comment' ||
       github.event_name == 'pull_request' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' ||
-      github.event_name == 'discussion_comment')))
+      github.event_name == 'discussion_comment'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/security-guard.lock.yml
+++ b/.github/workflows/security-guard.lock.yml
@@ -971,9 +971,9 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.draft == false)) && ((github.event_name != 'pull_request') ||
-      (github.event.pull_request.head.repo.id == github.repository_id)))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.draft == false)) &&
+      ((github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/security-review.lock.yml
+++ b/.github/workflows/security-review.lock.yml
@@ -1147,10 +1147,9 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/security-review')) &&
+      (github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/security-review')) &&
       (github.event.issue.pull_request != null)) || (github.event_name == 'pull_request_review_comment') &&
-      (contains(github.event.comment.body, '/security-review')))
+      (contains(github.event.comment.body, '/security-review'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/smoke-claude.lock.yml
+++ b/.github/workflows/smoke-claude.lock.yml
@@ -2104,9 +2104,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
-      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
+      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/smoke-codex.lock.yml
+++ b/.github/workflows/smoke-codex.lock.yml
@@ -1885,9 +1885,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
-      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
+      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -1819,9 +1819,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
-      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
+      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/smoke-opencode.lock.yml
+++ b/.github/workflows/smoke-opencode.lock.yml
@@ -1718,9 +1718,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
-      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
+      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/smoke-test-tools.lock.yml
+++ b/.github/workflows/smoke-test-tools.lock.yml
@@ -999,9 +999,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
-      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke'))))
+      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)) &&
+      ((github.event_name != 'pull_request') || ((github.event.action != 'labeled') || (github.event.label.name == 'smoke')))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/test-yaml-import.lock.yml
+++ b/.github/workflows/test-yaml-import.lock.yml
@@ -486,8 +486,6 @@ jobs:
           path: licenses.csv
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -1136,9 +1136,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/tidy')) &&
-      (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment')))
+      ((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/tidy')) &&
+      (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/unbloat-docs.lock.yml
+++ b/.github/workflows/unbloat-docs.lock.yml
@@ -1438,9 +1438,8 @@ jobs:
 
   pre_activation:
     if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/unbloat')) &&
-      (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment')))
+      ((github.event_name == 'issue_comment') && ((github.event_name == 'issue_comment') && ((contains(github.event.comment.body, '/unbloat')) &&
+      (github.event.issue.pull_request != null)))) || (!(github.event_name == 'issue_comment'))
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/workflow-generator.lock.yml
+++ b/.github/workflows/workflow-generator.lock.yml
@@ -1107,9 +1107,7 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      (((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')) &&
-      (startsWith(github.event.issue.title, '[Workflow]'))
+    if: startsWith(github.event.issue.title, '[Workflow]')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/workflow-health-manager.lock.yml
+++ b/.github/workflows/workflow-health-manager.lock.yml
@@ -1254,8 +1254,6 @@ jobs:
           if-no-files-found: ignore
 
   pre_activation:
-    if: >
-      ((github.event_name != 'schedule') && (github.event_name != 'merge_group')) && (github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/pkg/workflow/compiler_activation_jobs.go
+++ b/pkg/workflow/compiler_activation_jobs.go
@@ -285,7 +285,7 @@ func (c *Compiler) buildPreActivationJob(data *WorkflowData, needsPermissionChec
 	//   because check_membership.cjs already short-circuits for workflow_dispatch when write is allowed
 	//
 	// When pre_activation is skipped, downstream jobs check for needs.pre_activation.result == 'skipped'
-	canSkipForSafeEvents := c.skipPreActivationOptimization &&
+	canSkipForSafeEvents := c.skipPreActivationWithIfOptimization &&
 		data.StopTime == "" &&
 		data.SkipIfMatch == nil &&
 		data.SkipIfNoMatch == nil &&

--- a/pkg/workflow/compiler_activation_jobs.go
+++ b/pkg/workflow/compiler_activation_jobs.go
@@ -285,7 +285,8 @@ func (c *Compiler) buildPreActivationJob(data *WorkflowData, needsPermissionChec
 	//   because check_membership.cjs already short-circuits for workflow_dispatch when write is allowed
 	//
 	// When pre_activation is skipped, downstream jobs check for needs.pre_activation.result == 'skipped'
-	canSkipForSafeEvents := data.StopTime == "" &&
+	canSkipForSafeEvents := c.skipPreActivationOptimization &&
+		data.StopTime == "" &&
 		data.SkipIfMatch == nil &&
 		data.SkipIfNoMatch == nil &&
 		len(customSteps) == 0

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -72,11 +72,11 @@ func WithRepositorySlug(slug string) CompilerOption {
 	return func(c *Compiler) { c.repositorySlug = slug }
 }
 
-// WithSkipPreActivationOptimization enables the optimization that adds
+// WithSkipPreActivationWithIfOptimization enables the optimization that adds
 // an "if" condition to the pre_activation job to skip it for safe events (schedule, merge_group, etc.)
 // This is disabled by default. Enable it only when specifically testing this optimization.
-func WithSkipPreActivationOptimization(enable bool) CompilerOption {
-	return func(c *Compiler) { c.skipPreActivationOptimization = enable }
+func WithSkipPreActivationWithIfOptimization(enable bool) CompilerOption {
+	return func(c *Compiler) { c.skipPreActivationWithIfOptimization = enable }
 }
 
 // FileTracker interface for tracking files created during compilation
@@ -101,38 +101,38 @@ func GetDefaultVersion() string {
 
 // Compiler handles converting markdown workflows to GitHub Actions YAML
 type Compiler struct {
-	verbose                       bool
-	quiet                         bool // If true, suppress success messages (for interactive mode)
-	engineOverride                string
-	customOutput                  string              // If set, output will be written to this path instead of default location
-	version                       string              // Version of the extension
-	skipValidation                bool                // If true, skip schema validation
-	noEmit                        bool                // If true, validate without generating lock files
-	strictMode                    bool                // If true, enforce strict validation requirements
-	trialMode                     bool                // If true, suppress safe outputs for trial mode execution
-	trialLogicalRepoSlug          string              // If set in trial mode, the logical repository to checkout
-	refreshStopTime               bool                // If true, regenerate stop-after times instead of preserving existing ones
-	forceRefreshActionPins        bool                // If true, clear action cache and resolve all actions from GitHub API
-	failFast                      bool                // If true, stop at first validation error instead of collecting all errors
-	actionCacheCleared            bool                // Tracks if action cache has already been cleared (for forceRefreshActionPins)
-	markdownPath                  string              // Path to the markdown file being compiled (for context in dynamic tool generation)
-	actionMode                    ActionMode          // Mode for generating JavaScript steps (inline vs custom actions)
-	actionTag                     string              // Override action SHA or tag for actions/setup (when set, overrides actionMode to release)
-	jobManager                    *JobManager         // Manages jobs and dependencies
-	engineRegistry                *EngineRegistry     // Registry of available agentic engines
-	fileTracker                   FileTracker         // Optional file tracker for tracking created files
-	warningCount                  int                 // Number of warnings encountered during compilation
-	stepOrderTracker              *StepOrderTracker   // Tracks step ordering for validation
-	actionCache                   *ActionCache        // Shared cache for action pin resolutions across all workflows
-	actionResolver                *ActionResolver     // Shared resolver for action pins across all workflows
-	actionPinWarnings             map[string]bool     // Shared cache of already-warned action pin failures (key: "repo@version")
-	importCache                   *parser.ImportCache // Shared cache for imported workflow files
-	workflowIdentifier            string              // Identifier for the current workflow being compiled (for schedule scattering)
-	scheduleWarnings              []string            // Accumulated schedule warnings for this compiler instance
-	repositorySlug                string              // Repository slug (owner/repo) used as seed for scattering
-	artifactManager               *ArtifactManager    // Tracks artifact uploads/downloads for validation
-	scheduleFriendlyFormats       map[int]string      // Maps schedule item index to friendly format string for current workflow
-	skipPreActivationOptimization bool                // If true, add if condition to pre_activation job to skip for safe events
+	verbose                             bool
+	quiet                               bool // If true, suppress success messages (for interactive mode)
+	engineOverride                      string
+	customOutput                        string              // If set, output will be written to this path instead of default location
+	version                             string              // Version of the extension
+	skipValidation                      bool                // If true, skip schema validation
+	noEmit                              bool                // If true, validate without generating lock files
+	strictMode                          bool                // If true, enforce strict validation requirements
+	trialMode                           bool                // If true, suppress safe outputs for trial mode execution
+	trialLogicalRepoSlug                string              // If set in trial mode, the logical repository to checkout
+	refreshStopTime                     bool                // If true, regenerate stop-after times instead of preserving existing ones
+	forceRefreshActionPins              bool                // If true, clear action cache and resolve all actions from GitHub API
+	failFast                            bool                // If true, stop at first validation error instead of collecting all errors
+	actionCacheCleared                  bool                // Tracks if action cache has already been cleared (for forceRefreshActionPins)
+	markdownPath                        string              // Path to the markdown file being compiled (for context in dynamic tool generation)
+	actionMode                          ActionMode          // Mode for generating JavaScript steps (inline vs custom actions)
+	actionTag                           string              // Override action SHA or tag for actions/setup (when set, overrides actionMode to release)
+	jobManager                          *JobManager         // Manages jobs and dependencies
+	engineRegistry                      *EngineRegistry     // Registry of available agentic engines
+	fileTracker                         FileTracker         // Optional file tracker for tracking created files
+	warningCount                        int                 // Number of warnings encountered during compilation
+	stepOrderTracker                    *StepOrderTracker   // Tracks step ordering for validation
+	actionCache                         *ActionCache        // Shared cache for action pin resolutions across all workflows
+	actionResolver                      *ActionResolver     // Shared resolver for action pins across all workflows
+	actionPinWarnings                   map[string]bool     // Shared cache of already-warned action pin failures (key: "repo@version")
+	importCache                         *parser.ImportCache // Shared cache for imported workflow files
+	workflowIdentifier                  string              // Identifier for the current workflow being compiled (for schedule scattering)
+	scheduleWarnings                    []string            // Accumulated schedule warnings for this compiler instance
+	repositorySlug                      string              // Repository slug (owner/repo) used as seed for scattering
+	artifactManager                     *ArtifactManager    // Tracks artifact uploads/downloads for validation
+	scheduleFriendlyFormats             map[int]string      // Maps schedule item index to friendly format string for current workflow
+	skipPreActivationWithIfOptimization bool                // If true, add if condition to pre_activation job to skip for safe events
 }
 
 // NewCompiler creates a new workflow compiler with functional options.

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -72,6 +72,13 @@ func WithRepositorySlug(slug string) CompilerOption {
 	return func(c *Compiler) { c.repositorySlug = slug }
 }
 
+// WithSkipPreActivationOptimization enables the optimization that adds
+// an "if" condition to the pre_activation job to skip it for safe events (schedule, merge_group, etc.)
+// This is disabled by default. Enable it only when specifically testing this optimization.
+func WithSkipPreActivationOptimization(enable bool) CompilerOption {
+	return func(c *Compiler) { c.skipPreActivationOptimization = enable }
+}
+
 // FileTracker interface for tracking files created during compilation
 type FileTracker interface {
 	TrackCreated(filePath string)
@@ -94,37 +101,38 @@ func GetDefaultVersion() string {
 
 // Compiler handles converting markdown workflows to GitHub Actions YAML
 type Compiler struct {
-	verbose                 bool
-	quiet                   bool // If true, suppress success messages (for interactive mode)
-	engineOverride          string
-	customOutput            string              // If set, output will be written to this path instead of default location
-	version                 string              // Version of the extension
-	skipValidation          bool                // If true, skip schema validation
-	noEmit                  bool                // If true, validate without generating lock files
-	strictMode              bool                // If true, enforce strict validation requirements
-	trialMode               bool                // If true, suppress safe outputs for trial mode execution
-	trialLogicalRepoSlug    string              // If set in trial mode, the logical repository to checkout
-	refreshStopTime         bool                // If true, regenerate stop-after times instead of preserving existing ones
-	forceRefreshActionPins  bool                // If true, clear action cache and resolve all actions from GitHub API
-	failFast                bool                // If true, stop at first validation error instead of collecting all errors
-	actionCacheCleared      bool                // Tracks if action cache has already been cleared (for forceRefreshActionPins)
-	markdownPath            string              // Path to the markdown file being compiled (for context in dynamic tool generation)
-	actionMode              ActionMode          // Mode for generating JavaScript steps (inline vs custom actions)
-	actionTag               string              // Override action SHA or tag for actions/setup (when set, overrides actionMode to release)
-	jobManager              *JobManager         // Manages jobs and dependencies
-	engineRegistry          *EngineRegistry     // Registry of available agentic engines
-	fileTracker             FileTracker         // Optional file tracker for tracking created files
-	warningCount            int                 // Number of warnings encountered during compilation
-	stepOrderTracker        *StepOrderTracker   // Tracks step ordering for validation
-	actionCache             *ActionCache        // Shared cache for action pin resolutions across all workflows
-	actionResolver          *ActionResolver     // Shared resolver for action pins across all workflows
-	actionPinWarnings       map[string]bool     // Shared cache of already-warned action pin failures (key: "repo@version")
-	importCache             *parser.ImportCache // Shared cache for imported workflow files
-	workflowIdentifier      string              // Identifier for the current workflow being compiled (for schedule scattering)
-	scheduleWarnings        []string            // Accumulated schedule warnings for this compiler instance
-	repositorySlug          string              // Repository slug (owner/repo) used as seed for scattering
-	artifactManager         *ArtifactManager    // Tracks artifact uploads/downloads for validation
-	scheduleFriendlyFormats map[int]string      // Maps schedule item index to friendly format string for current workflow
+	verbose                       bool
+	quiet                         bool // If true, suppress success messages (for interactive mode)
+	engineOverride                string
+	customOutput                  string              // If set, output will be written to this path instead of default location
+	version                       string              // Version of the extension
+	skipValidation                bool                // If true, skip schema validation
+	noEmit                        bool                // If true, validate without generating lock files
+	strictMode                    bool                // If true, enforce strict validation requirements
+	trialMode                     bool                // If true, suppress safe outputs for trial mode execution
+	trialLogicalRepoSlug          string              // If set in trial mode, the logical repository to checkout
+	refreshStopTime               bool                // If true, regenerate stop-after times instead of preserving existing ones
+	forceRefreshActionPins        bool                // If true, clear action cache and resolve all actions from GitHub API
+	failFast                      bool                // If true, stop at first validation error instead of collecting all errors
+	actionCacheCleared            bool                // Tracks if action cache has already been cleared (for forceRefreshActionPins)
+	markdownPath                  string              // Path to the markdown file being compiled (for context in dynamic tool generation)
+	actionMode                    ActionMode          // Mode for generating JavaScript steps (inline vs custom actions)
+	actionTag                     string              // Override action SHA or tag for actions/setup (when set, overrides actionMode to release)
+	jobManager                    *JobManager         // Manages jobs and dependencies
+	engineRegistry                *EngineRegistry     // Registry of available agentic engines
+	fileTracker                   FileTracker         // Optional file tracker for tracking created files
+	warningCount                  int                 // Number of warnings encountered during compilation
+	stepOrderTracker              *StepOrderTracker   // Tracks step ordering for validation
+	actionCache                   *ActionCache        // Shared cache for action pin resolutions across all workflows
+	actionResolver                *ActionResolver     // Shared resolver for action pins across all workflows
+	actionPinWarnings             map[string]bool     // Shared cache of already-warned action pin failures (key: "repo@version")
+	importCache                   *parser.ImportCache // Shared cache for imported workflow files
+	workflowIdentifier            string              // Identifier for the current workflow being compiled (for schedule scattering)
+	scheduleWarnings              []string            // Accumulated schedule warnings for this compiler instance
+	repositorySlug                string              // Repository slug (owner/repo) used as seed for scattering
+	artifactManager               *ArtifactManager    // Tracks artifact uploads/downloads for validation
+	scheduleFriendlyFormats       map[int]string      // Maps schedule item index to friendly format string for current workflow
+	skipPreActivationOptimization bool                // If true, add if condition to pre_activation job to skip for safe events
 }
 
 // NewCompiler creates a new workflow compiler with functional options.

--- a/pkg/workflow/pre_activation_skip_test.go
+++ b/pkg/workflow/pre_activation_skip_test.go
@@ -21,7 +21,7 @@ import (
 func TestPreActivationSkipForScheduleEvents(t *testing.T) {
 	tmpDir := testutil.TempDir(t, "pre-activation-skip-test")
 	// Enable the pre_activation skip optimization for this test since we're specifically testing this behavior
-	compiler := NewCompiler(WithSkipPreActivationOptimization(true))
+	compiler := NewCompiler(WithSkipPreActivationWithIfOptimization(true))
 
 	t.Run("schedule_only_workflow_has_no_pre_activation", func(t *testing.T) {
 		// Schedule-only workflows don't need a pre_activation job at all

--- a/pkg/workflow/pre_activation_skip_test.go
+++ b/pkg/workflow/pre_activation_skip_test.go
@@ -17,9 +17,11 @@ import (
 
 // TestPreActivationSkipForScheduleEvents verifies that the pre_activation job is skipped
 // for safe events (schedule, merge_group) and that downstream jobs handle this correctly.
+// NOTE: This test enables the pre_activation skip optimization which is disabled by default.
 func TestPreActivationSkipForScheduleEvents(t *testing.T) {
 	tmpDir := testutil.TempDir(t, "pre-activation-skip-test")
-	compiler := NewCompiler()
+	// Enable the pre_activation skip optimization for this test since we're specifically testing this behavior
+	compiler := NewCompiler(WithSkipPreActivationOptimization(true))
 
 	t.Run("schedule_only_workflow_has_no_pre_activation", func(t *testing.T) {
 		// Schedule-only workflows don't need a pre_activation job at all


### PR DESCRIPTION
## Summary

- Removed redundant `if` conditions in multiple workflow files that prevented pre-activation for schedule, merge_group, and workflow_dispatch events
- Added a new compiler option to control pre-activation optimization
- Simplified pre-activation job conditions across various workflow files

## Changes

- Removed complex `if` conditions in pre-activation jobs for multiple workflow files
- Introduced `skipPreActivationOptimization` flag in the workflow compiler
- Created a new compiler option `WithSkipPreActivationOptimization` to enable/disable the optimization
- Updated `compiler_activation_jobs.go` to support the new optimization flag