### PR TITLE
Auto-add 'Fixes #N' closing keyword to PR body when triggered from issue

### DIFF
--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -81,6 +81,11 @@ async function main(config = {}) {
     throw new Error("base_branch configuration is required");
   }
 
+  // Extract triggering issue number from context (for auto-linking PRs to issues)
+  const triggeringIssueNumber = context.payload?.issue?.number && !context.payload?.issue?.pull_request
+    ? context.payload.issue.number
+    : undefined;
+
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
 
@@ -327,6 +332,17 @@ async function main(config = {}) {
 
     // Remove duplicate title from description if it starts with a header matching the title
     processedBody = removeDuplicateTitleFromDescription(title, processedBody);
+
+    // Auto-add "Fixes #N" closing keyword if triggered from an issue and not already present.
+    // This ensures the triggering issue is auto-closed when the PR is merged.
+    // Agents are instructed to include this but don't reliably do so.
+    if (triggeringIssueNumber) {
+      const hasClosingKeyword = /(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\s+#\d+/i.test(processedBody);
+      if (!hasClosingKeyword) {
+        processedBody = processedBody.trimEnd() + `\n\nFixes #${triggeringIssueNumber}`;
+        core.info(`Auto-added "Fixes #${triggeringIssueNumber}" closing keyword to PR body`);
+      }
+    }
 
     let bodyLines = processedBody.split("\n");
     let branchName = pullRequestItem.branch ? pullRequestItem.branch.trim() : null;


### PR DESCRIPTION
## Summary

When the Copilot SWE agent (or any AI agent) is assigned to an issue and creates a PR via the `create_pull_request` safe output, the PR body typically doesn't include GitHub closing keywords (`Fixes #N`, `Closes #N`, `Resolves #N`). This means the original issue **does not auto-close when the PR is merged**.

This PR auto-injects `Fixes #<issue_number>` into the PR body when:
1. The workflow was triggered from an issue context (`context.payload.issue.number` exists)
2. The PR body doesn't already contain a closing keyword

### Changes

- Extract `triggeringIssueNumber` from context in `create_pull_request.cjs` (same pattern as `create_issue.cjs` line 241 and `create_pr_review_comment.cjs` line 43)
- After `removeDuplicateTitleFromDescription`, check for existing closing keywords via regex
- If missing, append `Fixes #N` to the PR body before footer generation

### Why

Agents are instructed to include "Fixes #ISSUE_NUMBER" in PR descriptions but **don't reliably follow it**. Tested across 10+ Copilot PRs in [kubestellar/console](https://github.com/kubestellar/console) — none included closing keywords despite the instruction appearing in:
- `.github/copilot-instructions.md`
- Workflow comment instructions
- Issue assignment comments

This is a common pain point — repos using Copilot for automated issue fixing accumulate open issues even after fix PRs are merged.

### Test plan

- [ ] Trigger a workflow from an issue assignment → verify `Fixes #N` appears in the created PR body
- [ ] Trigger same workflow when agent already includes `Fixes #N` → verify no duplicate is added
- [ ] Trigger from a non-issue context (e.g., `push`) → verify no `Fixes` line is added

Fixes #12822

🤖 Generated with [Claude Code](https://claude.com/claude-code)