### PR TITLE
Add inline-prompt option to compile workflows without runtime-import macros

### DIFF
--- a/cmd/gh-aw/main.go
+++ b/cmd/gh-aw/main.go
@@ -265,6 +265,7 @@ Examples:
 		fix, _ := cmd.Flags().GetBool("fix")
 		stats, _ := cmd.Flags().GetBool("stats")
 		failFast, _ := cmd.Flags().GetBool("fail-fast")
+		inlinePrompt, _ := cmd.Flags().GetBool("inline-prompt")
 		noCheckUpdate, _ := cmd.Flags().GetBool("no-check-update")
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		if err := validateEngine(engineOverride); err != nil {
@@ -317,6 +318,7 @@ Examples:
 			JSONOutput:             jsonOutput,
 			Stats:                  stats,
 			FailFast:               failFast,
+			InlinePrompt:           inlinePrompt,
 		}
 		if _, err := cli.CompileWorkflows(cmd.Context(), config); err != nil {
 			// Return error as-is without additional formatting
@@ -558,6 +560,7 @@ Use "` + string(constants.CLIExtensionPrefix) + ` help all" to show help for all
 	compileCmd.Flags().BoolP("json", "j", false, "Output results in JSON format")
 	compileCmd.Flags().Bool("stats", false, "Display statistics table sorted by file size (shows jobs, steps, scripts, and shells)")
 	compileCmd.Flags().Bool("fail-fast", false, "Stop at the first validation error instead of collecting all errors")
+	compileCmd.Flags().Bool("inline-prompt", false, "Inline all markdown content directly in compiled YAML instead of using runtime-import macros")
 	compileCmd.Flags().Bool("no-check-update", false, "Skip checking for gh-aw updates")
 	compileCmd.MarkFlagsMutuallyExclusive("dir", "workflows-dir")
 

--- a/pkg/cli/compile_compiler_setup.go
+++ b/pkg/cli/compile_compiler_setup.go
@@ -91,11 +91,15 @@ func createAndConfigureCompiler(config CompileConfig) *workflow.Compiler {
 
 	// Create compiler with auto-detected version and action mode
 	// Git root is now auto-detected in NewCompiler() for all compiler instances
-	compiler := workflow.NewCompiler(
+	compilerOpts := []workflow.CompilerOption{
 		workflow.WithVerbose(config.Verbose),
 		workflow.WithEngineOverride(config.EngineOverride),
 		workflow.WithFailFast(config.FailFast),
-	)
+	}
+	if config.InlinePrompt {
+		compilerOpts = append(compilerOpts, workflow.WithInlinePrompt(true))
+	}
+	compiler := workflow.NewCompiler(compilerOpts...)
 	compileCompilerSetupLog.Print("Created compiler instance")
 
 	// Configure compiler flags

--- a/pkg/cli/compile_config.go
+++ b/pkg/cli/compile_config.go
@@ -33,6 +33,7 @@ type CompileConfig struct {
 	ActionTag              string   // Override action SHA or tag for actions/setup (overrides action-mode to release)
 	Stats                  bool     // Display statistics table sorted by file size
 	FailFast               bool     // Stop at first error instead of collecting all errors
+	InlinePrompt           bool     // Inline all markdown in YAML instead of runtime-import macros
 }
 
 // WorkflowFailure represents a failed workflow with its error count

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -6457,6 +6457,12 @@
         }
       ]
     },
