### PR TITLE
🏗️ Add dry-run support for trial command

### DIFF
--- a/pkg/cli/repo_error_messages_test.go
+++ b/pkg/cli/repo_error_messages_test.go
@@ -55,7 +55,7 @@ func TestRepoSlugErrorMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test ensureTrialRepository function
-			err := ensureTrialRepository(tt.repoSlug, "", false, false)
+			err := ensureTrialRepository(tt.repoSlug, "", false, false, false)
 
 			if err == nil {
 				t.Errorf("expected error for repo slug '%s', got nil", tt.repoSlug)

--- a/pkg/cli/trial_command.go
+++ b/pkg/cli/trial_command.go
@@ -53,6 +53,7 @@ type TrialOptions struct {
 	DeleteHostRepo bool
 	ForceDelete    bool
 	Quiet          bool
+	DryRun         bool
 	TimeoutMinutes int
 	TriggerContext string
 	RepeatCount    int
@@ -121,6 +122,7 @@ Trial results are saved both locally (in trials/ directory) and in the host repo
 			deleteHostRepo, _ := cmd.Flags().GetBool("delete-host-repo-after")
 			forceDeleteHostRepo, _ := cmd.Flags().GetBool("force-delete-host-repo-before")
 			yes, _ := cmd.Flags().GetBool("yes")
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			timeout, _ := cmd.Flags().GetInt("timeout")
 			triggerContext, _ := cmd.Flags().GetString("trigger-context")
 			repeatCount, _ := cmd.Flags().GetInt("repeat")
@@ -147,6 +149,7 @@ Trial results are saved both locally (in trials/ directory) and in the host repo
 				DeleteHostRepo: deleteHostRepo,
 				ForceDelete:    forceDeleteHostRepo,
 				Quiet:          yes,
+				DryRun:         dryRun,
 				TimeoutMinutes: timeout,
 				TriggerContext: triggerContext,
 				RepeatCount:    repeatCount,
@@ -180,6 +183,7 @@ Trial results are saved both locally (in trials/ directory) and in the host repo
 	cmd.Flags().Bool("delete-host-repo-after", false, "Delete the host repository after completion (default: keep)")
 	cmd.Flags().Bool("force-delete-host-repo-before", false, "Force delete the host repository before creation, if it exists before creating it")
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().Bool("dry-run", false, "Show what would be done without making any changes")
 	cmd.Flags().Int("timeout", 30, "Execution timeout in minutes (default: 30)")
 	cmd.Flags().String("trigger-context", "", "Trigger context URL (e.g., GitHub issue URL) for issue-triggered workflows")
 	cmd.Flags().Int("repeat", 0, "Number of times to repeat running workflows (0 = run once)")
@@ -205,6 +209,10 @@ func RunWorkflowTrials(ctx context.Context, workflowSpecs []string, opts TrialOp
 			return fmt.Errorf("invalid workflow specification '%s': %w", spec, err)
 		}
 		parsedSpecs = append(parsedSpecs, parsedSpec)
+	}
+
+	if opts.DryRun {
+		fmt.Fprintln(os.Stderr, console.FormatInfoMessage("[DRY RUN] Showing what would be done without making changes"))
 	}
 
 	if len(parsedSpecs) == 1 {
@@ -303,8 +311,14 @@ func RunWorkflowTrials(ctx context.Context, workflowSpecs []string, opts TrialOp
 
 	// Step 2: Create or reuse host repository
 	trialLog.Printf("Ensuring trial repository exists: %s", hostRepoSlug)
-	if err := ensureTrialRepository(hostRepoSlug, cloneRepoSlug, opts.ForceDelete, opts.Verbose); err != nil {
+	if err := ensureTrialRepository(hostRepoSlug, cloneRepoSlug, opts.ForceDelete, opts.DryRun, opts.Verbose); err != nil {
 		return fmt.Errorf("failed to ensure host repository: %w", err)
+	}
+
+	// In dry-run mode, stop here after showing what would be done
+	if opts.DryRun {
+		fmt.Fprintln(os.Stderr, console.FormatInfoMessage("[DRY RUN] Stopping here. No actual changes were made."))
+		return nil
 	}
 
 	// Step 2.5: Create secret tracker

--- a/pkg/cli/trial_command.go
+++ b/pkg/cli/trial_command.go
@@ -95,6 +95,7 @@ Repeat and cleanup examples:
   ` + string(constants.CLIExtensionPrefix) + ` trial githubnext/agentics/my-workflow --repeat 3                # Run 3 times total
   ` + string(constants.CLIExtensionPrefix) + ` trial githubnext/agentics/my-workflow --delete-host-repo-after  # Delete repo after completion
   ` + string(constants.CLIExtensionPrefix) + ` trial githubnext/agentics/my-workflow --quiet --host-repo my-trial # Custom host repo
+  ` + string(constants.CLIExtensionPrefix) + ` trial githubnext/agentics/my-workflow --dry-run                 # Show what would be done without changes
 
 Auto-merge examples:
   ` + string(constants.CLIExtensionPrefix) + ` trial githubnext/agentics/my-workflow --auto-merge-prs          # Auto-merge any PRs created during trial

--- a/pkg/cli/trial_dry_run_test.go
+++ b/pkg/cli/trial_dry_run_test.go
@@ -1,0 +1,382 @@
+//go:build !integration
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrialCommandDryRunFlag verifies that the --dry-run flag is correctly parsed
+func TestTrialCommandDryRunFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+		description string
+	}{
+		{
+			name:        "dry-run flag present",
+			args:        []string{"workflow-spec", "--dry-run"},
+			expectError: false,
+			description: "Should accept --dry-run flag",
+		},
+		{
+			name:        "dry-run with other flags",
+			args:        []string{"workflow-spec", "--dry-run", "--verbose", "-y"},
+			expectError: false,
+			description: "Should work with other flags",
+		},
+		{
+			name:        "no dry-run flag",
+			args:        []string{"workflow-spec"},
+			expectError: false,
+			description: "Should work without dry-run flag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewTrialCommand(func(engine string) error {
+				return nil
+			})
+
+			cmd.SetArgs(tt.args)
+
+			// We expect the command to fail because it will try to actually run
+			// but we're just checking flag parsing here
+			_ = cmd.Execute()
+
+			// Verify the flag exists and can be retrieved
+			dryRunFlag := cmd.Flags().Lookup("dry-run")
+			require.NotNil(t, dryRunFlag, "dry-run flag should be defined")
+			assert.Equal(t, "bool", dryRunFlag.Value.Type(), "dry-run should be a boolean flag")
+		})
+	}
+}
+
+// TestTrialOptionsDryRun verifies that TrialOptions correctly stores the dry-run flag
+func TestTrialOptionsDryRun(t *testing.T) {
+	tests := []struct {
+		name           string
+		dryRun         bool
+		expectedDryRun bool
+	}{
+		{
+			name:           "dry-run enabled",
+			dryRun:         true,
+			expectedDryRun: true,
+		},
+		{
+			name:           "dry-run disabled",
+			dryRun:         false,
+			expectedDryRun: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := TrialOptions{
+				DryRun: tt.dryRun,
+			}
+
+			assert.Equal(t, tt.expectedDryRun, opts.DryRun, "DryRun field should match input")
+		})
+	}
+}
+
+// TestEnsureTrialRepositoryDryRun verifies behavior in dry-run mode
+func TestEnsureTrialRepositoryDryRun(t *testing.T) {
+	// This test verifies that ensureTrialRepository handles dry-run mode correctly
+	// In dry-run mode, it should not make actual API calls but should validate inputs
+
+	tests := []struct {
+		name          string
+		repoSlug      string
+		cloneRepoSlug string
+		forceDelete   bool
+		dryRun        bool
+		verbose       bool
+		expectError   bool
+		errorContains string
+		description   string
+	}{
+		{
+			name:          "dry-run with invalid repo slug format",
+			repoSlug:      "invalid-format",
+			cloneRepoSlug: "",
+			forceDelete:   false,
+			dryRun:        true,
+			verbose:       false,
+			expectError:   true,
+			errorContains: "invalid repository slug format",
+			description:   "Should validate repo slug format even in dry-run mode",
+		},
+		{
+			name:          "dry-run with valid repo slug",
+			repoSlug:      "owner/repo",
+			cloneRepoSlug: "",
+			forceDelete:   false,
+			dryRun:        true,
+			verbose:       false,
+			expectError:   false,
+			description:   "Should accept valid repo slug in dry-run mode",
+		},
+		{
+			name:          "dry-run with force delete",
+			repoSlug:      "owner/repo",
+			cloneRepoSlug: "",
+			forceDelete:   true,
+			dryRun:        true,
+			verbose:       true,
+			expectError:   false,
+			description:   "Should handle force delete flag in dry-run mode",
+		},
+		{
+			name:          "dry-run with clone repo",
+			repoSlug:      "owner/host-repo",
+			cloneRepoSlug: "owner/source-repo",
+			forceDelete:   false,
+			dryRun:        true,
+			verbose:       true,
+			expectError:   false,
+			description:   "Should handle clone repo in dry-run mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stderr to verify dry-run messages
+			oldStderr := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+
+			err := ensureTrialRepository(tt.repoSlug, tt.cloneRepoSlug, tt.forceDelete, tt.dryRun, tt.verbose)
+
+			// Restore stderr
+			w.Close()
+			os.Stderr = oldStderr
+
+			// Read captured output
+			var buf bytes.Buffer
+			buf.ReadFrom(r)
+			output := buf.String()
+
+			if tt.expectError {
+				require.Error(t, err, "Expected error for %s", tt.description)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains, "Error should contain expected text")
+				}
+			} else {
+				assert.NoError(t, err, "Should not error for %s", tt.description)
+
+				// In dry-run mode with verbose, output should contain dry-run indicators
+				if tt.dryRun && tt.verbose {
+					assert.Contains(t, output, "[DRY RUN]", "Verbose dry-run should show [DRY RUN] prefix")
+				}
+			}
+		})
+	}
+}
+
+// TestDryRunMessageFormatting verifies that dry-run messages are formatted consistently
+func TestDryRunMessageFormatting(t *testing.T) {
+	tests := []struct {
+		name             string
+		repoSlug         string
+		dryRun           bool
+		verbose          bool
+		expectedPrefixes []string
+		description      string
+	}{
+		{
+			name:     "dry-run enabled with verbose",
+			repoSlug: "owner/test-repo",
+			dryRun:   true,
+			verbose:  true,
+			expectedPrefixes: []string{
+				"[DRY RUN]",
+			},
+			description: "Should show [DRY RUN] prefix when verbose and dry-run enabled",
+		},
+		{
+			name:     "dry-run enabled without verbose",
+			repoSlug: "owner/test-repo",
+			dryRun:   true,
+			verbose:  false,
+			expectedPrefixes: []string{
+				"[DRY RUN]",
+			},
+			description: "Should show [DRY RUN] prefix even without verbose",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stderr to check message formatting
+			oldStderr := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+
+			_ = ensureTrialRepository(tt.repoSlug, "", false, tt.dryRun, tt.verbose)
+
+			// Restore stderr
+			w.Close()
+			os.Stderr = oldStderr
+
+			// Read captured output
+			var buf bytes.Buffer
+			buf.ReadFrom(r)
+			output := buf.String()
+
+			// Check for expected prefixes
+			for _, prefix := range tt.expectedPrefixes {
+				assert.Contains(t, output, prefix, "Output should contain prefix: %s", prefix)
+			}
+		})
+	}
+}
+
+// TestDryRunNoActualAPICallsForCreate verifies that dry-run doesn't create repositories
+func TestDryRunNoActualAPICallsForCreate(t *testing.T) {
+	// This test documents that in dry-run mode, we should not make actual GitHub API calls
+	// This is a behavioral test - actual integration would require mocking gh CLI
+
+	repoSlug := "test-owner/test-repo-" + fmt.Sprintf("%d", os.Getpid())
+	dryRun := true
+	verbose := true
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := ensureTrialRepository(repoSlug, "", false, dryRun, verbose)
+
+	// Restore stderr
+	w.Close()
+	os.Stderr = oldStderr
+
+	// Read captured output
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should not error
+	assert.NoError(t, err, "Dry-run should not error")
+
+	// Should indicate that it would create the repository
+	if strings.Contains(output, "exists") {
+		// If repo exists message shown, that's fine
+		t.Logf("Repository appears to exist: %s", repoSlug)
+	} else {
+		// Should show would-create messages
+		assert.Contains(t, output, "[DRY RUN]", "Should show dry-run prefix")
+		assert.Contains(t, output, "Would create", "Should indicate it would create repo")
+	}
+
+	// The key assertion: the repository should NOT actually be created
+	// We can't fully verify this without integration tests, but the presence of
+	// "Would create" messages indicates the actual create call was skipped
+	t.Log("Dry-run mode should skip actual repository creation")
+}
+
+// TestDryRunForceDeleteBehavior verifies dry-run behavior with force delete flag
+func TestDryRunForceDeleteBehavior(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoSlug    string
+		forceDelete bool
+		dryRun      bool
+		verbose     bool
+		description string
+	}{
+		{
+			name:        "dry-run with force delete",
+			repoSlug:    "owner/test-repo",
+			forceDelete: true,
+			dryRun:      true,
+			verbose:     true,
+			description: "Should show would-delete message in dry-run mode",
+		},
+		{
+			name:        "dry-run without force delete",
+			repoSlug:    "owner/test-repo",
+			forceDelete: false,
+			dryRun:      true,
+			verbose:     true,
+			description: "Should show would-reuse message in dry-run mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stderr
+			oldStderr := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+
+			err := ensureTrialRepository(tt.repoSlug, "", tt.forceDelete, tt.dryRun, tt.verbose)
+
+			// Restore stderr
+			w.Close()
+			os.Stderr = oldStderr
+
+			// Read captured output
+			var buf bytes.Buffer
+			buf.ReadFrom(r)
+			output := buf.String()
+
+			assert.NoError(t, err, "Should not error in dry-run mode")
+			assert.Contains(t, output, "[DRY RUN]", "Should show dry-run prefix")
+		})
+	}
+}
+
+// TestDryRunValidationStillOccurs verifies that input validation happens in dry-run mode
+func TestDryRunValidationStillOccurs(t *testing.T) {
+	tests := []struct {
+		name          string
+		repoSlug      string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "empty repo slug",
+			repoSlug:      "/",
+			expectError:   true,
+			errorContains: "invalid repository slug format",
+		},
+		{
+			name:          "no slash in repo slug",
+			repoSlug:      "justname",
+			expectError:   true,
+			errorContains: "invalid repository slug format",
+		},
+		{
+			name:          "valid repo slug",
+			repoSlug:      "owner/repo",
+			expectError:   false,
+			errorContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ensureTrialRepository(tt.repoSlug, "", false, true, false)
+
+			if tt.expectError {
+				require.Error(t, err, "Expected validation error in dry-run mode")
+				assert.Contains(t, err.Error(), tt.errorContains, "Error should contain expected text")
+			} else {
+				assert.NoError(t, err, "Valid input should not error in dry-run mode")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Introduced a new `--dry-run` flag for the trial command to preview actions without making changes
- Updated `ensureTrialRepository` function to support dry-run mode
- Added verbose logging for dry-run scenarios

## Details

The changes enable users to run trial workflows in a preview mode, showing what actions would be taken without actually executing them. This is helpful for understanding the potential impact of a trial before committing to the full process.