### PR TITLE
parser: report full import cycle chain in topological import sort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,10 @@ check-node-version:
 .PHONY: tools
 tools: ## Install build-time tools from tools.go
 	@echo "Installing build tools..."
-	@grep _ tools.go | awk -F'"' '{print $$2}' | xargs -tI % go install %
+	@go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
+	@go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
+	@go install golang.org/x/tools/gopls@v0.21.1
+	@go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 	@echo "✓ Tools installed successfully"
 
 # Install golangci-lint binary (avoiding GPL dependencies in go.mod)

--- a/Makefile
+++ b/Makefile
@@ -377,10 +377,7 @@ check-node-version:
 .PHONY: tools
 tools: ## Install build-time tools from tools.go
 	@echo "Installing build tools..."
-	@go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
-	@go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
-	@go install golang.org/x/tools/gopls@v0.21.1
-	@go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+	@grep _ tools.go | awk -F'"' '{print $$2}' | xargs -tI % go install %
 	@echo "✓ Tools installed successfully"
 
 # Install golangci-lint binary (avoiding GPL dependencies in go.mod)

--- a/pkg/parser/import_processor.go
+++ b/pkg/parser/import_processor.go
@@ -771,7 +771,10 @@ func processImportsFromFrontmatterWithManifestAndSource(frontmatter map[string]a
 	log.Printf("Completed BFS traversal. Processed %d imports in total", len(processedOrder))
 
 	// Sort imports in topological order (roots first, dependencies before dependents)
-	topologicalOrder := topologicalSortImports(processedOrder, baseDir, cache)
+	topologicalOrder, err := topologicalSortImports(processedOrder, baseDir, cache)
+	if err != nil {
+		return nil, err
+	}
 	log.Printf("Sorted imports in topological order: %v", topologicalOrder)
 
 	return &ImportsResult{
@@ -809,7 +812,7 @@ func processImportsFromFrontmatterWithManifestAndSource(frontmatter map[string]a
 // topologicalSortImports sorts imports in topological order using Kahn's algorithm
 // Returns imports sorted such that roots (files with no imports) come first,
 // and each import has all its dependencies listed before it
-func topologicalSortImports(imports []string, baseDir string, cache *ImportCache) []string {
+func topologicalSortImports(imports []string, baseDir string, cache *ImportCache) ([]string, error) {
 	importLog.Printf("Starting topological sort of %d imports", len(imports))
 
 	// Build dependency graph: map each import to its list of nested imports
@@ -932,7 +935,72 @@ func topologicalSortImports(imports []string, baseDir string, cache *ImportCache
 	}
 
 	importLog.Printf("Topological sort complete: %v", result)
-	return result
+	if len(result) != len(imports) {
+		if cycle := detectImportCycleChain(dependencies, allImportsSet); len(cycle) > 0 {
+			return nil, fmt.Errorf("import cycle detected: %s", strings.Join(cycle, " -> "))
+		}
+		return nil, fmt.Errorf("import cycle detected")
+	}
+	return result, nil
+}
+
+// detectImportCycleChain returns a deterministic cycle chain where the last
+// node points back to the first back-edge target. Example:
+// A -> B -> C -> D -> B
+func detectImportCycleChain(dependencies map[string][]string, allImportsSet map[string]bool) []string {
+	visited := make(map[string]bool)
+	inStack := make(map[string]bool)
+	path := []string{}
+	pathIndex := make(map[string]int)
+
+	nodes := make([]string, 0, len(dependencies))
+	for node := range dependencies {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	var visit func(string) []string
+	visit = func(node string) []string {
+		visited[node] = true
+		inStack[node] = true
+		pathIndex[node] = len(path)
+		path = append(path, node)
+
+		deps := append([]string{}, dependencies[node]...)
+		sort.Strings(deps)
+		for _, dep := range deps {
+			if !allImportsSet[dep] {
+				continue
+			}
+			if !visited[dep] {
+				if cycle := visit(dep); len(cycle) > 0 {
+					return cycle
+				}
+				continue
+			}
+			if inStack[dep] {
+				start := pathIndex[dep]
+				cycle := append([]string{}, path[start:]...)
+				cycle = append(cycle, dep)
+				return cycle
+			}
+		}
+
+		delete(inStack, node)
+		delete(pathIndex, node)
+		path = path[:len(path)-1]
+		return nil
+	}
+
+	for _, node := range nodes {
+		if visited[node] {
+			continue
+		}
+		if cycle := visit(node); len(cycle) > 0 {
+			return cycle
+		}
+	}
+	return nil
 }
 
 // extractImportPaths extracts just the import paths from frontmatter

--- a/pkg/parser/import_topological_test.go
+++ b/pkg/parser/import_topological_test.go
@@ -417,3 +417,49 @@ tools:
 	assert.Equal(t, "m-root.md", result.ImportedFiles[1])
 	assert.Equal(t, "z-root.md", result.ImportedFiles[2])
 }
+
+func TestImportTopologicalSortReportsFullCycleChain(t *testing.T) {
+	tempDir := testutil.TempDir(t, "import-topo-cycle-*")
+
+	files := map[string]string{
+		"a.md": `---
+imports:
+  - b.md
+tools:
+  tool-a: {}
+---`,
+		"b.md": `---
+imports:
+  - c.md
+tools:
+  tool-b: {}
+---`,
+		"c.md": `---
+imports:
+  - d.md
+tools:
+  tool-c: {}
+---`,
+		"d.md": `---
+imports:
+  - b.md
+tools:
+  tool-d: {}
+---`,
+	}
+
+	for filename, content := range files {
+		filePath := filepath.Join(tempDir, filename)
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+
+	frontmatter := map[string]any{
+		"imports": []string{"a.md"},
+	}
+
+	_, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "import cycle detected")
+	assert.Contains(t, err.Error(), "b.md -> c.md -> d.md -> b.md")
+}


### PR DESCRIPTION
## Problem
Import cycle failures are hard to fix because diagnostics can miss the full dependency chain, forcing operators to manually reconstruct multi-hop cycles.

## Why now
Nested import usage is increasing, and cycle triage has become recurring operator friction.

## What changed
- Added explicit cycle detection in import topological sorting.
- Emit deterministic chain diagnostics including the back-edge (for example `b.md -> c.md -> d.md -> b.md`).
- Added regression test for a 4-file cycle.

## Validation
- `make fmt`
- `go test ./pkg/parser -run 'TestImportTopologicalSortReportsFullCycleChain|TestImportTopologicalSort'`
- `make agent-finish` *(fails in local env while building `actionlint` with Go 1.25; logged as toolchain/environment blocker, not product regression)*

Refs #16544


---

---
✨ PR Review Safe Output Test - Run 22140174180

> 💥 *[THE END] — Illustrated by [Smoke Claude](https://github.com/github/gh-aw/actions/runs/22140174180)*