### PR TITLE
Add auto-save to localStorage for Playground editor

### DIFF
--- a/docs/public/editor/editor.js
+++ b/docs/public/editor/editor.js
@@ -130,6 +130,7 @@ const panels = $('panels');
 // ---------------------------------------------------------------
 // State
 // ---------------------------------------------------------------
+const STORAGE_KEY = 'gh-aw-playground-content';
 let compiler = null;
 let isReady = false;
 let isCompiling = false;
@@ -175,8 +176,11 @@ function setTheme(theme) {
 // ---------------------------------------------------------------
 // CodeMirror: Input Editor (Markdown with YAML frontmatter)
 // ---------------------------------------------------------------
+const savedContent = localStorage.getItem(STORAGE_KEY);
+const initialContent = savedContent || DEFAULT_CONTENT;
+
 const editorView = new EditorView({
-  doc: DEFAULT_CONTENT,
+  doc: initialContent,
   extensions: [
     basicSetup,
     markdown(),
@@ -189,6 +193,8 @@ const editorView = new EditorView({
     }]),
     EditorView.updateListener.of(update => {
       if (update.docChanged) {
+        try { localStorage.setItem(STORAGE_KEY, update.state.doc.toString()); }
+        catch (_) { /* localStorage full or unavailable */ }
         if (isReady) {
           scheduleCompile();
         } else {
@@ -199,6 +205,11 @@ const editorView = new EditorView({
   ],
   parent: editorMount,
 });
+
+// If restoring saved content, clear the dropdown since it may not match any sample
+if (savedContent) {
+  sampleSelect.value = '';
+}
 
 // ---------------------------------------------------------------
 // CodeMirror: Output View (YAML, read-only)


### PR DESCRIPTION
## Summary

- Save editor content to `localStorage` on every document change so users don't lose work when closing/refreshing the tab
- On page load, restore saved content from `localStorage`, falling back to the default Hello World template
- Clear the sample dropdown when restoring saved content to avoid a misleading selection
- Wrap `localStorage.setItem` in try/catch for resilience when storage is full or unavailable

This is a ~10-line change to `docs/public/editor/editor.js`.

## Test plan

- [ ] Load the Playground, edit content, close/refresh the tab -- content should be restored
- [ ] Select a sample template from the dropdown -- it should replace the editor content and auto-save
- [ ] Clear `localStorage.removeItem('gh-aw-playground-content')` in devtools, reload -- should fall back to Hello World
- [ ] Verify theme preference (`gh-aw-playground-theme`) is unaffected
- [ ] Verify deep-link hash URLs still override saved content

🤖 Generated with [Claude Code](https://claude.com/claude-code)