### PR TITLE
🔧 Simplify `secrets set` to use single `--repo` flag

### DIFF
--- a/docs/src/content/docs/setup/cli.md
+++ b/docs/src/content/docs/setup/cli.md
@@ -162,12 +162,13 @@ Manage GitHub Actions secrets and tokens.
 Create or update a repository secret (from stdin, flag, or environment variable).
 
 ```bash wrap
-gh aw secrets set MY_SECRET                                    # From stdin
+gh aw secrets set MY_SECRET                                    # From stdin (current repo)
+gh aw secrets set MY_SECRET --repo myorg/myrepo                # Specify target repo
 gh aw secrets set MY_SECRET --value "secret123"                # From flag
 gh aw secrets set MY_SECRET --value-from-env MY_TOKEN          # From env var
 ```
 
-**Options:** `--owner`, `--repo`, `--value`, `--value-from-env`, `--api-url`
+**Options:** `--repo`, `--value`, `--value-from-env`, `--api-url`
 
 ##### `secrets bootstrap`
 


### PR DESCRIPTION
## Summary

- Replace separate `--owner` and `--repo` flags with a single `--repo owner/repo` flag for `gh aw secrets set`
- Default to the current repository when `--repo` is not specified
- Update documentation and usage examples to reflect the new flag interface