### PR TITLE
Update quick-start guide for authentication instructions

### DIFF
--- a/docs/src/content/docs/setup/quick-start.mdx
+++ b/docs/src/content/docs/setup/quick-start.mdx
@@ -40,11 +40,18 @@ Install the GitHub Agentic Workflows extension:
 gh extension install github/gh-aw
 ```
 
-If you are encountering authentication issues, use this script instead:
+> [!TIP]
+> If you are encountering authentication issues, use this script instead:
+>
+> ```text wrap
+> curl -sL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
+> ```
+>
+> or login interactively:
+> ```text wrap
+> gh auth login
+> ```
 
-```text wrap
-curl -sL https://raw.githubusercontent.com/github/gh-aw/main/install-gh-aw.sh | bash
-```
 
 ### Step 2 - Add the sample workflow and trigger a run
 


### PR DESCRIPTION
improved quickstart guide for authentication instructions:
- indented the auth topic as Tip
- added hint to login interactively if non-bash e.g. on windows etc