+    "inline-prompt": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, inline all markdown content (including imported fragments) directly in the compiled YAML instead of using runtime-import macros. This is required for reusable workflows (workflow_call) where the calling repository does not have access to the source repository's fragment files at runtime.",
+      "examples": [true, false]
+    },
     "strict": {
       "type": "boolean",
       "default": true,

--- a/pkg/workflow/compiler_activation_jobs.go
+++ b/pkg/workflow/compiler_activation_jobs.go
@@ -655,7 +655,9 @@ func (c *Compiler) buildActivationJob(data *WorkflowData, preActivationJobCreate
 
 	// Generate prompt in the activation job (before agent job runs)
 	compilerActivationJobsLog.Print("Generating prompt in activation job")
-	c.generatePromptInActivationJob(&steps, data)
+	if err := c.generatePromptInActivationJob(&steps, data); err != nil {
+		return nil, fmt.Errorf("generating prompt in activation job: %w", err)
+	}
 
 	// Upload prompt.txt as an artifact for the agent job to download
 	compilerActivationJobsLog.Print("Adding prompt artifact upload step")
@@ -944,20 +946,23 @@ func (c *Compiler) buildMainJob(data *WorkflowData, activationJobCreated bool) (
 
 // generatePromptInActivationJob generates the prompt creation steps and adds them to the activation job
 // This creates the prompt.txt file that will be uploaded as an artifact and downloaded by the agent job
-func (c *Compiler) generatePromptInActivationJob(steps *[]string, data *WorkflowData) {
+func (c *Compiler) generatePromptInActivationJob(steps *[]string, data *WorkflowData) error {
 	compilerActivationJobsLog.Print("Generating prompt steps in activation job")
 
 	// Use a string builder to collect the YAML
 	var yaml strings.Builder
 
 	// Call the existing generatePrompt method to get all the prompt steps
-	c.generatePrompt(&yaml, data)
+	if err := c.generatePrompt(&yaml, data); err != nil {
+		return err
+	}
 
 	// Append the generated YAML content as a single string to steps
 	yamlContent := yaml.String()
 	*steps = append(*steps, yamlContent)
 
 	compilerActivationJobsLog.Print("Prompt generation steps added to activation job")
+	return nil
 }
 
 // generateCheckoutGitHubFolderForActivation generates the checkout step for .github and .agents folders

--- a/pkg/workflow/compiler_inline_prompt_test.go
+++ b/pkg/workflow/compiler_inline_prompt_test.go
@@ -100,6 +100,28 @@ func TestReadImportedMarkdown_MissingFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "reading import", "error should describe the failure")
 }
 
+func TestReadImportedMarkdown_PathTraversal(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "read-import-traversal")
+	c := &Compiler{gitRoot: tmpDir}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"parent directory escape", "../../etc/passwd"},
+		{"absolute path", "/etc/passwd"},
+		{"dotdot only", ".."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := c.readImportedMarkdown(tt.path)
+			require.Error(t, err, "should reject path traversal")
+			assert.Contains(t, err.Error(), "escapes repository root", "error should mention traversal")
+		})
+	}
+}
+
 func TestInlinePromptFromFrontmatter(t *testing.T) {
 	tmpDir := testutil.TempDir(t, "inline-prompt-frontmatter")
 

--- a/pkg/workflow/compiler_inline_prompt_test.go
+++ b/pkg/workflow/compiler_inline_prompt_test.go
@@ -1,0 +1,240 @@
+//go:build !integration
+
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/github/gh-aw/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveInlinePrompt(t *testing.T) {
+	tests := []struct {
+		name           string
+		compilerFlag   bool
+		frontmatter    map[string]any
+		expectedResult bool
+	}{
+		{
+			name:           "default is false",
+			compilerFlag:   false,
+			frontmatter:    map[string]any{},
+			expectedResult: false,
+		},
+		{
+			name:           "compiler flag true overrides everything",
+			compilerFlag:   true,
+			frontmatter:    map[string]any{"inline-prompt": false},
+			expectedResult: true,
+		},
+		{
+			name:           "frontmatter true enables inlining",
+			compilerFlag:   false,
+			frontmatter:    map[string]any{"inline-prompt": true},
+			expectedResult: true,
+		},
+		{
+			name:           "frontmatter false keeps default",
+			compilerFlag:   false,
+			frontmatter:    map[string]any{"inline-prompt": false},
+			expectedResult: false,
+		},
+		{
+			name:           "missing frontmatter key uses default",
+			compilerFlag:   false,
+			frontmatter:    map[string]any{"engine": "copilot"},
+			expectedResult: false,
+		},
+		{
+			name:           "non-boolean frontmatter value is ignored",
+			compilerFlag:   false,
+			frontmatter:    map[string]any{"inline-prompt": "yes"},
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Compiler{inlinePrompt: tt.compilerFlag}
+			result := c.resolveInlinePrompt(tt.frontmatter)
+			assert.Equal(t, tt.expectedResult, result, "resolveInlinePrompt should return expected value")
+		})
+	}
+}
+
+func TestReadImportedMarkdown(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "read-import-test")
+
+	fragmentDir := filepath.Join(tmpDir, ".github", "workflows", "shared")
+	require.NoError(t, os.MkdirAll(fragmentDir, 0755), "creating fragment directory")
+
+	fragmentContent := `---
+description: A shared fragment
+---
+
+# Fragment Content
+
+This is the body of the fragment.`
+	fragmentPath := filepath.Join(fragmentDir, "fragment.md")
+	require.NoError(t, os.WriteFile(fragmentPath, []byte(fragmentContent), 0644), "writing fragment file")
+
+	c := &Compiler{gitRoot: tmpDir}
+	markdown, err := c.readImportedMarkdown(".github/workflows/shared/fragment.md")
+	require.NoError(t, err, "reading imported markdown should succeed")
+	assert.Contains(t, markdown, "# Fragment Content", "should contain the markdown heading")
+	assert.Contains(t, markdown, "This is the body of the fragment.", "should contain the body")
+	assert.NotContains(t, markdown, "description:", "should not contain frontmatter")
+}
+
+func TestReadImportedMarkdown_MissingFile(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "read-import-missing")
+
+	c := &Compiler{gitRoot: tmpDir}
+	_, err := c.readImportedMarkdown("nonexistent/file.md")
+	require.Error(t, err, "should error on missing file")
+	assert.Contains(t, err.Error(), "reading import", "error should describe the failure")
+}
+
+func TestInlinePromptFromFrontmatter(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "inline-prompt-frontmatter")
+
+	sharedDir := filepath.Join(tmpDir, ".github", "workflows", "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0755), "creating shared directory")
+
+	fragmentContent := `# Shared Instructions
+
+Always be helpful.`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sharedDir, "instructions.md"),
+		[]byte(fragmentContent), 0644),
+		"writing shared fragment",
+	)
+
+	workflowContent := `---
+on: push
+inline-prompt: true
+strict: false
+engine: copilot
+imports:
+  - shared/instructions.md
+features:
+  dangerous-permissions-write: true
+---
+
+# My Workflow
+
+Do the thing.`
+	workflowDir := filepath.Join(tmpDir, ".github", "workflows")
+	workflowFile := filepath.Join(workflowDir, "test-workflow.md")
+	require.NoError(t, os.WriteFile(workflowFile, []byte(workflowContent), 0644), "writing workflow file")
+
+	compiler := NewCompiler(WithGitRoot(tmpDir))
+	err := compiler.CompileWorkflow(workflowFile)
+	require.NoError(t, err, "compilation with inline-prompt should succeed")
+
+	lockFile := filepath.Join(workflowDir, "test-workflow.lock.yml")
+	lockContent, err := os.ReadFile(lockFile)
+	require.NoError(t, err, "reading lock file")
+
+	content := string(lockContent)
+	assert.NotContains(t, content, "{{#runtime-import", "lock file should not contain runtime-import macros")
+	assert.Contains(t, content, "Always be helpful", "lock file should contain inlined fragment content")
+	assert.Contains(t, content, "Do the thing", "lock file should contain inlined main workflow content")
+}
+
+func TestInlinePromptCLIFlag(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "inline-prompt-cli")
+
+	sharedDir := filepath.Join(tmpDir, ".github", "workflows", "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0755), "creating shared directory")
+
+	fragmentContent := `# CLI Fragment
+
+Fragment from CLI test.`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sharedDir, "cli-fragment.md"),
+		[]byte(fragmentContent), 0644),
+		"writing fragment",
+	)
+
+	workflowContent := `---
+on: push
+strict: false
+engine: copilot
+imports:
+  - shared/cli-fragment.md
+features:
+  dangerous-permissions-write: true
+---
+
+# CLI Test Workflow
+
+Main body here.`
+	workflowDir := filepath.Join(tmpDir, ".github", "workflows")
+	workflowFile := filepath.Join(workflowDir, "cli-test.md")
+	require.NoError(t, os.WriteFile(workflowFile, []byte(workflowContent), 0644), "writing workflow")
+
+	compiler := NewCompiler(WithGitRoot(tmpDir), WithInlinePrompt(true))
+	err := compiler.CompileWorkflow(workflowFile)
+	require.NoError(t, err, "compilation with WithInlinePrompt should succeed")
+
+	lockFile := filepath.Join(workflowDir, "cli-test.lock.yml")
+	lockContent, err := os.ReadFile(lockFile)
+	require.NoError(t, err, "reading lock file")
+
+	content := string(lockContent)
+	assert.NotContains(t, content, "{{#runtime-import", "lock file should not contain runtime-import macros")
+	assert.Contains(t, content, "Fragment from CLI test", "should contain inlined fragment")
+	assert.Contains(t, content, "Main body here", "should contain inlined main workflow")
+}
+
+func TestDefaultCompilationUsesRuntimeImport(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "default-runtime-import")
+
+	sharedDir := filepath.Join(tmpDir, ".github", "workflows", "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0755), "creating shared directory")
+
+	fragmentContent := `# Default Fragment
+
+Should be runtime-imported.`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sharedDir, "default-fragment.md"),
+		[]byte(fragmentContent), 0644),
+		"writing fragment",
+	)
+
+	workflowContent := `---
+on: push
+strict: false
+engine: copilot
+imports:
+  - shared/default-fragment.md
+features:
+  dangerous-permissions-write: true
+---
+
+# Default Workflow
+
+Normal compilation.`
+	workflowDir := filepath.Join(tmpDir, ".github", "workflows")
+	workflowFile := filepath.Join(workflowDir, "default-test.md")
+	require.NoError(t, os.WriteFile(workflowFile, []byte(workflowContent), 0644), "writing workflow")
+
+	compiler := NewCompiler(WithGitRoot(tmpDir))
+	err := compiler.CompileWorkflow(workflowFile)
+	require.NoError(t, err, "default compilation should succeed")
+
+	lockFile := filepath.Join(workflowDir, "default-test.lock.yml")
+	lockContent, err := os.ReadFile(lockFile)
+	require.NoError(t, err, "reading lock file")
+
+	content := string(lockContent)
+	runtimeImportCount := strings.Count(content, "{{#runtime-import")
+	assert.GreaterOrEqual(t, runtimeImportCount, 2, "default compilation should produce runtime-import macros for fragments and main workflow")
+	assert.NotContains(t, content, "Should be runtime-imported", "fragment content should NOT be inlined in default mode")
+}

