### PR TITLE
ci: build wasm binary during docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,17 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - 'cmd/gh-aw-wasm/**'
+      - 'pkg/**'
+      - 'scripts/bundle-wasm-docs.sh'
   push:
     branches:
       - main
     paths:
       - 'docs/**'
+      - 'cmd/gh-aw-wasm/**'
+      - 'pkg/**'
+      - 'scripts/bundle-wasm-docs.sh'
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -46,6 +52,15 @@ jobs:
       - name: Install dependencies
         working-directory: ./docs
         run: npm ci
+
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build WebAssembly compiler for docs
+        run: ./scripts/bundle-wasm-docs.sh
 
       - name: Build documentation
         working-directory: ./docs


### PR DESCRIPTION
## Summary
- Adds Go setup and WebAssembly compiler build step to the docs deployment workflow, running `scripts/bundle-wasm-docs.sh` before the Astro build
- Expands path triggers to include `cmd/gh-aw-wasm/**`, `pkg/**`, and `scripts/bundle-wasm-docs.sh` so Go changes affecting the wasm build trigger a docs rebuild

## Test plan
- [ ] Verify docs workflow triggers on PRs touching `cmd/gh-aw-wasm/`, `pkg/`, or `scripts/bundle-wasm-docs.sh`
- [ ] Verify Go is set up correctly and `bundle-wasm-docs.sh` runs before the Astro build
- [ ] Verify the docs build still succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)