### PR TITLE
🔧 Refactor CLI init command flags and options

### DIFF
--- a/docs/src/content/docs/setup/cli.md
+++ b/docs/src/content/docs/setup/cli.md
@@ -128,7 +128,7 @@ gh aw init --completions                # Install shell completions
 gh aw init --push                       # Initialize and automatically commit/push changes
 ```
 
-**Options:** `--engine` (copilot, claude, codex), `--no-mcp`, `--tokens`, `--codespaces`, `--completions`, `--push` (see [--push flag](#the---push-flag))
+**Options:** `--no-mcp`, `--codespaces`, `--completions`, `--push` (see [--push flag](#the---push-flag))
 
 #### `add`
 

--- a/docs/src/content/docs/setup/cli.md
+++ b/docs/src/content/docs/setup/cli.md
@@ -121,9 +121,7 @@ Initialize repository for agentic workflows. Configures `.gitattributes`, Copilo
 
 ```bash wrap
 gh aw init                              # Interactive mode: select engine and configure secrets
-gh aw init --engine copilot             # Non-interactive with specific engine
 gh aw init --no-mcp                     # Skip MCP server integration
-gh aw init --tokens --engine copilot    # Check Copilot token configuration
 gh aw init --codespaces                 # Configure devcontainer for current repo
 gh aw init --codespaces repo1,repo2     # Configure devcontainer for additional repos
 gh aw init --completions                # Install shell completions

--- a/install.md
+++ b/install.md
@@ -34,7 +34,7 @@ You should see version information displayed. If you encounter an error, check t
 
 ## Step 2: Initialize Repository for Agentic Workflows
 
-Run the initialization command with the Copilot engine:
+Run the initialization command:
 
 ```bash
 gh aw init
@@ -47,7 +47,7 @@ gh aw init
 - Creates `.github/agents/agentic-workflows.agent.md` as an AI assistant for workflows
 - Creates workflow management prompts in `.github/aw/` directory
 - Configures VSCode settings in `.vscode/settings.json`
-- Creates MCP server configuration in `.vscode/mcp.json`
+- Creates GH-AW MCP server configuration in `.vscode/mcp.json`
 - Creates `.github/workflows/copilot-setup-steps.yml` with setup instructions
 
 **Note**: The command may prompt for additional configuration or secrets. If secrets are needed, `gh aw init` will provide instructions for setting them up. You don't need to configure secrets as part of this initial setup.

--- a/install.md
+++ b/install.md
@@ -37,7 +37,7 @@ You should see version information displayed. If you encounter an error, check t
 Run the initialization command with the Copilot engine:
 
 ```bash
