### PR TITLE
Fix enable/disable ignoring --repo flag for workflow status check

### DIFF
--- a/pkg/cli/enable.go
+++ b/pkg/cli/enable.go
@@ -99,7 +99,7 @@ func toggleWorkflowsByNames(workflowNames []string, enable bool, repoOverride st
 
 	// Get GitHub workflows status for comparison; warn but continue if unavailable
 	enableLog.Print("Fetching GitHub workflows status for comparison")
-	githubWorkflows, err := fetchGitHubWorkflows("", false)
+	githubWorkflows, err := fetchGitHubWorkflows(repoOverride, false)
 	if err != nil {
 		enableLog.Printf("Failed to fetch GitHub workflows: %v", err)
 		fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Unable to fetch GitHub workflows (gh CLI may not be authenticated): %v", err)))


### PR DESCRIPTION
## Summary

`toggleWorkflowsByNames` receives a `repoOverride` parameter but passes an empty string to `fetchGitHubWorkflows` when checking current workflow status for the "already enabled/disabled" skip logic:

```go
// enable.go:102 — before
githubWorkflows, err := fetchGitHubWorkflows("", false)

// enable.go:102 — after
githubWorkflows, err := fetchGitHubWorkflows(repoOverride, false)
```

When using `gh aw enable --repo other-org/other-repo my-workflow`, the status comparison queries the **current** repo's workflows instead of the target repo. This causes workflows to be incorrectly skipped if the current repo happens to have a same-named workflow that's already in the desired state.

The `repoOverride` parameter is correctly used later for the actual enable/disable API calls — only the status comparison query was missing it.

## Test plan
- [x] `go build` succeeds
- [x] Existing tests pass