### PR TITLE
fix: add --yolo flag to Gemini CLI for auto-approving tool executions

### DIFF
--- a/.changeset/patch-add-gemini-yolo-flag.md
+++ b/.changeset/patch-add-gemini-yolo-flag.md
@@ -1,0 +1,5 @@
+---
+"gh-aw": patch
+---
+
+Add `--yolo` to Gemini CLI invocations so tool executions are automatically approved.

--- a/.github/workflows/smoke-gemini.lock.yml
+++ b/.github/workflows/smoke-gemini.lock.yml
@@ -901,7 +901,7 @@ jobs:
         run: |
           set -o pipefail
           sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --allow-domains '*.githubusercontent.com,*.googleapis.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,generativelanguage.googleapis.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.20.2 --skip-pull \
-            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && gemini --output-format json --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && gemini --yolo --output-format json --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GH_AW_MCP_CONFIG: ${{ github.workspace }}/.gemini/settings.json
@@ -1197,7 +1197,7 @@ jobs:
         id: agentic_execution
         run: |
           set -o pipefail
-          gemini --output-format json --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/gh-aw/threat-detection/detection.log
+          gemini --yolo --output-format json --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)" 2>&1 | tee /tmp/gh-aw/threat-detection/detection.log
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GH_AW_MODEL_DETECTION_GEMINI: ${{ vars.GH_AW_MODEL_DETECTION_GEMINI || '' }}

--- a/pkg/workflow/gemini_engine.go
+++ b/pkg/workflow/gemini_engine.go
@@ -176,6 +176,10 @@ func (e *GeminiEngine) GetExecutionSteps(workflowData *WorkflowData, logFile str
 	// The conversion script (convert_gateway_config_gemini.sh) writes settings.json
 	// during the MCP setup step, so no --mcp-config flag is needed here.
 
+	// Auto-approve all tool executions (equivalent to Codex's --dangerously-bypass-approvals-and-sandbox)
+	// Without this, Gemini CLI's default approval mode rejects tool calls with "Tool execution denied by policy"
+	geminiArgs = append(geminiArgs, "--yolo")
+
 	// Add headless mode with JSON output
 	geminiArgs = append(geminiArgs, "--output-format", "json")
 

--- a/pkg/workflow/gemini_engine_test.go
+++ b/pkg/workflow/gemini_engine_test.go
@@ -151,6 +151,7 @@ func TestGeminiEngineExecution(t *testing.T) {
 		assert.Contains(t, stepContent, "name: Run Gemini", "Should have correct step name")
 		assert.Contains(t, stepContent, "id: agentic_execution", "Should have agentic_execution ID")
 		assert.Contains(t, stepContent, "gemini", "Should invoke gemini command")
+		assert.Contains(t, stepContent, "--yolo", "Should include --yolo flag for auto-approving tool executions")
 		assert.Contains(t, stepContent, "--output-format json", "Should use JSON output format")
 		assert.Contains(t, stepContent, `--prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"`, "Should include prompt argument with correct shell quoting")
 		assert.Contains(t, stepContent, "/tmp/test.log", "Should include log file")


### PR DESCRIPTION
## Summary

- Add `--yolo` flag to Gemini CLI invocations to auto-approve all tool executions
- Without this flag, Gemini CLI's default approval mode rejects MCP tool calls with "Tool execution denied by policy"
- Add test assertion verifying `--yolo` is included in generated commands

## Context

After merging #16938 (which fixed the `--mcp-config` flag issue), the Gemini smoke test showed the Gemini agent started successfully and connected to all MCP servers, but every tool call was rejected:

```
Error executing tool list_pull_requests: Tool execution denied by policy.
Error executing tool search_pull_requests: Tool execution denied by policy.
Error executing tool gh: Tool execution denied by policy.
Error executing tool noop: Tool execution denied by policy.
Error executing tool missing_tool: Tool execution denied by policy.
```

This is because Gemini CLI defaults to requiring user approval for tool executions. The `--yolo` flag is the Gemini equivalent of:
- Codex's `--dangerously-bypass-approvals-and-sandbox`
- Claude's `--allowed-tools` list

Closes #16933

## Test plan

- [x] Unit tests pass (`go test ./pkg/workflow/ -run Gemini`)
- [x] Test asserts `--yolo` flag is present in generated command
- [x] Lock file recompiled with dev build (no version in header)
- [ ] Smoke test with `smoke` label to verify tools work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

---
✨ PR Review Safe Output Test - Run 22205336918

> 💥 *[THE END] — Illustrated by [Smoke Claude](https://github.com/github/gh-aw/actions/runs/22205336918)*

---

fix: add --yolo flag to Gemini CLI for auto-approving tool executions

## Summary

- Add `--yolo` flag to Gemini CLI invocations to auto-approve all tool executions
- Without this flag, Gemini CLI's default approval mode rejects MCP tool calls with "Tool execution denied by policy"
- Add test assertion verifying `--yolo` is included in generated commands

## Context

After merging #16938 (which fixed the `--mcp-config` flag issue), the Gemini smoke test showed the Gemini agent started successfully and connected to all MCP servers, but every tool call was rejected:

````markdown
```
Error executing tool list_pull_requests: Tool execution denied by policy.
Error executing tool search_pull_requests: Tool execution denied by policy.
Error executing tool gh: Tool execution denied by policy.
Error executing tool noop: Tool execution denied by policy.
Error executing tool missing_tool: Tool execution denied by policy.
```
````

This is because Gemini CLI defaults to requiring user approval for tool executions. The `--yolo` flag is the Gemini equivalent of:
- Codex's `--dangerously-bypass-approvals-and-sandbox`
- Claude's `--allowed-tools` list

```Closes #16933```

## Test plan

- [x] Unit tests pass (`go test ./pkg/workflow/ -run Gemini`)
- [x] Test asserts `--yolo` flag is present in generated command
- [x] Lock file recompiled with dev build (no version in header)
- [ ] Smoke test with `smoke` label to verify tools work end-to-end

🤖 Generated with [Claude Code]((claude.com/redacted)

## Changeset

- **Type**: patch
- **Description**: Add `--yolo` to Gemini CLI invocations so tool executions are auto-approved.
```

> Generated by [Changeset Generator](https://github.com/github/gh-aw/actions/runs/22205336903)