### PR TITLE
Add wasm binary to release pipeline

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -57,6 +57,38 @@ for p in "${platforms[@]}"; do
   
 done
 
+# Build WebAssembly binary
+echo ""
+echo "Building gh-aw WebAssembly binary..."
+GOOS=js GOARCH=wasm go build \
+  -trimpath \
+  -ldflags="-s -w" \
+  -o "dist/gh-aw.wasm" \
+  ./cmd/gh-aw-wasm
+
+# Run wasm-opt if available
+if command -v wasm-opt &> /dev/null; then
+  echo "Running wasm-opt -Oz (size optimization)..."
+  BEFORE=$(wc -c < dist/gh-aw.wasm)
+  wasm-opt -Oz --enable-bulk-memory dist/gh-aw.wasm -o dist/gh-aw.opt.wasm && \
+    mv dist/gh-aw.opt.wasm dist/gh-aw.wasm
+  AFTER=$(wc -c < dist/gh-aw.wasm)
+  echo "wasm-opt: $BEFORE -> $AFTER bytes"
+fi
+
+# Bundle wasm_exec.js (required Go runtime for loading the wasm binary)
+WASM_EXEC_SRC="$(go env GOROOT)/lib/wasm/wasm_exec.js"
+if [ ! -f "$WASM_EXEC_SRC" ]; then
+  WASM_EXEC_SRC="$(go env GOROOT)/misc/wasm/wasm_exec.js"
+fi
+if [ ! -f "$WASM_EXEC_SRC" ]; then
+  echo "error: wasm_exec.js not found in Go installation" >&2
+  exit 1
+fi
+cp "$WASM_EXEC_SRC" dist/wasm_exec.js
+echo "Bundled wasm_exec.js from $WASM_EXEC_SRC"
+
+echo ""
 echo "Build complete. Binaries:"
 ls -lh dist/
 


### PR DESCRIPTION
## Summary
- Adds `gh-aw.wasm` (WebAssembly compiler) and `wasm_exec.js` (Go runtime) to the release build script
- Both artifacts land in `dist/` and are automatically included in GitHub release assets and checksums
- Uses `wasm-opt` for size optimization when available (consistent with `make build-wasm`)

## Details

The wasm binary lets users compile workflows in the browser without a Go installation. Until now it was only built during CI checks and for the docs site — it was never published as a versioned release asset. This change adds it to `scripts/build-release.sh` so every release includes:

| Asset | Description |
|-------|-------------|
| `gh-aw.wasm` | WebAssembly compiler module (~15 MB) |
| `wasm_exec.js` | Go's Wasm runtime (required to load the module) |

No changes needed to the release workflow itself — the existing `gh release create "$RELEASE_TAG" dist/*` command picks up the new files automatically.

## Test plan
- [x] Ran `bash scripts/build-release.sh v0.0.0-test` locally — confirmed `gh-aw.wasm` and `wasm_exec.js` appear in `dist/` with correct checksums
- [ ] CI passes (build, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)