### PR TITLE
Fix typo in 'pre-requisites' in quick-start guide

### DIFF
--- a/docs/src/content/docs/setup/quick-start.mdx
+++ b/docs/src/content/docs/setup/quick-start.mdx
@@ -56,7 +56,7 @@ gh aw add-wizard githubnext/agentics/daily-repo-status
 
 This will take you through an interactive process to:
 
-1. **Check pre-requisites** - Verify repository permissions.
+1. **Check prerequisites** - Verify repository permissions.
 2. **Select an AI Engine** - Choose between Copilot, Claude, or Codex.
 3. **Set up the required secret** - [`COPILOT_GITHUB_TOKEN`](/gh-aw/reference/tokens/#copilot_github_token), [`ANTHROPIC_API_KEY`](/gh-aw/reference/tokens/#anthropic_api_key) or [`OPENAI_API_KEY`](/gh-aw/reference/tokens/#openai_api_key).
 4. **Add the workflow** - Adds the workflow and lock file to `.github/workflows/`.

--- a/docs/src/content/docs/setup/quick-start.mdx
+++ b/docs/src/content/docs/setup/quick-start.mdx
@@ -56,7 +56,7 @@ gh aw add-wizard githubnext/agentics/daily-repo-status
 
 This will take you through an interactive process to:
 
-1. **Check pre-requisttes** - Verify repository permissions.
+1. **Check pre-requisites** - Verify repository permissions.
 2. **Select an AI Engine** - Choose between Copilot, Claude, or Codex.
 3. **Set up the required secret** - [`COPILOT_GITHUB_TOKEN`](/gh-aw/reference/tokens/#copilot_github_token), [`ANTHROPIC_API_KEY`](/gh-aw/reference/tokens/#anthropic_api_key) or [`OPENAI_API_KEY`](/gh-aw/reference/tokens/#openai_api_key).
 4. **Add the workflow** - Adds the workflow and lock file to `.github/workflows/`.


### PR DESCRIPTION
Just wanted to pop in and fix the typo!