### PR TITLE
🔑 Fix double key set in interactive API key collection

### DIFF
--- a/pkg/cli/add_interactive_engine.go
+++ b/pkg/cli/add_interactive_engine.go
@@ -143,5 +143,17 @@ func (c *AddInteractiveConfig) collectAPIKey(engine string) error {
 		IncludeOptional:      false,
 	}
 
-	return CheckAndCollectEngineSecrets(config)
+	if err := CheckAndCollectEngineSecrets(config); err != nil {
+		return err
+	}
+
+	// Update existingSecrets to reflect that the secret was uploaded
+	// This prevents duplicate secret uploads in applyChanges later
+	opt := constants.GetEngineOption(engine)
+	if opt != nil {
+		c.existingSecrets[opt.SecretName] = true
+		addInteractiveLog.Printf("Updated existingSecrets to include %s after upload", opt.SecretName)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

- Prevent duplicate secret uploads by updating `existingSecrets` after key upload
- Added error handling for `CheckAndCollectEngineSecrets` function
- Log secret update to improve tracking of secret management

## Details

The changes ensure that when an API key is collected interactively, the `existingSecrets` map is updated to reflect the new secret. This prevents potential duplicate secret uploads in subsequent steps of the process.