### PR TITLE
build: pin tool installs in make tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,10 @@ check-node-version:
 .PHONY: tools
 tools: ## Install build-time tools from tools.go
 	@echo "Installing build tools..."
-	@grep _ tools.go | awk -F'"' '{print $$2}' | xargs -tI % go install %
+	@go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
+	@go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
+	@go install golang.org/x/tools/gopls@v0.21.1
+	@go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 	@echo "✓ Tools installed successfully"
 
 # Install golangci-lint binary (avoiding GPL dependencies in go.mod)


### PR DESCRIPTION
## Problem
`make agent-finish` can fail during `make tools` because the current `go install` pipeline resolves tool builds through the repo module graph, causing `actionlint` compilation to break under local dependency/toolchain combinations.

## Why now
This currently blocks local completion of required pre-commit validation.

## What changed
- Replaced the dynamic `grep ... | xargs go install` pipeline in `Makefile` `tools` target.
- Added explicit pinned installs for each build tool:
  - `actionlint@v1.7.11`
  - `gosec@v2.23.0`
  - `gopls@v0.21.1`
  - `govulncheck@v1.1.4`

## Validation
- `make tools` ✅

