### PR TITLE
Bundle WASM release assets into versioned archive

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -88,6 +88,15 @@ fi
 cp "$WASM_EXEC_SRC" dist/wasm_exec.js
 echo "Bundled wasm_exec.js from $WASM_EXEC_SRC"
 
+# Create WASM bundle archive
+echo "Creating WASM bundle archive..."
+tar -czf "dist/gh-aw-wasm-${VERSION}.tar.gz" -C dist gh-aw.wasm wasm_exec.js
+
+# Remove individual WASM files from dist (they're now in the archive)
+rm dist/gh-aw.wasm dist/wasm_exec.js
+
+echo "✓ Created dist/gh-aw-wasm-${VERSION}.tar.gz"
+
 echo ""
 echo "Build complete. Binaries:"
 ls -lh dist/


### PR DESCRIPTION
## Summary

- Bundle `gh-aw.wasm` and `wasm_exec.js` into a single `gh-aw-wasm-<version>.tar.gz` archive in the release, instead of uploading them as separate top-level assets.
- `wasm_exec.js` **must** match the exact Go version used to compile `gh-aw.wasm`; shipping them together prevents version mismatches.
- Follows the convention used by esbuild-wasm, sql.js, and other WASM-distributing projects.

## What changes

In `scripts/build-release.sh`, after building `gh-aw.wasm` and copying `wasm_exec.js` into `dist/`:

1. Create `dist/gh-aw-wasm-${VERSION}.tar.gz` containing both files.
2. Remove the individual `gh-aw.wasm` and `wasm_exec.js` from `dist/`.
3. The existing checksums step (`sha256sum *`) automatically picks up the archive.

**Before** (release assets):
```
darwin-amd64
linux-amd64
...
gh-aw.wasm          # 16 MB loose file
wasm_exec.js        # 17 KB loose file
checksums.txt
```

**After** (release assets):
```
darwin-amd64
linux-amd64
...
gh-aw-wasm-v0.48.0.tar.gz   # bundled archive
checksums.txt
```

## Test plan

- [ ] Run `scripts/build-release.sh v0.0.0-test` locally and verify `dist/` contains the `.tar.gz` archive but not loose `gh-aw.wasm` / `wasm_exec.js`
- [ ] Verify `dist/checksums.txt` includes a hash for the `.tar.gz` archive
- [ ] Extract the archive and confirm it contains both `gh-aw.wasm` and `wasm_exec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)