### PR TITLE
fix: inline prompt content in wasm compilation

### DIFF
--- a/pkg/workflow/compiler_string_api.go
+++ b/pkg/workflow/compiler_string_api.go
@@ -54,6 +54,10 @@ func (c *Compiler) ParseWorkflowString(content string, virtualPath string) (*Wor
 	c.contentOverride = content
 	defer func() { c.contentOverride = "" }()
 
+	// Enable inline prompt mode for string-based compilation (Wasm/browser)
+	// since runtime-import macros cannot resolve without filesystem access
+	c.inlinePrompt = true
+
 	// Parse frontmatter directly from content string
 	result, err := parser.ExtractFrontmatterFromContent(content)
 	if err != nil {

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -77,6 +77,13 @@ func WithGitRoot(gitRoot string) CompilerOption {
 	return func(c *Compiler) { c.gitRoot = gitRoot }
 }
 
+// WithInlinePrompt configures whether to inline markdown content directly in the compiled YAML
+// instead of using runtime-import macros. This is required for Wasm/browser builds where
+// the filesystem is unavailable at runtime.
+func WithInlinePrompt(inline bool) CompilerOption {
+	return func(c *Compiler) { c.inlinePrompt = inline }
+}
+
 // FileTracker interface for tracking files created during compilation
 type FileTracker interface {
 	TrackCreated(filePath string)
@@ -132,6 +139,7 @@ type Compiler struct {
 	scheduleFriendlyFormats map[int]string      // Maps schedule item index to friendly format string for current workflow
 	gitRoot                 string              // Git repository root directory (if set, used for action cache path)
 	contentOverride         string              // If set, use this content instead of reading from disk (for Wasm/in-memory compilation)
+	inlinePrompt            bool                // If true, inline markdown content in YAML instead of using runtime-import macros (for Wasm builds)
 }
 
 // NewCompiler creates a new workflow compiler with functional options.

--- a/pkg/workflow/compiler_yaml.go
+++ b/pkg/workflow/compiler_yaml.go
@@ -300,7 +300,8 @@ func (c *Compiler) generatePrompt(yaml *strings.Builder, data *WorkflowData) {
 	// The main workflow markdown uses runtime-import, but expressions like needs.* must be
 	// available at compile time for the substitute placeholders step
 	// Use MainWorkflowMarkdown (not MarkdownContent) to avoid extracting from imported content
-	if data.MainWorkflowMarkdown != "" {
+	// Skip this step when inlinePrompt is true because expression extraction happens in Step 2
+	if !c.inlinePrompt && data.MainWorkflowMarkdown != "" {
 		compilerYamlLog.Printf("Extracting expressions from main workflow markdown (%d bytes)", len(data.MainWorkflowMarkdown))
 
 		// Create a new extractor for main workflow markdown
@@ -313,40 +314,63 @@ func (c *Compiler) generatePrompt(yaml *strings.Builder, data *WorkflowData) {
 		}
 	}
 
-	// Step 2: Add runtime-import for main workflow markdown
-	// This allows users to edit the main workflow file without recompilation
-	workflowBasename := filepath.Base(c.markdownPath)
+	// Step 2: Add main workflow markdown content to the prompt
+	if c.inlinePrompt {
+		// Inline mode (Wasm/browser): embed the markdown content directly in the YAML
+		// since runtime-import macros cannot resolve without filesystem access
+		if data.MainWorkflowMarkdown != "" {
+			compilerYamlLog.Printf("Inlining main workflow markdown (%d bytes)", len(data.MainWorkflowMarkdown))
 
-	// Determine the directory path relative to workspace root
-	// For a workflow at ".github/workflows/test.md", the runtime-import path should be ".github/workflows/test.md"
-	// This makes the path explicit and matches the actual file location in the repository
-	var workflowFilePath string
+			inlinedMarkdown := removeXMLComments(data.MainWorkflowMarkdown)
+			inlinedMarkdown = wrapExpressionsInTemplateConditionals(inlinedMarkdown)
 
-	// Normalize path separators first to handle both Unix and Windows paths consistently
-	normalizedPath := filepath.ToSlash(c.markdownPath)
+			// Extract expressions and replace with env var references
+			inlineExtractor := NewExpressionExtractor()
+			inlineExprMappings, err := inlineExtractor.ExtractExpressions(inlinedMarkdown)
+			if err == nil && len(inlineExprMappings) > 0 {
+				inlinedMarkdown = inlineExtractor.ReplaceExpressionsWithEnvVars(inlinedMarkdown)
+				expressionMappings = append(expressionMappings, inlineExprMappings...)
+			}
 
-	// Look for "/.github/" as a directory (not just substring in repo name like "username.github.io")
-	// We need to match the directory component, not arbitrary substrings
-	githubDirPattern := "/.github/"
-	githubIndex := strings.Index(normalizedPath, githubDirPattern)
-
-	if githubIndex != -1 {
-		// Extract everything from ".github/" onwards (inclusive)
-		// +1 to skip the leading slash, so we get ".github/workflows/..." not "/.github/workflows/..."
-		workflowFilePath = normalizedPath[githubIndex+1:]
+			inlinedChunks := splitContentIntoChunks(inlinedMarkdown)
+			userPromptChunks = append(userPromptChunks, inlinedChunks...)
+			compilerYamlLog.Printf("Inlined main workflow markdown in %d chunks", len(inlinedChunks))
+		}
 	} else {
-		// For non-standard paths (like /tmp/test.md), just use the basename
-		workflowFilePath = workflowBasename
+		// Normal mode: use runtime-import macro so users can edit without recompilation
+		workflowBasename := filepath.Base(c.markdownPath)
+
+		// Determine the directory path relative to workspace root
+		// For a workflow at ".github/workflows/test.md", the runtime-import path should be ".github/workflows/test.md"
+		// This makes the path explicit and matches the actual file location in the repository
+		var workflowFilePath string
+
+		// Normalize path separators first to handle both Unix and Windows paths consistently
+		normalizedPath := filepath.ToSlash(c.markdownPath)
+
+		// Look for "/.github/" as a directory (not just substring in repo name like "username.github.io")
+		// We need to match the directory component, not arbitrary substrings
+		githubDirPattern := "/.github/"
+		githubIndex := strings.Index(normalizedPath, githubDirPattern)
+
+		if githubIndex != -1 {
+			// Extract everything from ".github/" onwards (inclusive)
+			// +1 to skip the leading slash, so we get ".github/workflows/..." not "/.github/workflows/..."
+			workflowFilePath = normalizedPath[githubIndex+1:]
+		} else {
+			// For non-standard paths (like /tmp/test.md), just use the basename
+			workflowFilePath = workflowBasename
+		}
+
+		// Create a runtime-import macro for the main workflow markdown
+		// The runtime_import.cjs helper will extract and process the markdown body at runtime
+		// The path uses .github/ prefix for clarity (e.g., .github/workflows/test.md)
+		runtimeImportMacro := fmt.Sprintf("{{#runtime-import %s}}", workflowFilePath)
+		compilerYamlLog.Printf("Using runtime-import for main workflow markdown: %s", workflowFilePath)
+
+		// Append runtime-import macro after imported chunks
+		userPromptChunks = append(userPromptChunks, runtimeImportMacro)
 	}
-
-	// Create a runtime-import macro for the main workflow markdown
-	// The runtime_import.cjs helper will extract and process the markdown body at runtime
-	// The path uses .github/ prefix for clarity (e.g., .github/workflows/test.md)
-	runtimeImportMacro := fmt.Sprintf("{{#runtime-import %s}}", workflowFilePath)
-	compilerYamlLog.Printf("Using runtime-import for main workflow markdown: %s", workflowFilePath)
-
-	// Append runtime-import macro after imported chunks
-	userPromptChunks = append(userPromptChunks, runtimeImportMacro)
 
 	// Generate a single unified prompt creation step WITHOUT known needs expressions
 	// Known needs expressions are added later for the substitution step only


### PR DESCRIPTION
## Summary

- Fix the wasm live editor's compiled YAML output missing the agent prompt (markdown content after frontmatter)
- Add `inlinePrompt` flag to the Compiler that embeds markdown content directly in YAML instead of using `{{#runtime-import}}` macros
- `ParseWorkflowString` (the wasm/browser entry point) now automatically enables inline prompt mode

## Problem

When compiling a workflow like:

```markdown
---
name: hello-world
on:
  workflow_dispatch:
engine: copilot
---

# Mission

Say hello to the world!
```

The native CLI properly includes "# Mission\n\nSay hello to the world!" in the compiled YAML via a `{{#runtime-import}}` macro that resolves at runtime by reading from the filesystem. However, in the wasm live editor, there is no filesystem at runtime, so the runtime-import macro never resolves and the agent prompt is missing from the output.

## Solution

The `generatePrompt` function in `compiler_yaml.go` now checks `c.inlinePrompt`:
- **When false (default/native)**: Uses `{{#runtime-import}}` macros as before, allowing users to edit workflows without recompilation
- **When true (wasm/browser)**: Inlines the markdown content directly into the compiled YAML, processing XML comments, GitHub expressions, and content chunking identically to how imported markdown with inputs is handled

`ParseWorkflowString` automatically sets `inlinePrompt = true` since it is the entry point for wasm/browser compilation where filesystem access is unavailable.

## Test plan

- [x] New test `TestCompileToYAML_PromptContentInlined` verifies prompt content appears in YAML output and no `{{#runtime-import}}` macros are present
- [x] New test `TestCompileToYAML_PromptContentInlinedWithExpressions` verifies GitHub expressions in prompts are properly extracted when inlined
- [x] All existing `go test -short ./pkg/workflow/` tests pass (25s, no regressions)
- [x] Native build succeeds: `go build -o /dev/null ./cmd/gh-aw`
- [x] Wasm build succeeds: `GOOS=js GOARCH=wasm go build -o /dev/null ./cmd/gh-aw-wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)