### PR TITLE
chore: add CentralRepoOps pattern to design patterns list

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -189,6 +189,7 @@ export default defineConfig({
 				{
 					label: 'Design Patterns',
 					items: [
+						{ label: 'CentralRepoOps', link: '/patterns/central-repo-ops/' },
 						{ label: 'ChatOps', link: '/patterns/chat-ops/' },
 						{ label: 'DailyOps', link: '/patterns/daily-ops/' },
 						{ label: 'DataOps', link: '/patterns/data-ops/' },


### PR DESCRIPTION
- Surface "Central Repo Ops" page in toc under "Design Patterns".