### PR TITLE
Show editor immediately while WASM compiler loads

### DIFF
--- a/docs/public/editor/index.html
+++ b/docs/public/editor/index.html
@@ -126,8 +126,8 @@ html, body {
 </head>
 <body class="color-bg-default color-fg-default">
 <div class="d-flex flex-column" style="height: 100vh; width: 100vw;" id="app">
-  <!-- Loading Overlay -->
-  <div class="loading-overlay" id="loadingOverlay">
+  <!-- Loading Overlay (hidden by default — editor is shown immediately) -->
+  <div class="loading-overlay hidden" id="loadingOverlay">
     <div class="loading-spinner"></div>
     <div class="f4 color-fg-muted mb-1">Loading gh-aw compiler...</div>
     <div class="f6 color-fg-subtle">Downloading WebAssembly module (~17 MB)</div>


### PR DESCRIPTION
## Summary

- Remove the full-page loading overlay that blocks the UI for 5-10s during WASM download
- Show the CodeMirror editor immediately (~0.5s) so users can start typing right away
- Display "Loading compiler..." status badge and output placeholder while WASM downloads in background
- Track edits made before compiler is ready and auto-compile once loaded

## Before
1. Page loads → loading overlay covers **everything**
2. WASM downloads (5-10s)
3. Overlay fades → editor becomes visible
4. User can finally start typing

## After
1. Page loads → CodeMirror editors visible **immediately**
2. Status badge shows "Loading compiler..." with pulsing dot
3. Output panel shows friendly "Compiler loading... You can start editing!"
4. WASM downloads in background
5. When ready: status → "Ready", content auto-compiles

## Changes

**`docs/public/editor/index.html`**
- Start the loading overlay with `hidden` class so it never flashes on screen

**`docs/public/editor/editor.js`**
- Add `pendingCompile` flag to track edits made before WASM is ready
- Update `EditorView.updateListener` to set the flag instead of no-oping when `!isReady`
- Rewrite `init()` to hide overlay immediately, show loading status, and compile on WASM ready

## Test plan
- [ ] Editor is visible and interactive immediately on page load
- [ ] Output panel shows "Compiler loading..." placeholder
- [ ] Status badge shows "Loading compiler..." with pulsing dot
- [ ] After WASM loads, default content compiles automatically
- [ ] If you type before WASM is ready, content compiles when WASM loads
- [ ] Deep-link loading (e.g. `#issue-triage`) still works
- [ ] Error state still shown if WASM fails to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)