### PR TITLE
Enhance scout command with additional inputs

### DIFF
--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -33,7 +33,7 @@
 #     - shared/mcp/tavily.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"3ecc8e8ef5dd3dc2f232da0e4c2254673b255194cf825d28901ba12ce9c41aab"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"83ed95cbe48a05e39cab40042aa5d647ed791127120f4948c07c78855d3fbe96"}
 
 name: "Scout"
 "on":
@@ -69,6 +69,14 @@ name: "Scout"
   # - write # Roles processed as role check in pre-activation job
   workflow_dispatch:
     inputs:
+      history:
+        default: shallow
+        description: "Git history to fetch: shallow (default) or full"
+        options:
+        - shallow
+        - full
+        required: false
+        type: choice
       topic:
         description: Research topic or question
         required: true
@@ -164,6 +172,7 @@ jobs:
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          GH_AW_GITHUB_EVENT_INPUTS_HISTORY: ${{ github.event.inputs.history }}
           GH_AW_GITHUB_EVENT_INPUTS_TOPIC: ${{ github.event.inputs.topic }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
@@ -293,6 +302,7 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
+          GH_AW_GITHUB_EVENT_INPUTS_HISTORY: ${{ github.event.inputs.history }}
           GH_AW_GITHUB_EVENT_INPUTS_TOPIC: ${{ github.event.inputs.topic }}
           GH_AW_EXPR_799BE623: ${{ github.event.issue.number || github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
@@ -314,6 +324,7 @@ jobs:
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          GH_AW_GITHUB_EVENT_INPUTS_HISTORY: ${{ github.event.inputs.history }}
           GH_AW_GITHUB_EVENT_INPUTS_TOPIC: ${{ github.event.inputs.topic }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
@@ -342,6 +353,7 @@ jobs:
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
+                GH_AW_GITHUB_EVENT_INPUTS_HISTORY: process.env.GH_AW_GITHUB_EVENT_INPUTS_HISTORY,
                 GH_AW_GITHUB_EVENT_INPUTS_TOPIC: process.env.GH_AW_GITHUB_EVENT_INPUTS_TOPIC,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,

--- a/.github/workflows/scout.md
+++ b/.github/workflows/scout.md
@@ -5,11 +5,28 @@ on:
   roles: [admin, maintainer, write]
   slash_command:
     name: scout
+    inputs:
+      topic:
+        description: "Research topic or question"
+        required: false
+      history:
+        description: "Git history to fetch: shallow (default) or full"
+        required: false
+        default: "shallow"
+        choices: ["shallow", "full"]
   workflow_dispatch:
     inputs:
       topic:
-        description: 'Research topic or question'
+        description: "Research topic or question"
         required: true
+      history:
+        description: "Git history to fetch: shallow (default) or full"
+        required: false
+        default: "shallow"
+        type: choice
+        options:
+          - shallow
+          - full
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/scout.md
+++ b/.github/workflows/scout.md
@@ -5,19 +5,10 @@ on:
   roles: [admin, maintainer, write]
   slash_command:
     name: scout
-    inputs:
-      topic:
-        description: "Research topic or question"
-        required: false
-      history:
-        description: "Git history to fetch: shallow (default) or full"
-        required: false
-        default: "shallow"
-        choices: ["shallow", "full"]
   workflow_dispatch:
     inputs:
       topic:
-        description: "Research topic or question"
+        description: 'Research topic or question'
         required: true
       history:
         description: "Git history to fetch: shallow (default) or full"

--- a/.github/workflows/scout.md
+++ b/.github/workflows/scout.md
@@ -66,10 +66,21 @@ When invoked with the `/scout` command in an issue or pull request comment, OR m
 - **Repository**: ${{ github.repository }}
 - **Triggering Content**: "${{ steps.sanitized.outputs.text }}"
 - **Research Topic** (if workflow_dispatch): "${{ github.event.inputs.topic }}"
+- **Git History Mode** (if workflow_dispatch): "${{ github.event.inputs.history }}"
 - **Issue/PR Number**: ${{ github.event.issue.number || github.event.pull_request.number }}
 - **Triggered by**: @${{ github.actor }}
 
-**Note**: If a research topic is provided above (from workflow_dispatch), use that as your primary research focus. Otherwise, analyze the triggering content to determine the research topic.
+**Note**:
+- **Topic precedence**: Use `workflow_dispatch` topic when present. Otherwise, derive topic from triggering content (for example `/scout ...`).
+- **History precedence**: Use `workflow_dispatch` history when present. Otherwise, default to `shallow` unless the triggering content explicitly requests full history (for example `history=full`).
+
+**Git History Handling**: If `Git History Mode` is `full`, fetch full history before doing any git-history analysis:
+
+```bash
+git fetch --unshallow --tags || git fetch --tags
+```
+
+If `Git History Mode` is `shallow` (or empty), keep default shallow history unless triggering content explicitly requests `history=full`, and avoid conclusions that require complete historical data.
 
 **Deep Research Agent**: This workflow imports the GitHub deep research agent repository, which provides additional tools and capabilities from `.github/agents/` and `.github/workflows/` for enhanced research functionality.
 


### PR DESCRIPTION
- Added input for 'history' to the scout command to be able to do more deep research on the repo (`history=full`).
- Default is still a shallow clone (`history=shallow`).