### PR TITLE
Add lock schema compatibility gate for workflow lock files

### DIFF
--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -451,6 +451,8 @@ func (c *Compiler) generateAndValidateYAML(workflowData *WorkflowData, markdownP
 // writeWorkflowOutput writes the compiled workflow to the lock file
 // and handles console output formatting.
 func (c *Compiler) writeWorkflowOutput(lockFile, yamlContent string, markdownPath string) error {
+	yamlContent = prependLockSchemaVersionHeader(yamlContent)
+
 	// Write to lock file (unless noEmit is enabled)
 	if c.noEmit {
 		log.Print("Validation completed - no lock file generated (--no-emit enabled)")

--- a/pkg/workflow/compiler_test.go
+++ b/pkg/workflow/compiler_test.go
@@ -717,7 +717,7 @@ func TestWriteWorkflowOutput(t *testing.T) {
 					// Verify content
 					content, err := os.ReadFile(lockFile)
 					require.NoError(t, err, "Should be able to read lock file")
-					assert.Equal(t, tt.yamlContent, string(content), "File content should match")
+					assert.Equal(t, prependLockSchemaVersionHeader(tt.yamlContent), string(content), "File content should match")
 				} else {
 					// Verify file was NOT created in noEmit mode
 					_, err := os.Stat(lockFile)
@@ -736,8 +736,8 @@ func TestWriteWorkflowOutput_ContentUnchanged(t *testing.T) {
 
 	yamlContent := "name: test\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
 
-	// Write initial content
-	require.NoError(t, os.WriteFile(lockFile, []byte(yamlContent), 0644))
+	// Write initial content as it would be emitted by writeWorkflowOutput.
+	require.NoError(t, os.WriteFile(lockFile, []byte(prependLockSchemaVersionHeader(yamlContent)), 0644))
 
 	// Get initial modification time
 	initialInfo, err := os.Stat(lockFile)

--- a/pkg/workflow/lock_schema.go
+++ b/pkg/workflow/lock_schema.go
@@ -1,0 +1,96 @@
+package workflow
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/github/gh-aw/pkg/stringutil"
+)
+
+const (
+	// Unversioned lock files are treated as legacy schema v0 for backward compatibility.
+	legacyLockSchemaVersion  = 0
+	currentLockSchemaVersion = 1
+
+	lockSchemaVersionCommentPrefix = "# gh-aw-lock-schema-version:"
+)
+
+type lockSchemaCompatibility struct {
+	MinReadable int
+	MaxReadable int
+}
+
+var defaultLockSchemaCompatibility = lockSchemaCompatibility{
+	MinReadable: legacyLockSchemaVersion,
+	MaxReadable: currentLockSchemaVersion,
+}
+
+func prependLockSchemaVersionHeader(yamlContent string) string {
+	if strings.HasPrefix(strings.TrimSpace(yamlContent), lockSchemaVersionCommentPrefix) {
+		return yamlContent
+	}
+
+	return fmt.Sprintf("%s %d\n%s", lockSchemaVersionCommentPrefix, currentLockSchemaVersion, yamlContent)
+}
+
+func parseLockSchemaVersion(content []byte) (int, error) {
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		if !strings.HasPrefix(trimmed, "#") {
+			break
+		}
+
+		if strings.HasPrefix(trimmed, lockSchemaVersionCommentPrefix) {
+			rawVersion := strings.TrimSpace(strings.TrimPrefix(trimmed, lockSchemaVersionCommentPrefix))
+			if rawVersion == "" {
+				return 0, fmt.Errorf("missing lock schema version value")
+			}
+
+			version, err := strconv.Atoi(rawVersion)
+			if err != nil {
+				return 0, fmt.Errorf("invalid lock schema version %q", rawVersion)
+			}
+			if version < 0 {
+				return 0, fmt.Errorf("invalid lock schema version %d", version)
+			}
+
+			return version, nil
+		}
+	}
+
+	return legacyLockSchemaVersion, nil
+}
+
+func ValidateLockSchemaCompatibility(lockFilePath string, content []byte) error {
+	lockSchemaVersion, err := parseLockSchemaVersion(content)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to read lock schema version for '%s': %w. Regenerate with 'gh aw compile %s'",
+			lockFilePath,
+			err,
+			stringutil.NormalizeWorkflowName(filepath.Base(lockFilePath)),
+		)
+	}
+
+	if lockSchemaVersion < defaultLockSchemaCompatibility.MinReadable ||
+		lockSchemaVersion > defaultLockSchemaCompatibility.MaxReadable {
+		return fmt.Errorf(
+			"incompatible lock schema version %d in '%s' (supported read range: %d-%d). "+
+				"Regenerate with 'gh aw compile %s' or upgrade gh-aw",
+			lockSchemaVersion,
+			lockFilePath,
+			defaultLockSchemaCompatibility.MinReadable,
+			defaultLockSchemaCompatibility.MaxReadable,
+			stringutil.NormalizeWorkflowName(filepath.Base(lockFilePath)),
+		)
+	}
+
+	return nil
+}

--- a/pkg/workflow/lock_schema_test.go
+++ b/pkg/workflow/lock_schema_test.go
@@ -1,0 +1,65 @@
+//go:build !integration
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrependLockSchemaVersionHeader(t *testing.T) {
+	content := "name: test\non: push\n"
+	withHeader := prependLockSchemaVersionHeader(content)
+
+	expectedPrefix := "# gh-aw-lock-schema-version: 1\n"
+	if !strings.HasPrefix(withHeader, expectedPrefix) {
+		t.Fatalf("expected header prefix %q, got %q", expectedPrefix, withHeader)
+	}
+
+	// Header should not be duplicated when already present.
+	withHeaderAgain := prependLockSchemaVersionHeader(withHeader)
+	if strings.Count(withHeaderAgain, lockSchemaVersionCommentPrefix) != 1 {
+		t.Fatalf("expected exactly one schema header, got: %q", withHeaderAgain)
+	}
+}
+
+func TestValidateLockSchemaCompatibility(t *testing.T) {
+	t.Run("accepts legacy unversioned lock", func(t *testing.T) {
+		content := []byte("name: legacy\non: push\n")
+		if err := ValidateLockSchemaCompatibility("legacy.lock.yml", content); err != nil {
+			t.Fatalf("expected legacy lock to be readable, got error: %v", err)
+		}
+	})
+
+	t.Run("accepts current versioned lock", func(t *testing.T) {
+		content := []byte("# gh-aw-lock-schema-version: 1\nname: test\non: push\n")
+		if err := ValidateLockSchemaCompatibility("current.lock.yml", content); err != nil {
+			t.Fatalf("expected current lock to be readable, got error: %v", err)
+		}
+	})
+
+	t.Run("rejects incompatible future version", func(t *testing.T) {
+		content := []byte("# gh-aw-lock-schema-version: 999\nname: future\non: push\n")
+		err := ValidateLockSchemaCompatibility("future.lock.yml", content)
+		if err == nil {
+			t.Fatal("expected incompatible schema error, got nil")
+		}
+		if !strings.Contains(err.Error(), "incompatible lock schema version 999") {
+			t.Fatalf("expected incompatible version error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "gh aw compile future") {
+			t.Fatalf("expected migration guidance in error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects malformed version header", func(t *testing.T) {
+		content := []byte("# gh-aw-lock-schema-version: banana\nname: bad\non: push\n")
+		err := ValidateLockSchemaCompatibility("bad.lock.yml", content)
+		if err == nil {
+			t.Fatal("expected malformed schema error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to read lock schema version") {
+			t.Fatalf("expected parse error details, got: %v", err)
+		}
+	})
+}

--- a/pkg/workflow/resolve.go
+++ b/pkg/workflow/resolve.go
@@ -77,6 +77,9 @@ func ResolveWorkflowName(workflowInput string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read lock file '%s': %w", lockFile, err)
 	}
+	if err := ValidateLockSchemaCompatibility(lockFile, content); err != nil {
+		return "", err
+	}
 
 	// Parse YAML to extract the name field
 	var workflow struct {
@@ -218,6 +221,9 @@ func GetAllWorkflows() ([]WorkflowNameMatch, error) {
 		if err != nil {
 			resolveLog.Printf("Failed to read lock file %s: %v", lockFile, err)
 			continue
+		}
+		if err := ValidateLockSchemaCompatibility(lockFile, content); err != nil {
+			return nil, err
 		}
 
 		var wf struct {

--- a/pkg/workflow/resolve_test.go
+++ b/pkg/workflow/resolve_test.go
@@ -231,6 +231,45 @@ func TestResolveWorkflowName_InvalidYAML(t *testing.T) {
 	}
 }
 
+func TestResolveWorkflowName_IncompatibleLockSchema(t *testing.T) {
+	tempDir := testutil.TempDir(t, "test-*")
+	workflowsDir := filepath.Join(tempDir, constants.GetWorkflowDir())
+	err := os.MkdirAll(workflowsDir, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mdFile := filepath.Join(workflowsDir, "future-schema.md")
+	lockFile := filepath.Join(workflowsDir, "future-schema.lock.yml")
+
+	err = os.WriteFile(mdFile, []byte("# Future Schema\nSome content"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lockContent := `# gh-aw-lock-schema-version: 999
+name: "Future Schema Workflow"
+on: push
+`
+	err = os.WriteFile(lockFile, []byte(lockContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(tempDir)
+
+	_, err = ResolveWorkflowName("future-schema")
+	if err == nil {
+		t.Fatal("expected error for incompatible lock schema version, got nil")
+	}
+	if !contains(err.Error(), "incompatible lock schema version 999") {
+		t.Fatalf("expected schema compatibility error, got: %v", err)
+	}
+	if !contains(err.Error(), "gh aw compile future-schema") {
+		t.Fatalf("expected migration guidance in error, got: %v", err)
+	}
+}
+
 func TestResolveWorkflowName_MissingNameField(t *testing.T) {
 	// Create a temporary directory with workflow files
 	tempDir := testutil.TempDir(t, "test-*")

--- a/pkg/workflow/stop_after.go
+++ b/pkg/workflow/stop_after.go
@@ -64,7 +64,10 @@ func (c *Compiler) processStopAfterConfiguration(frontmatter map[string]any, wor
 		stopAfterLog.Printf("Stop-after value specified: %s", workflowData.StopTime)
 		// Check if there's already a lock file with a stop time (recompilation case)
 		lockFile := stringutil.MarkdownToLockFile(markdownPath)
-		existingStopTime := ExtractStopTimeFromLockFile(lockFile)
+		existingStopTime, err := extractStopTimeFromLockFileWithValidation(lockFile)
+		if err != nil {
+			return err
+		}
 
 		// If refresh flag is set, always regenerate the stop time
 		if c.refreshStopTime {
@@ -140,10 +143,17 @@ func resolveStopTime(stopTime string, compilationTime time.Time) (string, error)
 }
 
 // ExtractStopTimeFromLockFile extracts the STOP_TIME value from a compiled workflow lock file
-func ExtractStopTimeFromLockFile(lockFilePath string) string {
+func extractStopTimeFromLockFileWithValidation(lockFilePath string) (string, error) {
 	content, err := os.ReadFile(lockFilePath)
 	if err != nil {
-		return ""
+		// Missing lock file is expected on first compile.
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", nil
+	}
+	if err := ValidateLockSchemaCompatibility(lockFilePath, content); err != nil {
+		return "", err
 	}
 
 	lines := strings.Split(string(content), "\n")
@@ -153,11 +163,22 @@ func ExtractStopTimeFromLockFile(lockFilePath string) string {
 		if strings.Contains(line, "GH_AW_STOP_TIME:") {
 			prefix := "GH_AW_STOP_TIME:"
 			if idx := strings.Index(line, prefix); idx != -1 {
-				return strings.TrimSpace(line[idx+len(prefix):])
+				return strings.TrimSpace(line[idx+len(prefix):]), nil
 			}
 		}
 	}
-	return ""
+	return "", nil
+}
+
+// ExtractStopTimeFromLockFile extracts the STOP_TIME value from a compiled workflow lock file.
+// It tolerates read/parse failures for caller paths that are informational only.
+func ExtractStopTimeFromLockFile(lockFilePath string) string {
+	stopTime, err := extractStopTimeFromLockFileWithValidation(lockFilePath)
+	if err != nil {
+		stopAfterLog.Printf("Skipping stop-time extraction for incompatible lock file %s: %v", lockFilePath, err)
+		return ""
+	}
+	return stopTime
 }
 
 // extractSkipIfMatchFromOn extracts the skip-if-match value from the on: section

--- a/pkg/workflow/stop_after_test.go
+++ b/pkg/workflow/stop_after_test.go
@@ -256,3 +256,49 @@ jobs:
 		}
 	})
 }
+
+func TestProcessStopAfterConfiguration_FailsOnIncompatibleLockSchema(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "stop-after-incompatible-schema")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mdFile := filepath.Join(tmpDir, "test.md")
+	lockFile := filepath.Join(tmpDir, "test.lock.yml")
+
+	workflowData := &WorkflowData{}
+	compiler := NewCompiler()
+	compiler.SetRefreshStopTime(false)
+
+	frontmatter := map[string]any{
+		"on": map[string]any{
+			"workflow_dispatch": nil,
+			"stop-after":        "+24h",
+		},
+	}
+
+	err = os.WriteFile(lockFile, []byte(`# gh-aw-lock-schema-version: 999
+name: Test Workflow
+on:
+  workflow_dispatch:
+jobs:
+  stop_time_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        env:
+          GH_AW_STOP_TIME: 2025-12-31 23:59:59
+`), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create lock file: %v", err)
+	}
+
+	err = compiler.processStopAfterConfiguration(frontmatter, workflowData, mdFile)
+	if err == nil {
+		t.Fatal("expected schema compatibility error, got nil")
+	}
+	if !strings.Contains(err.Error(), "incompatible lock schema version 999") {
+		t.Fatalf("expected incompatible schema error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
Lock files were parsed without an explicit schema compatibility gate. Incompatible lock schema changes could be consumed silently and lead to ambiguous behavior instead of a deterministic fail-closed error.

## What changed
- Added lock schema parsing/compatibility checks with explicit handling for legacy unversioned lock files.
- Added lock schema header emission (`# gh-aw-lock-schema-version: 1`) when writing lock output.
- Enforced schema validation in lock read paths used by resolve and stop-after handling.
- Added focused workflow tests for compatibility, resolve failure behavior, stop-after failure behavior, and header emission.

## Validation
- `go test ./pkg/workflow -run 'Test(WriteWorkflowOutput|ValidateLockSchemaCompatibility|ResolveWorkflowName_IncompatibleLockSchema|ProcessStopAfterConfiguration_FailsOnIncompatibleLockSchema|ExtractStopTimeFromLockFile)'` ✅
- `make agent-finish` ❌ (environment/tooling mismatch while installing `actionlint`, compile errors in `yaml.ParserError` symbols)
- `make fmt` ✅
- `go test ./pkg/workflow -short` ❌ (baseline shell incompatibility in existing git patch tests: `TestGitPatchFromHEADCommits`, `TestGitPatchPrefersBranchOverHEAD`, `TestGitPatchNoCommits` due `${var@Q}` bad substitution)

Refs #16360