--- a/pkg/workflow/compiler_orchestrator_workflow.go
+++ b/pkg/workflow/compiler_orchestrator_workflow.go
@@ -153,7 +153,22 @@ func (c *Compiler) buildInitialWorkflowData(
 		ParsedFrontmatter:     toolsResult.parsedFrontmatter,
 		HasExplicitGitHubTool: toolsResult.hasExplicitGitHubTool,
 		ActionMode:            c.actionMode,
+		InlinePrompt:          c.resolveInlinePrompt(result.Frontmatter),
 	}
+}
+
+// resolveInlinePrompt determines whether to inline all markdown in the compiled YAML.
+// Priority: compiler flag (CLI/Wasm) > frontmatter > default (false)
+func (c *Compiler) resolveInlinePrompt(frontmatter map[string]any) bool {
+	if c.inlinePrompt {
+		return true
+	}
+	if inlineValue, exists := frontmatter["inline-prompt"]; exists {
+		if inlineBool, ok := inlineValue.(bool); ok {
+			return inlineBool
+		}
+	}
+	return false
 }
 
 // extractYAMLSections extracts YAML configuration sections from frontmatter

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -460,6 +460,7 @@ type WorkflowData struct {
 	ActionPinWarnings     map[string]bool      // cache of already-warned action pin failures (key: "repo@version")
 	ActionMode            ActionMode           // action mode for workflow compilation (dev, release, script)
 	HasExplicitGitHubTool bool                 // true if tools.github was explicitly configured in frontmatter
+	InlinePrompt          bool                 // if true, inline all markdown in YAML instead of runtime-import macros
 }
 
 // BaseSafeOutputConfig holds common configuration fields for all safe output types

