### PR TITLE
Fix safe output documentation errors in agent instructions

### DIFF
--- a/.github/aw/github-agentic-workflows.md
+++ b/.github/aw/github-agentic-workflows.md
@@ -733,7 +733,6 @@ The YAML frontmatter supports these fields:
         max-size: 10240                 # Optional: max file size in KB (default: 10MB)
         allowed-exts: [.png, .jpg, .pdf] # Optional: allowed file extensions
         max: 10                         # Optional: max assets (default: 10)
-        target-repo: "owner/repo"       # Optional: cross-repository
     ```
     Publishes workflow artifacts to an orphaned git branch for persistent storage. Default allowed extensions include common non-executable types. Maximum file size is 50MB (51200 KB).
   - `dispatch-workflow:` - Trigger other workflows with inputs
@@ -781,7 +780,7 @@ The YAML frontmatter supports these fields:
     ```yaml
     safe-outputs:
       assign-to-user:
-        assignees: [user1, user2]       # Optional: restrict to specific users
+        allowed: [user1, user2]         # Optional: restrict to specific users
         blocked: [copilot, "*[bot]"]    # Optional: deny specific users or glob patterns
         max: 3                          # Optional: max assignments (default: 3)
         target: "*"                     # Optional: "triggering" (default), "*", or number
@@ -1553,7 +1552,7 @@ Create an issue with your final analysis.
 
 ### Automatic Pull Request Creation
 
-Use the `safe-outputs.pull-request` configuration to automatically create pull requests from coding agent output:
+Use the `safe-outputs.create-pull-request` configuration to automatically create pull requests from coding agent output:
 
 ```aw
 ---


### PR DESCRIPTION
- Change 'assignees:' to 'allowed:' for assign-to-user (matches parser field)
- Remove unsupported 'target-repo' from upload-asset example (same-repo only)
- Fix 'safe-outputs.pull-request' to 'safe-outputs.create-pull-request'

These errors were causing agents to hallucinate non-existent parameters.