### PR TITLE
Increase scout timeout for deep research

### DIFF
--- a/.github/workflows/scout.lock.yml
+++ b/.github/workflows/scout.lock.yml
@@ -33,7 +33,7 @@
 #     - shared/mcp/tavily.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"83ed95cbe48a05e39cab40042aa5d647ed791127120f4948c07c78855d3fbe96"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"846be190041166607f8306af98153fe299bc88609914fca4e1cc5a9e748bbc69"}
 
 name: "Scout"
 "on":
@@ -924,7 +924,7 @@ jobs:
         # - mcp__markitdown
         # - mcp__microsoftdocs
         # - mcp__tavily
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           set -o pipefail
           sudo -E awf --tty --env-all --container-workdir "${GITHUB_WORKSPACE}" --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,mcp.deepwiki.com,mcp.tavily.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.20.2 --skip-pull --enable-api-proxy \

--- a/.github/workflows/scout.md
+++ b/.github/workflows/scout.md
@@ -44,7 +44,7 @@ safe-outputs:
     run-started: "🏕️ Scout on patrol! [{workflow_name}]({run_url}) is blazing trails through this {event_type}..."
     run-success: "🔭 Recon complete! [{workflow_name}]({run_url}) has charted the territory. Map ready! 🗺️"
     run-failure: "🏕️ Lost in the wilderness! [{workflow_name}]({run_url}) {status}. Sending search party..."
-timeout-minutes: 10
+timeout-minutes: 20
 strict: true
 ---
 


### PR DESCRIPTION
- Increases timeout for the Scout workflow from 10 to 20 minutes.
- Allows the workflow more time to complete, reducing the likelihood of premature timeouts during deep research.