### PR TITLE
ci: build wasm compiler during docs deployment to fix live editor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,10 @@ on:
       - 'cmd/gh-aw-wasm/**'
       - 'pkg/**'
       - 'scripts/bundle-wasm-docs.sh'
+      - '.github/workflows/docs.yml'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
   push:
     branches:
       - main
@@ -22,6 +26,10 @@ on:
       - 'cmd/gh-aw-wasm/**'
       - 'pkg/**'
       - 'scripts/bundle-wasm-docs.sh'
+      - '.github/workflows/docs.yml'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
 
 # Allow this job to clone the repo and create a page deployment
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,17 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - 'cmd/gh-aw-wasm/**'
+      - 'pkg/**'
+      - 'scripts/bundle-wasm-docs.sh'
   push:
     branches:
       - main
     paths:
       - 'docs/**'
+      - 'cmd/gh-aw-wasm/**'
+      - 'pkg/**'
+      - 'scripts/bundle-wasm-docs.sh'
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
@@ -42,6 +48,15 @@ jobs:
           node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'docs/package-lock.json'
+
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build WebAssembly compiler for docs
+        run: ./scripts/bundle-wasm-docs.sh
 
       - name: Install dependencies
         working-directory: ./docs


### PR DESCRIPTION
## Summary
- The live editor at `/gh-aw/editor/` is broken on the deployed docs site because `wasm_exec.js` and `gh-aw.wasm` are gitignored build artifacts that were never built during the docs deployment pipeline
- The Web Worker's `importScripts('./wasm_exec.js')` fails with `NetworkError` because the file does not exist on the deployed site
- Adds Go setup and `scripts/bundle-wasm-docs.sh` to the docs workflow so the WebAssembly compiler is built and placed in `docs/public/wasm/` before the Astro build
- Expands path triggers to include `cmd/gh-aw-wasm/**`, `pkg/**`, and `scripts/bundle-wasm-docs.sh` so Go changes affecting the wasm build trigger a docs rebuild

Supersedes #16306.

## Root cause analysis

The editor page loads `compiler-loader.js` which spawns a Web Worker from `compiler-worker.js`. The worker calls `importScripts('./wasm_exec.js')` which resolves to `/gh-aw/wasm/wasm_exec.js`. Both `wasm_exec.js` and `gh-aw.wasm` are generated by `scripts/bundle-wasm-docs.sh` (which invokes `make build-wasm`) and are listed in `.gitignore`. The docs deployment workflow (`docs.yml`) was only running `npm run build` without first building the wasm artifacts, so the deployed site was missing these files entirely.

## Test plan
- [x] Verified editor loads and compiles successfully on local dev server (Playwright test confirms status "Ready" and compiled YAML output)
- [ ] Verify docs workflow triggers on PRs touching `cmd/gh-aw-wasm/`, `pkg/`, or `scripts/bundle-wasm-docs.sh`
- [ ] Verify Go is set up correctly and `bundle-wasm-docs.sh` runs before the Astro build
- [ ] Verify the deployed docs site editor works end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)