### PR TITLE
docs: add supported runners table to frontmatter reference

### DIFF
--- a/docs/src/content/docs/reference/frontmatter.md
+++ b/docs/src/content/docs/reference/frontmatter.md
@@ -457,7 +457,7 @@ timeout-minutes: 30                  # Defaults to 20 minutes
 | `ubuntu-latest` | ✅ Default. Recommended for most workflows. |
 | `ubuntu-24.04` / `ubuntu-22.04` | ✅ Supported. |
 | `ubuntu-24.04-arm` | ✅ Supported. Linux ARM64 runner. |
-| `macos-*` | ❌ Not supported. Docker is unavailable on macOS runners (no nested virtualization). See [FAQ](/gh-aw/reference/faq/#why-dont-agentic-workflows-support-macos-runners). |
+| `macos-*` | ❌ Not supported. Docker is unavailable on macOS runners (no nested virtualization). See [FAQ](/gh-aw/reference/faq/). |
 | `windows-*` | ❌ Not supported. AWF requires Linux. |
 
 ### Workflow Concurrency Control (`concurrency:`)

--- a/docs/src/content/docs/reference/frontmatter.md
+++ b/docs/src/content/docs/reference/frontmatter.md
@@ -450,6 +450,16 @@ runs-on: ubuntu-latest               # Defaults to ubuntu-latest (main job only)
 timeout-minutes: 30                  # Defaults to 20 minutes
 ```
 
+**Supported runners for `runs-on:`**
+
+| Runner | Status |
+|--------|--------|
+| `ubuntu-latest` | ✅ Default. Recommended for most workflows. |
+| `ubuntu-24.04` / `ubuntu-22.04` | ✅ Supported. |
+| `ubuntu-24.04-arm` | ✅ Supported. Linux ARM64 runner. |
+| `macos-*` | ❌ Not supported. Docker is unavailable on macOS runners (no nested virtualization). See [FAQ](/gh-aw/reference/faq/#why-dont-agentic-workflows-support-macos-runners). |
+| `windows-*` | ❌ Not supported. AWF requires Linux. |
+
 ### Workflow Concurrency Control (`concurrency:`)
 
 Automatically generates concurrency policies for the agent job. See [Concurrency Control](/gh-aw/reference/concurrency/).


### PR DESCRIPTION
## Summary
Add a runner compatibility table to the `runs-on:` section of the frontmatter reference, so users know which runners work with agentic workflows.

## Changes
- `docs/src/content/docs/reference/frontmatter.md` — add table below `runs-on:` showing supported/unsupported runners
- Links to FAQ for macOS explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)