### PR TITLE
Update instructions janitor to specifically check safe outputs for co…

### DIFF
--- a/.github/workflows/instructions-janitor.md
+++ b/.github/workflows/instructions-janitor.md
@@ -42,7 +42,7 @@ timeout-minutes: 15
 
 # Instructions Janitor
 
-You are an AI agent specialized in maintaining instruction files for other AI agents. Your mission is to keep the `github-agentic-workflows.md` file synchronized with documentation changes.
+You are an AI agent specialized in maintaining instruction files for other AI agents. Your mission is to keep the `github-agentic-workflows.md` file synchronized with documentation changes and current safe-outputs behavior in code.
 
 ## Your Mission
 
@@ -88,7 +88,20 @@ Understand:
 - Coverage of features and capabilities
 - Style and formatting conventions
 
-### 4. Identify Gaps and Inconsistencies
+### 4. Audit Safe Outputs in Code
+
+Inspect the current safe-outputs implementation in code and treat it as a required source of truth:
+
+- Use `get_file_contents` to review these files:
+  - `pkg/workflow/safe_outputs_config.go`
+  - `pkg/workflow/safe_outputs_config_generation.go`
+  - `pkg/workflow/js/safe_outputs_tools.json`
+  - `pkg/workflow/compiler_safe_outputs.go`
+- Enumerate supported safe-output operations, options, and constraints.
+- Compare this code-level state against the safe-outputs sections in `.github/aw/github-agentic-workflows.md`.
+- If the instructions differ from code, update the instructions to match code even when documentation commits do not mention safe outputs.
+
+### 5. Identify Gaps and Inconsistencies
 
 Compare documentation changes against instructions:
 
@@ -101,11 +114,11 @@ Compare documentation changes against instructions:
 Focus on:
 - Frontmatter schema changes (new fields, deprecated fields)
 - Tool configuration updates (new tools, changed APIs)
-- Safe-output patterns (new output types, changed behavior)
+- Safe-output patterns (new output types, changed behavior), validated directly against code implementation
 - GitHub context expressions (new allowed expressions)
 - Compilation commands (new flags, changed behavior)
 
-### 5. Update Instructions File
+### 6. Update Instructions File
 
 Apply surgical updates following these principles:
 
@@ -138,7 +151,7 @@ Apply surgical updates following these principles:
 5. **Best Practices**: Update recommendations based on learned patterns
 6. **Examples**: Use real workflow patterns from the repository
 
-### 6. Create Pull Request
+### 7. Create Pull Request
 
 If you made updates:
 
@@ -183,7 +196,7 @@ When updating instructions for AI agents:
 
 ## Edge Cases
 
-- **No Documentation Changes**: If no docs changed since last release, exit gracefully
+- **No Documentation Changes**: If no docs changed since last release, still perform the safe-outputs code vs instructions comparison before deciding no update is needed
 - **Instructions Already Current**: If instructions already reflect all changes, exit gracefully
 - **Breaking Changes**: Highlight breaking changes prominently with warnings
 - **Complex Features**: For complex features, link to full documentation instead of explaining inline

--- a/.github/workflows/instructions-janitor.md
+++ b/.github/workflows/instructions-janitor.md
@@ -92,11 +92,11 @@ Understand:
 
 Inspect the current safe-outputs implementation in code and treat it as a required source of truth:
 
-- Use `get_file_contents` to review these files:
-  - `pkg/workflow/safe_outputs_config.go`
-  - `pkg/workflow/safe_outputs_config_generation.go`
-  - `pkg/workflow/js/safe_outputs_tools.json`
-  - `pkg/workflow/compiler_safe_outputs.go`
+- Use `get_file_contents` to review these three key files that define safe-output operations and their accepted arguments:
+  - `pkg/workflow/compiler_types.go` — `SafeOutputsConfig` struct defining every operation field and its Go type
+  - `pkg/workflow/safe_outputs_config.go` — parses frontmatter YAML into typed structs, showing what arguments each operation accepts
+  - `pkg/parser/schemas/main_workflow_schema.json` — JSON Schema listing all operations, their properties, types, and defaults
+- Browse other code files as needed to validate behavior or resolve ambiguity (e.g., config generation, compiler, validation, and step files under `pkg/workflow/`).
 - Enumerate supported safe-output operations, options, and constraints.
 - Compare this code-level state against the safe-outputs sections in `.github/aw/github-agentic-workflows.md`.
 - If the instructions differ from code, update the instructions to match code even when documentation commits do not mention safe outputs.


### PR DESCRIPTION
…nsistency

We've gotten reports that our authoring agent uses the wrong safe outputs or ones that don't exist.  I propose we update our instructions janitor to look for divergence between the safe outputs instructions and the safe outputs code.