### PR TITLE
docs: add FAQ on why macOS runners are not supported

### DIFF
--- a/docs/src/content/docs/reference/faq.md
+++ b/docs/src/content/docs/reference/faq.md
@@ -316,6 +316,12 @@ on:
 
 This approach maintains security while allowing CI to run after PR creation. See [GitHub Actions workflow_run documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) for details.
 
+## Platform Support
+
+### Why don't agentic workflows support macOS runners?
+
+Agentic workflows require Docker for the [Agent Workflow Firewall](/gh-aw/reference/sandbox/) (Squid proxy + agent containers), the MCP Gateway, and containerized MCP servers. GitHub-hosted macOS runners are themselves virtual machines (`Apple M1 (Virtual)`) that do not support nested virtualization, making it impossible to run Docker — Docker Desktop, colima, and QEMU all fail with `Virtualization is not available on this hardware`. Until GitHub offers macOS runners with Docker support or a non-Docker container runtime becomes viable, agentic workflows require Linux (`ubuntu-*`) runners.
+
 ## Workflow Design
 
 ### Should I focus on one workflow, or write many different ones?


### PR DESCRIPTION
## Summary
Add a "Platform Support" section to the FAQ explaining why agentic workflows don't support macOS runners.

## Context
GHA macOS ARM64 runners are VMs (`Apple M1 (Virtual)`) without nested virtualization. We extensively tested Docker Desktop (DMG installer, brew cask), colima (vz, qemu, auto-detect), and Apple's `container` tool — none can provide Docker on these runners. This FAQ documents the limitation for users.

## Test plan
- [x] Doc-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)