### PR TITLE
parser: stabilize strict unknown-property ordering

### DIFF
--- a/pkg/parser/schema_errors.go
+++ b/pkg/parser/schema_errors.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -211,9 +212,7 @@ func rewriteAdditionalPropertiesError(message string) string {
 		match := re.FindStringSubmatch(message)
 
 		if len(match) >= 2 {
-			properties := match[1]
-			// Clean up the property list and make it more readable
-			properties = strings.ReplaceAll(properties, "'", "")
+			properties := normalizeAdditionalPropertyList(match[1])
 
 			if strings.Contains(properties, ",") {
 				return "Unknown properties: " + properties
@@ -224,4 +223,18 @@ func rewriteAdditionalPropertiesError(message string) string {
 	}
 
 	return message
+}
+
+func normalizeAdditionalPropertyList(raw string) string {
+	raw = strings.ReplaceAll(raw, "'", "")
+	parts := strings.Split(raw, ",")
+	cleaned := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	sort.Strings(cleaned)
+	return strings.Join(cleaned, ", ")
 }

--- a/pkg/parser/schema_errors_test.go
+++ b/pkg/parser/schema_errors_test.go
@@ -274,3 +274,34 @@ func TestTranslateSchemaConstraintMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestRewriteAdditionalPropertiesErrorOrdering(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "sorts multiple unknown properties",
+			in:   "at '/safe-outputs': additional properties 'zeta', 'alpha', 'beta' not allowed",
+			want: "Unknown properties: alpha, beta, zeta",
+		},
+		{
+			name: "sorts and trims unquoted list",
+			in:   "additional properties zeta, alpha, beta not allowed",
+			want: "Unknown properties: alpha, beta, zeta",
+		},
+		{
+			name: "single unknown property remains singular",
+			in:   "additional property 'timeout_minutes' not allowed",
+			want: "Unknown property: timeout_minutes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteAdditionalPropertiesError(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem
Strict-mode unknown-property diagnostics can emit multi-property lists in unstable order, creating noisy diffs and flaky output expectations.

## Why now
Strict mode is used as a safety gate, and ordering noise obscures real behavioral regressions.

## What changed
- Normalized additional-property lists to deterministic lexical ordering in `rewriteAdditionalPropertiesError`.
- Added regression coverage for singular/plural unknown-property rewrite behavior and stable ordering.

## Validation
- `go test ./pkg/parser -run 'TestRewriteAdditionalPropertiesErrorOrdering|TestCleanJSONSchemaErrorMessage'`
- `make agent-finish` *(fails in baseline staticcheck on unrelated files)*
- `make fmt`
- `make test-unit` *(fails in baseline `pkg/workflow` git patch tests unrelated to changed parser files)*

Refs #17753
