### PR TITLE
Remove auto-compile toggle and compile button from playground

### DIFF
--- a/docs/public/editor/editor.js
+++ b/docs/public/editor/editor.js
@@ -38,7 +38,6 @@ const editorMount = $('editorMount');
 const outputPlaceholder = $('outputPlaceholder');
 const outputMount = $('outputMount');
 const outputContainer = $('outputContainer');
-const compileBtn = $('compileBtn');
 const statusBadge = $('statusBadge');
 const statusText = $('statusText');
 const statusDot = $('statusDot');
@@ -48,7 +47,6 @@ const errorText = $('errorText');
 const warningBanner = $('warningBanner');
 const warningText = $('warningText');
 const themeToggle = $('themeToggle');
-const toggleTrack = $('toggleTrack');
 const divider = $('divider');
 const panelEditor = $('panelEditor');
 const panelOutput = $('panelOutput');
@@ -60,7 +58,6 @@ const panels = $('panels');
 let compiler = null;
 let isReady = false;
 let isCompiling = false;
-let autoCompile = true;
 let compileTimer = null;
 let currentYaml = '';
 
@@ -115,7 +112,7 @@ const editorView = new EditorView({
       run: () => { doCompile(); return true; }
     }]),
     EditorView.updateListener.of(update => {
-      if (update.docChanged && autoCompile && isReady) {
+      if (update.docChanged && isReady) {
         scheduleCompile();
       }
     }),
@@ -156,13 +153,6 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e)
 });
 
 // ---------------------------------------------------------------
-// Keyboard shortcut hint (Mac vs other)
-// ---------------------------------------------------------------
-const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-document.querySelectorAll('.kbd-hint-mac').forEach(el => el.style.display = isMac ? 'inline' : 'none');
-document.querySelectorAll('.kbd-hint-other').forEach(el => el.style.display = isMac ? 'none' : 'inline');
-
-// ---------------------------------------------------------------
 // Status (uses Primer Label component)
 // ---------------------------------------------------------------
 const STATUS_LABEL_MAP = {
@@ -186,18 +176,6 @@ function setStatus(status, text) {
     statusDot.style.animation = '';
   }
 }
-
-// ---------------------------------------------------------------
-// Auto-compile toggle
-// ---------------------------------------------------------------
-$('autoCompileToggle').addEventListener('click', () => {
-  autoCompile = !autoCompile;
-  if (autoCompile) {
-    toggleTrack.classList.add('active');
-  } else {
-    toggleTrack.classList.remove('active');
-  }
-});
 
 // ---------------------------------------------------------------
 // Compile
@@ -226,7 +204,6 @@ async function doCompile() {
 
   isCompiling = true;
   setStatus('compiling', 'Compiling...');
-  compileBtn.disabled = true;
 
   // Hide old banners
   errorBanner.classList.add('d-none');
@@ -262,11 +239,8 @@ async function doCompile() {
     errorBanner.classList.remove('d-none');
   } finally {
     isCompiling = false;
-    compileBtn.disabled = !isReady;
   }
 }
-
-compileBtn.addEventListener('click', doCompile);
 
 // ---------------------------------------------------------------
 // Banner close
@@ -359,13 +333,10 @@ async function init() {
     await compiler.ready;
     isReady = true;
     setStatus('ready', 'Ready');
-    compileBtn.disabled = false;
     loadingOverlay.classList.add('hidden');
 
-    // Auto-compile the default content
-    if (autoCompile) {
-      doCompile();
-    }
+    // Compile the default content
+    doCompile();
   } catch (err) {
     setStatus('error', 'Failed to load');
     loadingOverlay.querySelector('.f4').textContent = 'Failed to load compiler';

--- a/docs/public/editor/index.html
+++ b/docs/public/editor/index.html
@@ -115,42 +115,12 @@ html, body {
   50% { opacity: 0.35; }
 }
 
-/* Toggle switch (no Primer equivalent in CSS-only) */
-.toggle-track {
-  position: relative;
-  width: 34px;
-  height: 20px;
-  border-radius: 10px;
-  background: var(--bgColor-neutral-muted, var(--color-neutral-muted, #afb8c1));
-  transition: background 180ms ease;
-  flex-shrink: 0;
-  cursor: pointer;
-}
-.toggle-track.active {
-  background: var(--fgColor-accent, var(--color-accent-fg));
-}
-.toggle-knob {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 16px;
-  height: 16px;
-  background: #fff;
-  border-radius: 50%;
-  transition: transform 180ms ease;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-}
-.toggle-track.active .toggle-knob {
-  transform: translateX(14px);
-}
-
 /* Responsive */
 @media (max-width: 767px) {
   .panels-container { flex-direction: column !important; }
   .divider { width: 100%; height: 4px; cursor: row-resize; }
   .header-bar { gap: 8px !important; padding: 8px 12px !important; flex-wrap: wrap; height: auto !important; min-height: 48px !important; }
   .header-separator { display: none !important; }
-  .auto-compile-label-text { display: none; }
 }
 </style>
 </head>
@@ -181,20 +151,6 @@ html, body {
     </span>
 
     <div class="d-flex flex-items-center gap-3 ml-auto">
-      <label class="d-flex flex-items-center gap-1 f6 color-fg-muted cursor-pointer" style="white-space: nowrap; user-select: none;" id="autoCompileToggle" title="Auto-compile on change">
-        <div class="toggle-track active" id="toggleTrack">
-          <div class="toggle-knob"></div>
-        </div>
-        <span class="auto-compile-label-text">Auto</span>
-      </label>
-
-      <button class="btn btn-primary btn-sm" id="compileBtn" disabled title="Compile workflow">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" class="flex-shrink-0">
-          <path d="M4 2a1 1 0 011.5-.87l8.5 5a1 1 0 010 1.74l-8.5 5A1 1 0 014 12V2z"/>
-        </svg>
-        Compile
-      </button>
-
       <button class="btn-octicon" id="themeToggle" title="Toggle theme" aria-label="Toggle dark mode">
         <!-- Sun icon (shown in dark mode) -->
         <svg class="icon-sun octicon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:none">
@@ -235,10 +191,6 @@ html, body {
           </svg>
           Workflow (.md)
         </span>
-        <kbd class="color-bg-subtle color-fg-muted text-mono" style="padding: 1px 5px; font-size: 11px; border: 1px solid var(--borderColor-default, var(--color-border-default)); border-radius: 3px; line-height: 1.4;" title="Press to compile">
-          <span class="kbd-hint-mac" style="display:none">&#8984;&#9166;</span>
-          <span class="kbd-hint-other">Ctrl+Enter</span>
-        </kbd>
       </div>
       <div class="flex-1" style="min-height: 0; overflow: hidden;" id="editorMount"></div>
     </div>


### PR DESCRIPTION
## Summary
- Removes the "Auto" toggle switch and "Compile" button from the playground editor header
- Removes the Ctrl+Enter keyboard shortcut hint from the editor panel
- Removes all related CSS (toggle switch styles) and JS (autoCompile state, toggle listener, button references)
- Compilation now always happens automatically on input change with 400ms debounce
- The Ctrl/Cmd+Enter keymap is retained as a shortcut for immediate compilation

## Test plan
- [ ] Open the playground editor and verify the Auto toggle and Compile button are gone
- [ ] Type in the editor and confirm output auto-compiles after a brief delay
- [ ] Press Ctrl+Enter (or Cmd+Enter on Mac) and confirm immediate compilation still works
- [ ] Toggle light/dark theme and verify it still works (theme button is the only remaining header control)
- [ ] Test on mobile viewport to ensure responsive layout still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)