-gh aw init --engine copilot
+gh aw init
 ```
 
 **What this does**:

--- a/pkg/cli/init_command.go
+++ b/pkg/cli/init_command.go
@@ -123,7 +123,9 @@ Examples:
 		},
 	}
 
-	cmd.Flags().Bool("no-mcp", false, "Skip configuring GitHub Copilot Agent MCP server integration")
+	cmd.Flags().StringP("engine", "e", "", "Override AI engine (claude, codex, copilot, custom)")
+	_ = cmd.Flags().MarkHidden("engine") // Hide the engine flag from help output (internal use only)
+	cmd.Flags().Bool("no-mcp", false, "Skip configuring GH-AW MCP server integration for GitHub Copilot Agent")
 	cmd.Flags().String("codespaces", "", "Create devcontainer.json for GitHub Codespaces with agentic workflows support. Specify comma-separated repository names in the same organization (e.g., repo1,repo2), or use without value for current repo only")
 	// NoOptDefVal allows using --codespaces without a value (returns empty string when no value provided)
 	cmd.Flags().Lookup("codespaces").NoOptDefVal = " "
@@ -134,9 +136,6 @@ Examples:
 	_ = cmd.Flags().MarkHidden("pr") // Hide the short alias from help output
 	cmd.Flags().Bool("mcp", false, "Configure GitHub Copilot Agent MCP server integration (deprecated, MCP is enabled by default)")
 	_ = cmd.Flags().MarkHidden("mcp") // Hide the short alias from help output
-	// --copilot with no args hidden
-	cmd.Flags().Bool("copilot", false, "DEPRECATED: Use --mcp to configure GitHub Copilot Agent MCP server integration (deprecated, MCP is enabled by default)")
-	_ = cmd.Flags().MarkHidden("copilot") // Hide the deprecated --copilot flag from help
 
 	// Hide the deprecated --mcp flag from help (kept for backward compatibility)
 	_ = cmd.Flags().MarkHidden("mcp")

--- a/pkg/cli/init_command.go
+++ b/pkg/cli/init_command.go
@@ -135,8 +135,6 @@ Examples:
 	cmd.Flags().Bool("pr", false, "Alias for --create-pull-request")
 	_ = cmd.Flags().MarkHidden("pr") // Hide the short alias from help output
 	cmd.Flags().Bool("mcp", false, "Configure GitHub Copilot Agent MCP server integration (deprecated, MCP is enabled by default)")
-	_ = cmd.Flags().MarkHidden("mcp") // Hide the short alias from help output
-
 	// Hide the deprecated --mcp flag from help (kept for backward compatibility)
 	_ = cmd.Flags().MarkHidden("mcp")
 

--- a/pkg/cli/init_command.go
+++ b/pkg/cli/init_command.go
@@ -124,7 +124,6 @@ Examples:
 	}
 
 	cmd.Flags().Bool("no-mcp", false, "Skip configuring GitHub Copilot Agent MCP server integration")
-	cmd.Flags().Bool("mcp", false, "Configure GitHub Copilot Agent MCP server integration (deprecated, MCP is enabled by default)")
 	cmd.Flags().String("codespaces", "", "Create devcontainer.json for GitHub Codespaces with agentic workflows support. Specify comma-separated repository names in the same organization (e.g., repo1,repo2), or use without value for current repo only")
 	// NoOptDefVal allows using --codespaces without a value (returns empty string when no value provided)
 	cmd.Flags().Lookup("codespaces").NoOptDefVal = " "
@@ -133,6 +132,11 @@ Examples:
 	cmd.Flags().Bool("create-pull-request", false, "Create a pull request with the initialization changes")
 	cmd.Flags().Bool("pr", false, "Alias for --create-pull-request")
 	_ = cmd.Flags().MarkHidden("pr") // Hide the short alias from help output
+	cmd.Flags().Bool("mcp", false, "Configure GitHub Copilot Agent MCP server integration (deprecated, MCP is enabled by default)")
+	_ = cmd.Flags().MarkHidden("mcp") // Hide the short alias from help output
+	// --copilot with no args hidden
+	cmd.Flags().Bool("copilot", false, "DEPRECATED: Use --mcp to configure GitHub Copilot Agent MCP server integration (deprecated, MCP is enabled by default)")
+	_ = cmd.Flags().MarkHidden("copilot") // Hide the deprecated --copilot flag from help
 
 	// Hide the deprecated --mcp flag from help (kept for backward compatibility)
 	_ = cmd.Flags().MarkHidden("mcp")

--- a/pkg/cli/secrets_command.go
+++ b/pkg/cli/secrets_command.go
@@ -12,8 +12,8 @@ func NewSecretsCommand() *cobra.Command {
 	secretsCommandLog.Print("Creating secrets command with subcommands")
 	cmd := &cobra.Command{
 		Use:   "secrets",
-		Short: "Manage repository secrets and GitHub tokens",
-		Long: `Manage GitHub Actions secrets and tokens for GitHub Agentic Workflows.
+		Short: "Manage repository secrets",
+		Long: `Manage GitHub Actions secrets for GitHub Agentic Workflows.
 
 This command provides tools for managing secrets required by agentic workflows, including
 AI API keys (Anthropic, OpenAI, GitHub Copilot) and GitHub tokens for workflow execution.
@@ -22,12 +22,9 @@ Available subcommands:
   • set       - Create or update individual secrets
   • bootstrap - Validate and configure all required secrets for workflows
 
-Use 'gh aw init --tokens' to check which secrets are configured for your repository.
-
 Examples:
   gh aw secrets set MY_SECRET --value "secret123"    # Set a secret directly
-  gh aw secrets bootstrap                             # Check all required secrets
-  gh aw init --tokens --engine copilot                # Validate Copilot tokens`,
+  gh aw secrets bootstrap                             # Check all required secrets`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/pkg/cli/secrets_command_test.go
+++ b/pkg/cli/secrets_command_test.go
@@ -14,7 +14,7 @@ func TestNewSecretsCommand(t *testing.T) {
 
 	require.NotNil(t, cmd, "NewSecretsCommand should not return nil")
 	assert.Equal(t, "secrets", cmd.Use, "Command use should be 'secrets'")
-	assert.Equal(t, "Manage repository secrets and GitHub tokens", cmd.Short, "Command short description should match")
+	assert.Equal(t, "Manage repository secrets", cmd.Short, "Command short description should match")
 	assert.Contains(t, cmd.Long, "Manage GitHub Actions secrets", "Command long description should contain expected text")
 
 	// Verify subcommands are added

--- a/pkg/cli/tokens_bootstrap.go
+++ b/pkg/cli/tokens_bootstrap.go
@@ -15,8 +15,6 @@ var tokensBootstrapLog = logger.New("cli:tokens_bootstrap")
 // newSecretsBootstrapSubcommand creates the `secrets bootstrap` subcommand
 func newSecretsBootstrapSubcommand() *cobra.Command {
 	var engineFlag string
-	var ownerFlag string
-	var repoFlag string
 
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
@@ -32,27 +30,25 @@ available) and prints the exact secrets to add and suggested scopes.
 For full details, including precedence rules, see the GitHub Tokens
 reference in the documentation.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTokensBootstrap(engineFlag, ownerFlag, repoFlag)
+			repo, _ := cmd.Flags().GetString("repo")
+			return runTokensBootstrap(engineFlag, repo)
 		},
 	}
 
 	cmd.Flags().StringVarP(&engineFlag, "engine", "e", "", "Check tokens for specific engine (copilot, claude, codex)")