--- a/pkg/workflow/frontmatter_types.go
+++ b/pkg/workflow/frontmatter_types.go
@@ -96,7 +96,8 @@ type FrontmatterConfig struct {
 	TrackerID      string   `json:"tracker-id,omitempty"`
 	Version        string   `json:"version,omitempty"`
 	TimeoutMinutes int      `json:"timeout-minutes,omitempty"`
-	Strict         *bool    `json:"strict,omitempty"` // Pointer to distinguish unset from false
+	Strict         *bool    `json:"strict,omitempty"`        // Pointer to distinguish unset from false
+	InlinePrompt   *bool    `json:"inline-prompt,omitempty"` // If true, inline all markdown in YAML instead of runtime-import macros
 	Labels         []string `json:"labels,omitempty"`
 
 	// Configuration sections - using strongly-typed structs
@@ -514,6 +515,9 @@ func (fc *FrontmatterConfig) ToMap() map[string]any {
 	}
 	if fc.Strict != nil {
 		result["strict"] = *fc.Strict
+	}
+	if fc.InlinePrompt != nil {
+		result["inline-prompt"] = *fc.InlinePrompt
 	}
 	if len(fc.Labels) > 0 {
 		result["labels"] = fc.Labels

--- a/pkg/workflow/missing_tool_test.go
+++ b/pkg/workflow/missing_tool_test.go
@@ -5,6 +5,8 @@ package workflow
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMissingToolSafeOutput(t *testing.T) {
@@ -148,7 +150,8 @@ func TestGeneratePromptIncludesGitHubAWPrompt(t *testing.T) {
 	}
 
 	var yaml strings.Builder
-	compiler.generatePrompt(&yaml, data)
+	err := compiler.generatePrompt(&yaml, data)
+	require.NoError(t, err, "generatePrompt should not return an error")
 
 	output := yaml.String()
 
@@ -175,7 +178,8 @@ func TestMissingToolPromptGeneration(t *testing.T) {
 	}
 
 	var yaml strings.Builder
-	compiler.generatePrompt(&yaml, data)
+	err := compiler.generatePrompt(&yaml, data)
+	require.NoError(t, err, "generatePrompt should not return an error")
 
 	output := yaml.String()
 

--- a/pkg/workflow/xml_comments_test.go
+++ b/pkg/workflow/xml_comments_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/github/gh-aw/pkg/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveXMLComments(t *testing.T) {
@@ -239,7 +240,8 @@ Final content.`,
 	}
 
 	var yaml strings.Builder
-	compiler.generatePrompt(&yaml, data)
+	err := compiler.generatePrompt(&yaml, data)
+	require.NoError(t, err, "generatePrompt should not return an error")
 
 	output := yaml.String()
 


### PR DESCRIPTION
Closes #16511

Exposes the existing `inlinePrompt` compiler capability as a user-facing setting so workflows compiled for `workflow_call` can embed all markdown directly in the `.lock.yml` instead of emitting `{{#runtime-import}}` macros that fail when the consumer repo lacks the fragment files.

## Changes

- **Frontmatter field**: `inline-prompt: true` in workflow frontmatter
- **CLI flag**: `gh aw compile --inline-prompt`
- **Schema**: Added `inline-prompt` boolean to `main_workflow_schema.json`
- **Inline w/o Inputs**: Previously, when inline-prompt was used on an include without inputs it was not properly inlined, this PR fixes that
- **Compiler**: Extracted shared `processMarkdownForInlining` helper; `generatePrompt` now returns `error` so inline failures propagate cleanly instead of silently falling back to macros that would also fail at runtime

Priority: CLI/Wasm flag > frontmatter > default (false). Default compilation behavior is unchanged -- 155 existing workflows recompile identically with zero lock file diffs.