### PR TITLE
Fix: Move footer control from PR review comments to PR review submission (#15783)

### DIFF
--- a/.github/aw/github-agentic-workflows.md
+++ b/.github/aw/github-agentic-workflows.md
@@ -447,13 +447,15 @@ The YAML frontmatter supports these fields:
     ```yaml
     safe-outputs:
       create-pull-request-review-comment:
-        max: 3                          # Optional: maximum number of review comments (default: 1)
+        max: 3                          # Optional: maximum number of review comments (default: 10)
         side: "RIGHT"                   # Optional: side of diff ("LEFT" or "RIGHT", default: "RIGHT")
-        footer: "always"                # Optional: footer control ("always", "none", "if-body", default: "always")
         target: "*"                     # Optional: "triggering" (default), "*", or number
         target-repo: "owner/repo"       # Optional: cross-repository
+      submit-pull-request-review:
+        max: 1                          # Optional: maximum number of reviews to submit (default: 1)
+        footer: "if-body"               # Optional: footer control ("always", "none", "if-body", default: "always")
     ```
-    **Footer Control**: The `footer` field controls when AI-generated footers appear in PR review comments. Values: `"always"` (default, always include footer), `"none"` (never include footer), `"if-body"` (only include footer when review body is non-empty). Boolean values are also supported: `true` maps to `"always"`, `false` maps to `"none"`.
+    **Footer Control**: The `footer` field on `submit-pull-request-review` controls when AI-generated footers appear in the PR review body. Values: `"always"` (default, always include footer), `"none"` (never include footer), `"if-body"` (only include footer when review body is non-empty). Boolean values are also supported: `true` maps to `"always"`, `false` maps to `"none"`. This is useful for clean approval reviews — with `"if-body"`, approvals without explanatory text appear without a footer.
 
     When using `safe-outputs.create-pull-request-review-comment`, the main job does **not** need `pull-requests: write` permission since review comment creation is handled by a separate job with appropriate permissions.
   - `update-issue:` - Update issue title, body, labels, assignees, or milestone (NOT for closing - use close-issue instead)

--- a/actions/setup/js/pr_review_buffer.cjs
+++ b/actions/setup/js/pr_review_buffer.cjs
@@ -128,8 +128,8 @@ function createReviewBuffer() {
    * Also accepts boolean values for backward compatibility:
    *   - true → "always"
    *   - false → "none"
-   * Note: create-pull-request-review-comment.footer is converted to a string in Go,
-   * but submit-pull-request-review.footer and global footer are still emitted as booleans.
+   * Note: submit-pull-request-review.footer is emitted as a string by the Go compiler.
+   * The global footer setting is emitted as a boolean and converted by getEffectiveFooterString.
    * @param {string|boolean} value - Footer mode string or boolean
    */
   function setFooterMode(value) {

--- a/actions/setup/js/safe_output_handler_manager.cjs
+++ b/actions/setup/js/safe_output_handler_manager.cjs
@@ -740,14 +740,10 @@ async function main() {
     const prReviewBuffer = createReviewBuffer();
 
     // Apply footer config with priority:
-    // 1. create_pull_request_review_comment.footer (highest priority)
-    // 2. submit_pull_request_review.footer (fallback)
-    // 3. Default: "always"
+    // 1. submit_pull_request_review.footer (highest priority — footer controls review body)
+    // 2. Default: "always"
     let footerConfig = undefined;
-    if (config.create_pull_request_review_comment?.footer !== undefined) {
-      footerConfig = config.create_pull_request_review_comment.footer;
-      core.info(`Using footer config from create_pull_request_review_comment: ${footerConfig}`);
-    } else if (config.submit_pull_request_review?.footer !== undefined) {
+    if (config.submit_pull_request_review?.footer !== undefined) {
       footerConfig = config.submit_pull_request_review.footer;
       core.info(`Using footer config from submit_pull_request_review: ${footerConfig}`);
     }

--- a/actions/setup/js/safe_output_unified_handler_manager.cjs
+++ b/actions/setup/js/safe_output_unified_handler_manager.cjs
@@ -985,14 +985,10 @@ async function main() {
     const prReviewBuffer = createReviewBuffer();
 
     // Apply footer config with priority:
-    // 1. create_pull_request_review_comment.footer (highest priority)
-    // 2. submit_pull_request_review.footer (fallback)
-    // 3. Default: "always"
+    // 1. submit_pull_request_review.footer (highest priority — footer controls review body)
+    // 2. Default: "always"
     let footerConfig = undefined;
-    if (configs.regular?.create_pull_request_review_comment?.footer !== undefined) {
-      footerConfig = configs.regular.create_pull_request_review_comment.footer;
-      core.info(`Using footer config from create_pull_request_review_comment: ${footerConfig}`);
-    } else if (configs.regular?.submit_pull_request_review?.footer !== undefined) {
+    if (configs.regular?.submit_pull_request_review?.footer !== undefined) {
       footerConfig = configs.regular.submit_pull_request_review.footer;
       core.info(`Using footer config from submit_pull_request_review: ${footerConfig}`);
     }

--- a/actions/setup/js/types/safe-outputs-config.d.ts
+++ b/actions/setup/js/types/safe-outputs-config.d.ts
@@ -95,6 +95,18 @@ interface CreatePullRequestReviewCommentConfig extends SafeOutputConfig {
 }
 
 /**
+ * Configuration for submitting a consolidated PR review.
+ * The footer field controls when AI-generated footer is added to the review body:
+ * - "always" (default): Always include footer
+ * - "none": Never include footer
+ * - "if-body": Only include footer when review has body text
+ * Boolean values are also supported: true maps to "always", false maps to "none".
+ */
+interface SubmitPullRequestReviewConfig extends SafeOutputConfig {
+  footer?: boolean | "always" | "none" | "if-body";
+}
+
+/**
  * Configuration for replying to pull request review comments.
  * Inherits common fields (e.g. "github-token") from SafeOutputConfig.
  */
@@ -290,6 +302,7 @@ type SpecificSafeOutputConfig =
   | AddCommentConfig
   | CreatePullRequestConfig
   | CreatePullRequestReviewCommentConfig
+  | SubmitPullRequestReviewConfig
   | CreateCodeScanningAlertConfig
   | AutofixCodeScanningAlertConfig
   | AddLabelsConfig
@@ -324,6 +337,7 @@ export {
   AddCommentConfig,
   CreatePullRequestConfig,
   CreatePullRequestReviewCommentConfig,
+  SubmitPullRequestReviewConfig,
   CreateCodeScanningAlertConfig,
   AutofixCodeScanningAlertConfig,
   AddLabelsConfig,

--- a/docs/src/content/docs/reference/footers.md
+++ b/docs/src/content/docs/reference/footers.md
@@ -42,21 +42,21 @@ safe-outputs:
 
 Individual handler settings always take precedence over the global setting.
 
-## PR Review Comment Footer Control
+## PR Review Footer Control
 
-For PR review comments (`create-pull-request-review-comment`), the `footer` field supports additional conditional control:
+For PR reviews (`submit-pull-request-review`), the `footer` field supports conditional control over when the footer is added to the review body:
 
 ```yaml wrap
 safe-outputs:
   create-pull-request-review-comment:
-    footer: "if-body"         # conditional footer based on review body
   submit-pull-request-review:
+    footer: "if-body"         # conditional footer based on review body
 ```
 
 The `footer` field accepts three string values:
 
-- `"always"` (default) - Always include footer on review comments
-- `"none"` - Never include footer on review comments
+- `"always"` (default) - Always include footer on the review body
+- `"none"` - Never include footer on the review body
 - `"if-body"` - Only include footer when the review has body text
 
 Boolean values are also supported and automatically converted:
@@ -70,9 +70,8 @@ This is particularly useful for clean approval reviews without body text. With `
 ```yaml wrap
 safe-outputs:
   create-pull-request-review-comment:
-    footer: "if-body"         # Show footer only when review has body
   submit-pull-request-review:
-    max: 1
+    footer: "if-body"         # Show footer only when review has body
 ```
 
 When the agent submits an approval without a body (just "APPROVE" event), no footer appears. When the agent includes explanatory comments in the review body, the footer is included.

--- a/docs/src/content/docs/reference/safe-outputs-specification.md
+++ b/docs/src/content/docs/reference/safe-outputs-specification.md
@@ -2191,6 +2191,7 @@ This section provides complete definitions for all remaining safe output types. 
 **Notes**:
 - Submits all buffered review comments from `create_pull_request_review_comment`
 - Review status affects PR merge requirements
+- Footer control: `footer` accepts `"always"` (default), `"none"`, or `"if-body"` (only when review body has text); boolean `true`/`false` maps to `"always"`/`"none"`
 
 ---
 

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -4987,8 +4987,18 @@
                   "maximum": 10
                 },
                 "footer": {
-                  "type": "boolean",
-                  "description": "Controls whether AI-generated footer is added to the review body. When false, the footer is omitted. Defaults to true."
+                  "oneOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Controls whether AI-generated footer is added to the review body. true maps to 'always', false maps to 'none'."
+                    },
+                    {
+                      "type": "string",
+                      "enum": ["always", "none", "if-body"],
+                      "description": "Controls when AI-generated footer is added to the review body: 'always' (default), 'none' (never), or 'if-body' (only when review has body text)."
+                    }
+                  ],
+                  "description": "Controls when AI-generated footer is added to the review body. Accepts boolean (true/false) or string ('always', 'none', 'if-body'). The 'if-body' mode is useful for clean approval reviews without body text. Defaults to 'always'."
                 },
                 "github-token": {
                   "$ref": "#/$defs/github_token",

--- a/pkg/workflow/compiler_safe_outputs_config.go
+++ b/pkg/workflow/compiler_safe_outputs_config.go
@@ -19,6 +19,25 @@ func getEffectiveFooter(localFooter *bool, globalFooter *bool) *bool {
 	return globalFooter
 }
 
+// getEffectiveFooterString returns the effective footer string value for a config.
+// If the local string footer is set, use it; otherwise convert the global bool footer.
+// Returns nil if neither is set (default to "always" in JavaScript).
+func getEffectiveFooterString(localFooter *string, globalFooter *bool) *string {
+	if localFooter != nil {
+		return localFooter
+	}
+	if globalFooter != nil {
+		var s string
+		if *globalFooter {
+			s = "always"
+		} else {
+			s = "none"
+		}
+		return &s
+	}
+	return nil
+}
+
 // handlerConfigBuilder provides a fluent API for building handler configurations
 type handlerConfigBuilder struct {
 	config map[string]any
@@ -303,7 +322,6 @@ var handlerRegistry = map[string]handlerBuilder{
 			AddIfNotEmpty("target", c.Target).
 			AddIfNotEmpty("target-repo", c.TargetRepoSlug).
 			AddStringSlice("allowed_repos", c.AllowedRepos).
-			AddStringPtr("footer", c.Footer).
 			Build()
 	},
 	"submit_pull_request_review": func(cfg *SafeOutputsConfig) map[string]any {
@@ -313,7 +331,7 @@ var handlerRegistry = map[string]handlerBuilder{
 		c := cfg.SubmitPullRequestReview
 		return newHandlerConfigBuilder().
 			AddIfPositive("max", c.Max).
-			AddBoolPtr("footer", getEffectiveFooter(c.Footer, cfg.Footer)).
+			AddStringPtr("footer", getEffectiveFooterString(c.Footer, cfg.Footer)).
 			Build()
 	},
 	"reply_to_pull_request_review_comment": func(cfg *SafeOutputsConfig) map[string]any {

--- a/pkg/workflow/create_pr_review_comment.go
+++ b/pkg/workflow/create_pr_review_comment.go
@@ -15,7 +15,6 @@ type CreatePullRequestReviewCommentsConfig struct {
 	Target               string   `yaml:"target,omitempty"`        // Target for comments: "triggering" (default), "*" (any PR), or explicit PR number
 	TargetRepoSlug       string   `yaml:"target-repo,omitempty"`   // Target repository in format "owner/repo" for cross-repository PR review comments
 	AllowedRepos         []string `yaml:"allowed-repos,omitempty"` // List of additional repositories that PR review comments can be added to (additionally to the target-repo)
-	Footer               *string  `yaml:"footer,omitempty"`        // Controls when to show footer in PR review: "always" (default), "none", or "if-body" (only when review has body text)
 }
 
 // buildCreateOutputPullRequestReviewCommentJob creates the create_pr_review_comment job
@@ -119,30 +118,6 @@ func (c *Compiler) parsePullRequestReviewCommentsConfig(outputMap map[string]any
 			return nil // Invalid configuration, return nil to cause validation error
 		}
 		prReviewCommentsConfig.TargetRepoSlug = targetRepoSlug
-
-		// Parse footer configuration
-		if footer, exists := configMap["footer"]; exists {
-			switch f := footer.(type) {
-			case string:
-				// Validate string values: "always", "none", "if-body"
-				if f == "always" || f == "none" || f == "if-body" {
-					prReviewCommentsConfig.Footer = &f
-					createPRReviewCommentLog.Printf("Footer control: %s", f)
-				} else {
-					createPRReviewCommentLog.Printf("Invalid footer value: %s (must be 'always', 'none', or 'if-body')", f)
-				}
-			case bool:
-				// Map boolean to string: true -> "always", false -> "none"
-				var footerStr string
-				if f {
-					footerStr = "always"
-				} else {
-					footerStr = "none"
-				}
-				prReviewCommentsConfig.Footer = &footerStr
-				createPRReviewCommentLog.Printf("Footer control (mapped from bool): %s", footerStr)
-			}
-		}
 
 		// Parse common base fields with default max of 10
 		c.parseBaseSafeOutputConfig(configMap, &prReviewCommentsConfig.BaseSafeOutputConfig, 10)


### PR DESCRIPTION
## Summary

- Moves the `footer` configuration from `create-pull-request-review-comment` to `submit-pull-request-review`, where it logically belongs
- PR review comments always have a body, so `if-body` was meaningless there. The review submission body is optional (e.g., simple approvals), making `if-body` useful
- Supports string values (`"always"`, `"none"`, `"if-body"`) with backward-compatible boolean support (`true` → `"always"`, `false` → `"none"`)

## Changes

- **Go structs**: Removed `Footer` from `CreatePullRequestReviewCommentsConfig`, added string-based `Footer` to `SubmitPullRequestReviewConfig`
- **Compiler**: Updated handler config emission to use `getEffectiveFooterString` helper for proper string/bool resolution
- **JS handlers**: Updated both handler managers to read footer from `submit_pull_request_review` config
- **Schema**: Updated `main_workflow_schema.json` to accept `boolean | "always" | "none" | "if-body"` on `submit-pull-request-review`
- **TypeScript**: Added `SubmitPullRequestReviewConfig` interface with footer typing
- **Tests**: Renamed and expanded test file with coverage for parsing, handler config emission, and the new helper function
- **Docs**: Updated footers reference, safe-outputs specification, and agent documentation

## Test plan

- [x] All footer-specific unit tests pass (parsing string/bool values, handler config emission, `getEffectiveFooterString`)
- [x] `make build` succeeds
- [x] `make fmt` and `make lint` pass
- [ ] CI passes
- [ ] Verify `footer: "if-body"` on `submit-pull-request-review` correctly suppresses footer when review body is empty

Fixes #15783


Made with [Cursor](https://cursor.com)