### PR TITLE
fix: remove leftover smoke test file

### DIFF
--- a/.github/smoke-test-22204001807.md
+++ b/.github/smoke-test-22204001807.md
@@ -1,1 +1,0 @@
-Test file for PR push - smoke test run 22204001807


### PR DESCRIPTION
## Summary
- Remove `.github/smoke-test-22204001807.md` leftover from smoke Claude test run

## Test plan
- [x] No code changes, just file cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)