### PR TITLE
Update docs to align with AWF chroot mode

### DIFF
--- a/docs/src/content/docs/introduction/architecture.mdx
+++ b/docs/src/content/docs/introduction/architecture.mdx
@@ -160,7 +160,11 @@ The SafeOutputs subsystem provides security by design: the agent never requires 
 
 ## Agent Workflow Firewall (AWF)
 
-The Agent Workflow Firewall (AWF) provides network egress control at the substrate level. AWF mediates all outbound network requests from the agent, enforcing a domain allowlist that constrains which external endpoints the agent may contact. This mechanism prevents unauthorized data exfiltration and limits the blast radius of a compromised agent to only those domains explicitly permitted by configuration.
+The Agent Workflow Firewall (AWF) enforces network egress control via a domain allowlist, preventing data exfiltration and containing compromised agents to permitted domains.
+
+AWF separates two concerns:
+- **Filesystem**: All host binaries and runtimes accessible; setup actions work transparently
+- **Network**: All traffic routed through proxy enforcing the domain allowlist
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
## Summary

- Updates documentation to reflect the `--enable-chroot` mode introduced in #13576 (commit 578ac0da3)
- Replaces outdated explicit mount and environment variable sections with chroot mode explanations
- Makes docs more concise by removing redundant tables and consolidating explanations

## Changes

### sandbox.md
- Replace "Default Mounted Volumes" table with "Chroot Mode" section explaining transparent filesystem access
- Replace utility mount tables with single paragraph (all host binaries available)
- Replace environment variable category tables with `--env-all` explanation
- Simplify runtime tools section (setup actions work transparently)

### architecture.mdx
- Add "Chroot-Based Transparency" subsection explaining filesystem/network separation

### security-architecture-spec.md
- Update SI-04 through SI-07 requirements for chroot mode
- Consolidate redundant requirements
- Update compliance test IDs

## Test plan

- [x] Documentation builds without errors (pre-existing link validation issues unrelated to this PR)
- [x] Content is consistent across all three files
- [x] Technical accuracy verified against implementation in `pkg/workflow/*_engine.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)