### PR TITLE
Add storage.googleapis.com to node ecosystem

### DIFF
--- a/pkg/workflow/data/ecosystem_domains.json
+++ b/pkg/workflow/data/ecosystem_domains.json
@@ -145,6 +145,7 @@
     "esm.sh",
     "googleapis.deno.dev",
     "googlechromelabs.github.io",
+    "storage.googleapis.com",
     "cdn.jsdelivr.net"
   ],
   "node-cdns": ["cdn.jsdelivr.net"],

--- a/test-pr-push-22315455890.txt
+++ b/test-pr-push-22315455890.txt
@@ -1,0 +1,1 @@
+Test file for PR push


### PR DESCRIPTION
## Summary
Add `storage.googleapis.com` to the `node` ecosystem domain list.

## Why
Deno and Bun workflows use the `node` ecosystem. Several repos (deno/fresh, deno/postgres) need `storage.googleapis.com` for:
- Chrome for Testing downloads (browser automation)
- Dart/Flutter package downloads
- Various GCS-hosted assets

Currently it's only in the `go` and `dart` ecosystems, requiring awkward cross-ecosystem additions.

## Test plan
- [ ] `make test-unit` passes
- [ ] No duplicate domain conflicts (or handled appropriately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

---
✨ PR Review Safe Output Test - Run 22315455890

> 💥 *[THE END] — Illustrated by [Smoke Claude](https://github.com/github/gh-aw/actions/runs/22315455890)*

<!-- gh-aw-agentic-workflow: Smoke Claude, engine: claude, id: 22315455890, workflow_id: smoke-claude, run: https://github.com/github/gh-aw/actions/runs/22315455890 -->