### PR TITLE
🧙 Improve add wizard with merge prompt and dirty check

### DIFF
--- a/pkg/cli/add_interactive_orchestrator.go
+++ b/pkg/cli/add_interactive_orchestrator.go
@@ -82,6 +82,11 @@ func RunAddInteractive(ctx context.Context, workflowSpecs []string, verbose bool
 		return err
 	}
 
+	// Step 3b: Check working directory is clean (must be clean for PR creation later)
+	if err := config.checkCleanWorkingDirectory(); err != nil {
+		return err
+	}
+
 	// Step 4: Check GitHub Actions is enabled
 	if err := config.checkActionsEnabled(); err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Adds an interactive confirmation prompt when a PR merge fails, allowing users to continue manually or stop gracefully
- Validates that the working directory is clean early in the wizard flow, before PR creation, with helpful recovery instructions
- Surfaces clear error messages and guidance for both failure scenarios
