### PR TITLE
Fix reply_to_pull_request_review_comment schema CI failures

### DIFF
--- a/actions/setup/js/safe_outputs_tools.json
+++ b/actions/setup/js/safe_outputs_tools.json
@@ -268,11 +268,8 @@
       "required": ["comment_id", "body"],
       "properties": {
         "comment_id": {
-          "oneOf": [
-            { "type": "number", "minimum": 1 },
-            { "type": "string", "pattern": "^[1-9][0-9]*$" }
-          ],
-          "description": "The numeric ID of the review comment to reply to."
+          "type": ["number", "string"],
+          "description": "The numeric ID of the review comment to reply to (e.g., 42853901 from the comment URL or API response)."
         },
         "body": {
           "type": "string",

--- a/pkg/workflow/js/safe_outputs_tools.json
+++ b/pkg/workflow/js/safe_outputs_tools.json
@@ -320,11 +320,8 @@
       "required": ["comment_id", "body"],
       "properties": {
         "comment_id": {
-          "oneOf": [
-            { "type": "number", "minimum": 1 },
-            { "type": "string", "pattern": "^[1-9][0-9]*$" }
-          ],
-          "description": "The numeric ID of the review comment to reply to."
+          "type": ["number", "string"],
+          "description": "The numeric ID of the review comment to reply to (e.g., 42853901 from the comment URL or API response)."
         },
         "body": {
           "type": "string",

--- a/schemas/agent-output.json
+++ b/schemas/agent-output.json
@@ -350,10 +350,7 @@
           "const": "reply_to_pull_request_review_comment"
         },
         "comment_id": {
-          "oneOf": [
-            { "type": "number", "minimum": 1 },
-            { "type": "string", "pattern": "^[1-9][0-9]*$" }
-          ],
+          "type": ["number", "string"],
           "description": "The numeric ID of the review comment to reply to"
         },
         "body": {
@@ -362,7 +359,7 @@
           "minLength": 1
         },
         "pull_request_number": {
-          "oneOf": [{ "type": "number" }, { "type": "string" }],
+          "type": ["number", "string"],
           "description": "Pull request number (optional - uses triggering PR if not provided)"
         }
       },


### PR DESCRIPTION
## Summary

Fixes #15778

Follow-up to #15691 — resolves CI failures in `safe_outputs_mcp_schema_validation.test.cjs` caused by the `comment_id` field using `oneOf` instead of the codebase-standard `"type": ["number", "string"]` pattern.