### PR TITLE
Fix test references to GitHub organization name

### DIFF
--- a/actions/setup/js/frontmatter_hash_github_api.test.cjs
+++ b/actions/setup/js/frontmatter_hash_github_api.test.cjs
@@ -52,7 +52,7 @@ describe("frontmatter_hash with GitHub API", () => {
 
   describe("createGitHubFileReader", () => {
     it("should create a file reader that fetches from GitHub API", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -68,7 +68,7 @@ describe("frontmatter_hash with GitHub API", () => {
     });
 
     it("should handle file not found errors", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -80,7 +80,7 @@ describe("frontmatter_hash with GitHub API", () => {
 
   describe("computeFrontmatterHash with real workflow", () => {
     it("should compute hash for audit-workflows.md using GitHub API", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -106,7 +106,7 @@ describe("frontmatter_hash with GitHub API", () => {
     });
 
     it("should handle workflows with imports using GitHub API", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -133,7 +133,7 @@ describe("frontmatter_hash with GitHub API", () => {
     });
 
     it("should compute hash for a workflow without imports", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -178,7 +178,7 @@ describe("frontmatter_hash with GitHub API", () => {
     });
 
     it("should produce deterministic hashes across multiple calls", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -203,7 +203,7 @@ describe("frontmatter_hash with GitHub API", () => {
 
   describe("GitHub API edge cases", () => {
     it("should handle workflows in subdirectories", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -224,7 +224,7 @@ describe("frontmatter_hash with GitHub API", () => {
     });
 
     it("should handle workflows with template expressions", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -249,7 +249,7 @@ describe("frontmatter_hash with GitHub API", () => {
     it("should use repository-relative paths for imports (not absolute filesystem paths)", async () => {
       // This test validates the fix for issue where path.resolve() created absolute paths
       // that broke GitHub API calls
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -312,7 +312,7 @@ describe("frontmatter_hash with GitHub API", () => {
     });
 
     it("should compute same hash with GitHub API reader as with filesystem reader", async () => {
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 
@@ -346,7 +346,7 @@ describe("frontmatter_hash with GitHub API", () => {
 
       // Use real GitHub API client
       const octokit = getOctokit(token);
-      const owner = "githubnext";
+      const owner = "github";
       const repo = "gh-aw";
       const ref = "main";
 

--- a/actions/setup/js/repo_helpers.cjs
+++ b/actions/setup/js/repo_helpers.cjs
@@ -51,7 +51,7 @@ function getDefaultTargetRepo(config) {
  * Validate that a repo is allowed for operations
  * If repo is a bare name (no slash), it is automatically qualified with the
  * default repo's organization (e.g., "gh-aw" becomes "github/gh-aw" if
- * the default repo is "githubnext/something").
+ * the default repo is "github/something").
  * @param {string} repo - Repository slug to validate (can be "owner/repo" or just "repo")
  * @param {string} defaultRepo - Default target repository
  * @param {Set<string>} allowedRepos - Set of explicitly allowed repos

--- a/actions/setup/js/repo_helpers.test.cjs
+++ b/actions/setup/js/repo_helpers.test.cjs
@@ -135,7 +135,7 @@ describe("repo_helpers", () => {
     it("should qualify bare repo name with default repo's org", async () => {
       const { validateRepo } = await import("./repo_helpers.cjs");
       const allowedRepos = new Set(["github/gh-aw"]);
-      const result = validateRepo("gh-aw", "githubnext/other-repo", allowedRepos);
+      const result = validateRepo("gh-aw", "github/other-repo", allowedRepos);
       expect(result.valid).toBe(true);
       expect(result.error).toBe(null);
     });
@@ -149,8 +149,8 @@ describe("repo_helpers", () => {
 
     it("should reject bare repo name not in allowed list", async () => {
       const { validateRepo } = await import("./repo_helpers.cjs");
-      const allowedRepos = new Set(["githubnext/other-repo"]);
-      const result = validateRepo("gh-aw", "githubnext/default-repo", allowedRepos);
+      const allowedRepos = new Set(["github/other-repo"]);
+      const result = validateRepo("gh-aw", "github/default-repo", allowedRepos);
       expect(result.valid).toBe(false);
       expect(result.error).toContain("not in the allowed-repos list");
     });
@@ -158,7 +158,7 @@ describe("repo_helpers", () => {
     it("should not qualify repo name that already has org", async () => {
       const { validateRepo } = await import("./repo_helpers.cjs");
       const allowedRepos = new Set(["github/gh-aw"]);
-      const result = validateRepo("other-org/gh-aw", "githubnext/default-repo", allowedRepos);
+      const result = validateRepo("other-org/gh-aw", "github/default-repo", allowedRepos);
       expect(result.valid).toBe(false);
       expect(result.error).toContain("not in the allowed-repos list");
     });
@@ -264,14 +264,14 @@ describe("repo_helpers", () => {
     it("should qualify bare repo name and return qualified version", async () => {
       const { resolveAndValidateRepo } = await import("./repo_helpers.cjs");
       const item = { repo: "gh-aw" };
-      const defaultRepo = "githubnext/other-repo";
+      const defaultRepo = "github/other-repo";
       const allowedRepos = new Set(["github/gh-aw"]);
 
       const result = resolveAndValidateRepo(item, defaultRepo, allowedRepos, "test");
 
       expect(result.success).toBe(true);
       expect(result.repo).toBe("github/gh-aw");
-      expect(result.repoParts).toEqual({ owner: "githubnext", repo: "gh-aw" });
+      expect(result.repoParts).toEqual({ owner: "github", repo: "gh-aw" });
     });
 
     it("should qualify bare repo name matching default repo", async () => {
@@ -284,7 +284,7 @@ describe("repo_helpers", () => {
 
       expect(result.success).toBe(true);
       expect(result.repo).toBe("github/gh-aw");
-      expect(result.repoParts).toEqual({ owner: "githubnext", repo: "gh-aw" });
+      expect(result.repoParts).toEqual({ owner: "github", repo: "gh-aw" });
     });
   });
 

--- a/actions/setup/js/test-live-github-api.cjs
+++ b/actions/setup/js/test-live-github-api.cjs
@@ -32,7 +32,7 @@ async function testLiveGitHubAPI() {
   console.log("🔍 Testing frontmatter hash with live GitHub API\n");
 
   // Configuration
-  const owner = "githubnext";
+  const owner = "github";
   const repo = "gh-aw";
   const ref = "main";
   const workflowPath = ".github/workflows/audit-workflows.md";

--- a/actions/setup/js/update_project.test.cjs
+++ b/actions/setup/js/update_project.test.cjs
@@ -125,7 +125,7 @@ describe("update_project token guardrails", () => {
   it("fails fast with a clear error when authenticated as github-actions[bot]", async () => {
     delete process.env.GH_AW_PROJECT_GITHUB_TOKEN;
 
-    const projectUrl = "https://github.com/orgs/githubnext/projects/146";
+    const projectUrl = "https://github.com/orgs/github/projects/146";
 
     mockGithub.graphql.mockImplementation(async (query, vars) => {
       const q = String(query);


### PR DESCRIPTION
Update tests and related functions to reference the correct GitHub organization name, ensuring consistency across the codebase.