### PR TITLE
Remove theme toggle, use browser color scheme

### DIFF
--- a/docs/public/editor/index.html
+++ b/docs/public/editor/index.html
@@ -160,18 +160,6 @@ html, body {
       <span id="statusText">Loading...</span>
     </span>
 
-    <div class="d-flex flex-items-center gap-3 ml-auto">
-      <button class="btn-octicon" id="themeToggle" title="Toggle theme" aria-label="Toggle dark mode">
-        <!-- Sun icon (shown in dark mode) -->
-        <svg class="icon-sun octicon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:none">
-          <path d="M8 12a4 4 0 100-8 4 4 0 000 8zm0-1.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5zm5.657-8.157a.75.75 0 010 1.06l-1.061 1.06a.75.75 0 01-1.06-1.06l1.06-1.06a.75.75 0 011.06 0zm-9.193 9.193a.75.75 0 010 1.06l-1.06 1.061a.75.75 0 11-1.061-1.06l1.06-1.061a.75.75 0 011.061 0zM8 0a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V.75A.75.75 0 018 0zM3 8a.75.75 0 01-.75.75H.75a.75.75 0 010-1.5h1.5A.75.75 0 013 8zm13 0a.75.75 0 01-.75.75h-1.5a.75.75 0 010-1.5h1.5A.75.75 0 0116 8zm-8 8a.75.75 0 01-.75-.75v-1.5a.75.75 0 011.5 0v1.5A.75.75 0 018 16zm-5.657-2.343a.75.75 0 010-1.06l1.06-1.061a.75.75 0 111.06 1.06l-1.06 1.06a.75.75 0 01-1.06 0zm12.728 0l-1.06-1.06a.75.75 0 011.06-1.061l1.06 1.06a.75.75 0 01-1.06 1.06z"/>
-        </svg>
-        <!-- Moon icon (shown in light mode) -->
-        <svg class="icon-moon octicon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-          <path d="M9.598 1.591a.75.75 0 01.785-.175 7 7 0 11-8.967 8.967.75.75 0 01.961-.96 5.5 5.5 0 007.046-7.046.75.75 0 01.175-.786zm1.616 1.945a7 7 0 01-7.678 7.678 5.5 5.5 0 107.678-7.678z"/>
-        </svg>
-      </button>
-    </div>
   </header>
 
   <!-- Error Banner -->


### PR DESCRIPTION
## Summary
- Removed the sun/moon theme toggle button from the playground editor header
- The editor now automatically follows the browser's `prefers-color-scheme` preference (light or dark mode)
- Primer CSS already supports `data-color-mode="auto"` on the `<html>` element, so page styles adapt natively
- CodeMirror themes (oneDark vs default) switch via a `matchMedia` listener

## Test plan
- [ ] Open the playground in a browser set to light mode — verify light theme renders
- [ ] Switch OS/browser to dark mode — verify both Primer styles and CodeMirror switch to dark
- [ ] Confirm no sun/moon button appears in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)