### PR TITLE
test(parser): add rerun stability contract for import topological order

### DIFF
--- a/pkg/parser/import_topological_test.go
+++ b/pkg/parser/import_topological_test.go
@@ -454,3 +454,48 @@ tools:
 	assert.Equal(t, "a-dependency.md", result.ImportedFiles[0])
 	assert.Equal(t, "z-parent.md", result.ImportedFiles[1])
 }
+
+func TestImportTopologicalSortStableAcrossRuns(t *testing.T) {
+	tempDir := testutil.TempDir(t, "import-topo-stable-*")
+
+	files := map[string]string{
+		"root.md": `---
+imports:
+  - b.md
+  - a.md
+---`,
+		"a.md": `---
+imports:
+  - c.md
+tools:
+  a-tool: {}
+---`,
+		"b.md": `---
+tools:
+  b-tool: {}
+---`,
+		"c.md": `---
+tools:
+  c-tool: {}
+---`,
+	}
+
+	for filename, content := range files {
+		filePath := filepath.Join(tempDir, filename)
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+
+	frontmatter := map[string]any{"imports": []string{"root.md"}}
+
+	var baseline []string
+	for i := 0; i < 5; i++ {
+		result, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+		require.NoError(t, err)
+		if i == 0 {
+			baseline = append([]string(nil), result.ImportedFiles...)
+			continue
+		}
+		assert.Equal(t, baseline, result.ImportedFiles)
+	}
+}


### PR DESCRIPTION
## Problem
Import-derived lock output ordering can appear unstable across repeated compiles, which creates noisy lock churn and makes PR review harder.

## Why now
This is active operator friction in current workflows and needs deterministic behavior for repeatable triage/replay.

## What changed
Added a parser-level regression test that re-runs import processing multiple times and asserts an identical imported file order across runs.

## Validation
- go test ./pkg/parser -run TestImportTopologicalSortStableAcrossRuns (pass)

Refs #17923
