### PR TITLE
perf: Ensure Docker daemon exists AND is running

### DIFF
--- a/pkg/workflow/docker_validation.go
+++ b/pkg/workflow/docker_validation.go
@@ -101,9 +101,8 @@ func validateDockerImage(image string, verbose bool) error {
 	// This prevents multi-minute hangs when Docker Desktop is installed but not running,
 	// which is common on macOS development machines.
 	if !isDockerDaemonRunning() {
-		dockerValidationLog.Print("Docker daemon not running, skipping image validation")
-		fmt.Fprintln(os.Stderr, console.FormatErrorMessage(fmt.Sprintf("Docker daemon not running - skipping container image validation for '%s'", image)))
-		return nil
+		dockerValidationLog.Print("Docker daemon not running, cannot validate image")
+		return fmt.Errorf("Docker daemon not running - could not validate container image '%s'. Start Docker Desktop or disable container-based tools", image)
 	}
 
 	// Try to inspect the image (will succeed if image exists locally)

--- a/pkg/workflow/docker_validation.go
+++ b/pkg/workflow/docker_validation.go
@@ -102,9 +102,7 @@ func validateDockerImage(image string, verbose bool) error {
 	// which is common on macOS development machines.
 	if !isDockerDaemonRunning() {
 		dockerValidationLog.Print("Docker daemon not running, skipping image validation")
-		if verbose {
-			fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Docker daemon not running - skipping validation for container image '%s'", image)))
-		}
+		fmt.Fprintln(os.Stderr, console.FormatErrorMessage(fmt.Sprintf("Docker daemon not running - skipping container image validation for '%s'", image)))
 		return nil
 	}
 

--- a/pkg/workflow/docker_validation.go
+++ b/pkg/workflow/docker_validation.go
@@ -83,14 +83,15 @@ func isDockerDaemonRunning() bool {
 }
 
 // validateDockerImage checks if a Docker image exists and is accessible
-// Returns nil if docker is not available or the daemon is not running (with a warning printed)
+// Returns nil if docker is not available (with a warning printed)
 func validateDockerImage(image string, verbose bool) error {
 	dockerValidationLog.Printf("Validating Docker image: %s", image)
 
-	// Check if docker CLI is available on PATH
+	// Check if docker is available
 	_, err := exec.LookPath("docker")
 	if err != nil {
 		dockerValidationLog.Print("Docker not available, skipping image validation")
+		// Docker not available - print warning and skip validation
 		if verbose {
 			fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Docker not available - skipping validation for container image '%s'", image)))
 		}
@@ -102,7 +103,7 @@ func validateDockerImage(image string, verbose bool) error {
 	// which is common on macOS development machines.
 	if !isDockerDaemonRunning() {
 		dockerValidationLog.Print("Docker daemon not running, cannot validate image")
-		return fmt.Errorf("Docker daemon not running - could not validate container image '%s'. Start Docker Desktop or disable container-based tools", image)
+		return fmt.Errorf("Docker daemon not running - could not validate container image '%s'. Start Docker Desktop or remove container-based tools", image)
 	}
 
 	// Try to inspect the image (will succeed if image exists locally)


### PR DESCRIPTION
Fixes https://github.com/github/gh-aw/issues/15690

When Docker Desktop is installed but not running (common when my battery is low), every docker command hangs waiting for the daemon. The existing validation function would then:

1. Run 'docker image inspect' (hangs until timeout)
2. Run 'docker pull' with 3 retries and exponential backoff (5s + 10s + 20s waits between retries)

This adds up to 35+ seconds per container image. With multiple workflows using containers, make recompile could hang for minutes.

Fix: Run a cached 'docker info' check with a 3-second timeout before any docker operations. If the daemon is not responsive, skip container image validation and print a warning. The check runs once and the result is cached for the process lifetime.