-	cmd.Flags().StringVar(&ownerFlag, "owner", "", "Repository owner (defaults to current repository)")
-	cmd.Flags().StringVar(&repoFlag, "repo", "", "Repository name (defaults to current repository)")
+	addRepoFlag(cmd)
 
 	return cmd
 }
 
-func runTokensBootstrap(engine, owner, repo string) error {
-	tokensBootstrapLog.Printf("Running tokens bootstrap: engine=%s, owner=%s, repo=%s", engine, owner, repo)
+func runTokensBootstrap(engine, repo string) error {
+	tokensBootstrapLog.Printf("Running tokens bootstrap: engine=%s, repo=%s", engine, repo)
 	var repoSlug string
 	var err error
 
 	// Determine target repository
-	if owner != "" && repo != "" {
-		repoSlug = fmt.Sprintf("%s/%s", owner, repo)
-	} else if owner != "" || repo != "" {
-		return fmt.Errorf("both --owner and --repo must be specified together")
+	if repo != "" {
+		repoSlug = repo
 	} else {
 		repoSlug, err = GetCurrentRepoSlug()
 		if err != nil {


### PR DESCRIPTION
## Summary

- Simplified `gh aw init` command by removing explicit `--engine copilot` flag
- Updated documentation to reflect simplified initialization process
- Reorganized and hidden deprecated command flags for cleaner CLI experience

## Changes

The pull request modifies the initialization command for the GitHub Agentic Workflows CLI, focusing on simplifying the user experience and cleaning up the command-line interface.