### PR TITLE
🔒 Add fork PR detection, CI trigger restrictions, and integration tests

### DIFF
--- a/actions/setup/js/checkout_pr_branch.cjs
+++ b/actions/setup/js/checkout_pr_branch.cjs
@@ -112,6 +112,11 @@ async function main() {
     // Log detailed context for debugging
     const { isFork } = logPRContext(eventName, pullRequest);
 
+    // Export fork status as environment variable for downstream jobs/steps
+    // This allows safe output collectors to reject fork PRs early
+    core.exportVariable("GH_AW_IS_FORK_PR", isFork ? "true" : "false");
+    core.info(`Exported GH_AW_IS_FORK_PR=${isFork ? "true" : "false"}`);
+
     if (eventName === "pull_request") {
       // For pull_request events, we run in the merge commit context
       // The PR branch is already available, so we can use direct git commands

--- a/actions/setup/js/checkout_pr_branch.test.cjs
+++ b/actions/setup/js/checkout_pr_branch.test.cjs
@@ -15,6 +15,7 @@ describe("checkout_pr_branch.cjs", () => {
       setOutput: vi.fn(),
       startGroup: vi.fn(),
       endGroup: vi.fn(),
+      exportVariable: vi.fn(),
       summary: {
         addRaw: vi.fn().mockReturnThis(),
         write: vi.fn().mockResolvedValue(undefined),
@@ -488,6 +489,29 @@ If the pull request is still open, verify that:
       expect(mockCore.warning).toHaveBeenCalledWith("⚠️ Head repo information not available (repo may be deleted)");
       expect(mockCore.info).toHaveBeenCalledWith("Is fork PR: true (head repository deleted (was likely a fork))");
       expect(mockCore.warning).toHaveBeenCalledWith("⚠️ Fork PR detected - gh pr checkout will fetch from fork repository");
+    });
+
+    it("should export GH_AW_IS_FORK_PR=true for fork PRs", async () => {
+      mockContext.eventName = "pull_request_target";
+      mockContext.payload.pull_request.head.repo.full_name = "fork-owner/test-repo";
+
+      await runScript();
+
+      // Verify environment variable is exported
+      expect(mockCore.exportVariable).toHaveBeenCalledWith("GH_AW_IS_FORK_PR", "true");
+      expect(mockCore.info).toHaveBeenCalledWith("Exported GH_AW_IS_FORK_PR=true");
+    });
+
+    it("should export GH_AW_IS_FORK_PR=false for same-repo PRs", async () => {
+      mockContext.eventName = "pull_request";
+      mockContext.payload.pull_request.head.repo.full_name = "test-owner/test-repo";
+      mockContext.payload.pull_request.head.repo.fork = false;
+
+      await runScript();
+
+      // Verify environment variable is exported
+      expect(mockCore.exportVariable).toHaveBeenCalledWith("GH_AW_IS_FORK_PR", "false");
+      expect(mockCore.info).toHaveBeenCalledWith("Exported GH_AW_IS_FORK_PR=false");
     });
 
     it("should log detailed PR context with startGroup/endGroup", async () => {

--- a/actions/setup/js/create_discussion_category_normalization.test.cjs
+++ b/actions/setup/js/create_discussion_category_normalization.test.cjs
@@ -105,8 +105,13 @@ describe("create_discussion category normalization", () => {
   });
 
   afterEach(() => {
-    // Restore environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
     vi.clearAllMocks();
   });
 

--- a/actions/setup/js/create_discussion_fallback.test.cjs
+++ b/actions/setup/js/create_discussion_fallback.test.cjs
@@ -102,8 +102,13 @@ describe("create_discussion fallback with close_older_discussions", () => {
   });
 
   afterEach(() => {
-    // Restore environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
     vi.clearAllMocks();
   });
 

--- a/actions/setup/js/create_discussion_labels.test.cjs
+++ b/actions/setup/js/create_discussion_labels.test.cjs
@@ -136,8 +136,13 @@ describe("create_discussion with labels", () => {
   });
 
   afterEach(() => {
-    // Restore environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
 
     // Clear mocks
     vi.clearAllMocks();

--- a/actions/setup/js/create_issue.test.cjs
+++ b/actions/setup/js/create_issue.test.cjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createRequire } from "module";
 

--- a/actions/setup/js/create_issue.test.cjs
+++ b/actions/setup/js/create_issue.test.cjs
@@ -81,8 +81,13 @@ describe("create_issue", () => {
   });
 
   afterEach(() => {
-    // Restore original environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
     vi.clearAllMocks();
   });
 

--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -569,8 +569,10 @@ async function main(config = {}) {
       }
 
       // Patches are created with git format-patch, so use git am to apply them
+      // Use --3way to handle cross-repo patches where the patch base may differ from target repo
+      // This allows git to resolve create-vs-modify mismatches when a file exists in target but not source
       try {
-        await exec.exec(`git am ${patchFilePath}`);
+        await exec.exec(`git am --3way ${patchFilePath}`);
         core.info("Patch applied successfully");
       } catch (patchError) {
         core.error(`Failed to apply patch: ${patchError instanceof Error ? patchError.message : String(patchError)}`);
@@ -679,8 +681,8 @@ To apply the patch locally:
 gh run download ${runId} -n agent-artifacts -D /tmp/agent-artifacts-${runId}
 
 # The patch file will be at agent-artifacts/tmp/gh-aw/${patchFileName} after download
-# Apply the patch
-git am /tmp/agent-artifacts-${runId}/${patchFileName}
+# Apply the patch (--3way handles cross-repo patches where files may already exist)
+git am --3way /tmp/agent-artifacts-${runId}/${patchFileName}
 \`\`\`
 ${patchPreview}`;
 

--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -553,6 +553,10 @@ async function main(config = {}) {
     core.info(`Created new branch from base: ${branchName}`);
 
     // Apply the patch using git CLI (skip if empty)
+    // Track number of new commits pushed so we can restrict the extra empty commit
+    // to branches with exactly one new commit (security: prevents use of CI trigger
+    // token on multi-commit branches where workflow files may have been modified).
+    let newCommitCount = 0;
     if (!isEmpty) {
       core.info("Applying patch...");
 
@@ -616,6 +620,17 @@ async function main(config = {}) {
 
         await exec.exec(`git push origin ${branchName}`);
         core.info("Changes pushed to branch");
+
+        // Count new commits on PR branch relative to base, used to restrict
+        // the extra empty CI-trigger commit to exactly 1 new commit.
+        try {
+          const { stdout: countStr } = await exec.getExecOutput("git", ["rev-list", "--count", `origin/${baseBranch}..HEAD`]);
+          newCommitCount = parseInt(countStr.trim(), 10);
+          core.info(`${newCommitCount} new commit(s) on branch relative to origin/${baseBranch}`);
+        } catch {
+          // Non-fatal - newCommitCount stays 0, extra empty commit will be skipped
+          core.info("Could not count new commits - extra empty commit will be skipped");
+        }
       } catch (pushError) {
         // Push failed - create fallback issue instead of PR (if fallback is enabled)
         core.error(`Git push failed: ${pushError instanceof Error ? pushError.message : String(pushError)}`);
@@ -750,6 +765,16 @@ ${patchPreview}`;
 
           await exec.exec(`git push origin ${branchName}`);
           core.info("Empty branch pushed successfully");
+
+          // Count new commits (will be 1 from the Initialize commit)
+          try {
+            const { stdout: countStr } = await exec.getExecOutput("git", ["rev-list", "--count", `origin/${baseBranch}..HEAD`]);
+            newCommitCount = parseInt(countStr.trim(), 10);
+            core.info(`${newCommitCount} new commit(s) on branch relative to origin/${baseBranch}`);
+          } catch {
+            // Non-fatal - newCommitCount stays 0, extra empty commit will be skipped
+            core.info("Could not count new commits - extra empty commit will be skipped");
+          }
         } catch (pushError) {
           const error = `Failed to push empty branch: ${pushError instanceof Error ? pushError.message : String(pushError)}`;
           core.error(error);
@@ -840,12 +865,15 @@ ${patchPreview}`;
         )
         .write();
 
-      // Push an extra empty commit if a token is configured.
+      // Push an extra empty commit if a token is configured and exactly 1 new commit was pushed.
       // This works around the GITHUB_TOKEN limitation where pushes don't trigger CI events.
+      // Restricting to exactly 1 new commit prevents the CI trigger token being used on
+      // multi-commit branches where workflow files may have been iteratively modified.
       const ciTriggerResult = await pushExtraEmptyCommit({
         branchName,
         repoOwner: repoParts.owner,
         repoName: repoParts.repo,
+        newCommitCount,
       });
       if (ciTriggerResult.success && !ciTriggerResult.skipped) {
         core.info("Extra empty commit pushed - CI checks should start shortly");

--- a/actions/setup/js/extra_empty_commit.cjs
+++ b/actions/setup/js/extra_empty_commit.cjs
@@ -27,13 +27,21 @@
  * @param {string} options.repoOwner - Repository owner
  * @param {string} options.repoName - Repository name
  * @param {string} [options.commitMessage] - Custom commit message (default: "ci: trigger CI checks")
+ * @param {number} [options.newCommitCount] - Number of new commits being pushed. Only pushes the
+ *   empty commit when exactly 1 new commit was pushed, preventing accidental workflow-file
+ *   modifications on multi-commit branches and reducing loop risk.
  * @returns {Promise<{success: boolean, skipped?: boolean, error?: string}>}
  */
-async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMessage }) {
+async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMessage, newCommitCount }) {
   const token = process.env.GH_AW_CI_TRIGGER_TOKEN;
 
   if (!token || !token.trim()) {
     core.info("No extra empty commit token configured - skipping");
+    return { success: true, skipped: true };
+  }
+
+  if (newCommitCount !== undefined && newCommitCount !== 1) {
+    core.info(`Skipping extra empty commit: ${newCommitCount} new commit(s) pushed (only triggers for exactly 1 commit)`);
     return { success: true, skipped: true };
   }
 

--- a/actions/setup/js/generate_git_patch.cjs
+++ b/actions/setup/js/generate_git_patch.cjs
@@ -36,9 +36,15 @@ function getPatchPath(branchName) {
 /**
  * Generates a git patch file for the current changes
  * @param {string} branchName - The branch name to generate patch for
+ * @param {Object} [options] - Optional parameters
+ * @param {string} [options.mode="full"] - Patch generation mode:
+ *   - "full": Include all commits since merge-base with default branch (for create_pull_request)
+ *   - "incremental": Only include commits since origin/branchName (for push_to_pull_request_branch)
+ *     In incremental mode, origin/branchName is fetched explicitly and merge-base fallback is disabled.
  * @returns {Object} Object with patch info or error
  */
-function generateGitPatch(branchName) {
+function generateGitPatch(branchName, options = {}) {
+  const mode = options.mode || "full";
   const patchPath = getPatchPath(branchName);
   const cwd = process.env.GITHUB_WORKSPACE || process.cwd();
   const defaultBranch = process.env.DEFAULT_BRANCH || getBaseBranch();
@@ -62,14 +68,41 @@ function generateGitPatch(branchName) {
 
         // Determine base ref for patch generation
         let baseRef;
-        try {
-          // Check if origin/branchName exists
-          execGitSync(["show-ref", "--verify", "--quiet", `refs/remotes/origin/${branchName}`], { cwd });
-          baseRef = `origin/${branchName}`;
-        } catch {
-          // Use merge-base with default branch
-          execGitSync(["fetch", "origin", defaultBranch], { cwd });
-          baseRef = execGitSync(["merge-base", `origin/${defaultBranch}`, branchName], { cwd }).trim();
+
+        if (mode === "incremental") {
+          // INCREMENTAL MODE (for push_to_pull_request_branch):
+          // Only include commits that are new since origin/branchName.
+          // This prevents including commits that already exist on the PR branch.
+          // We must explicitly fetch origin/branchName and fail if it doesn't exist.
+
+          try {
+            // Explicitly fetch origin/branchName to ensure we have the latest
+            execGitSync(["fetch", "origin", `${branchName}:refs/remotes/origin/${branchName}`], { cwd });
+            baseRef = `origin/${branchName}`;
+          } catch (fetchError) {
+            // In incremental mode, we MUST have origin/branchName - no fallback
+            errorMessage = `Cannot generate incremental patch: failed to fetch origin/${branchName}. ` + `This typically happens when the remote branch doesn't exist yet or was force-pushed. ` + `Error: ${getErrorMessage(fetchError)}`;
+            // Don't try other strategies in incremental mode
+            return {
+              success: false,
+              error: errorMessage,
+              patchPath: patchPath,
+            };
+          }
+        } else {
+          // FULL MODE (for create_pull_request):
+          // Include all commits since merge-base with default branch.
+          // This is appropriate for creating new PRs where we want all changes.
+
+          try {
+            // Check if origin/branchName exists
+            execGitSync(["show-ref", "--verify", "--quiet", `refs/remotes/origin/${branchName}`], { cwd });
+            baseRef = `origin/${branchName}`;
+          } catch {
+            // Use merge-base with default branch as fallback
+            execGitSync(["fetch", "origin", defaultBranch], { cwd });
+            baseRef = execGitSync(["merge-base", `origin/${defaultBranch}`, branchName], { cwd }).trim();
+          }
         }
 
         // Count commits to be included
@@ -83,9 +116,25 @@ function generateGitPatch(branchName) {
             fs.writeFileSync(patchPath, patchContent, "utf8");
             patchGenerated = true;
           }
+        } else if (mode === "incremental") {
+          // In incremental mode, zero commits means nothing new to push
+          return {
+            success: false,
+            error: "No new commits to push - your changes may already be on the remote branch",
+            patchPath: patchPath,
+            patchSize: 0,
+            patchLines: 0,
+          };
         }
       } catch (branchError) {
         // Branch does not exist locally
+        if (mode === "incremental") {
+          return {
+            success: false,
+            error: `Branch ${branchName} does not exist locally. Cannot generate incremental patch.`,
+            patchPath: patchPath,
+          };
+        }
       }
     }
 

--- a/actions/setup/js/generate_git_patch.cjs
+++ b/actions/setup/js/generate_git_patch.cjs
@@ -77,7 +77,8 @@ function generateGitPatch(branchName, options = {}) {
 
           try {
             // Explicitly fetch origin/branchName to ensure we have the latest
-            execGitSync(["fetch", "origin", `${branchName}:refs/remotes/origin/${branchName}`], { cwd });
+            // Use "--" to prevent branch names starting with "-" from being interpreted as options
+            execGitSync(["fetch", "origin", "--", `${branchName}:refs/remotes/origin/${branchName}`], { cwd });
             baseRef = `origin/${branchName}`;
           } catch (fetchError) {
             // In incremental mode, we MUST have origin/branchName - no fallback
@@ -100,8 +101,9 @@ function generateGitPatch(branchName, options = {}) {
             baseRef = `origin/${branchName}`;
           } catch {
             // Use merge-base with default branch as fallback
-            execGitSync(["fetch", "origin", defaultBranch], { cwd });
-            baseRef = execGitSync(["merge-base", `origin/${defaultBranch}`, branchName], { cwd }).trim();
+            // Use "--" to prevent branch names starting with "-" from being interpreted as options
+            execGitSync(["fetch", "origin", "--", defaultBranch], { cwd });
+            baseRef = execGitSync(["merge-base", "--", `origin/${defaultBranch}`, branchName], { cwd }).trim();
           }
         }
 

--- a/actions/setup/js/generate_git_patch.cjs
+++ b/actions/setup/js/generate_git_patch.cjs
@@ -100,10 +100,31 @@ function generateGitPatch(branchName, options = {}) {
             execGitSync(["show-ref", "--verify", "--quiet", `refs/remotes/origin/${branchName}`], { cwd });
             baseRef = `origin/${branchName}`;
           } catch {
-            // Use merge-base with default branch as fallback
-            // Use "--" to prevent branch names starting with "-" from being interpreted as options
-            execGitSync(["fetch", "origin", "--", defaultBranch], { cwd });
-            baseRef = execGitSync(["merge-base", "--", `origin/${defaultBranch}`, branchName], { cwd }).trim();
+            // origin/branchName doesn't exist - use merge-base with default branch
+            // First check if origin/<defaultBranch> already exists locally (e.g., from checkout with fetch-depth: 0)
+            // This is important for cross-repo checkouts where persist-credentials: false prevents fetching
+            let hasLocalDefaultBranch = false;
+            try {
+              execGitSync(["show-ref", "--verify", "--quiet", `refs/remotes/origin/${defaultBranch}`], { cwd });
+              hasLocalDefaultBranch = true;
+            } catch {
+              // origin/<defaultBranch> doesn't exist locally, try to fetch it
+              try {
+                // Use "--" to prevent branch names starting with "-" from being interpreted as options
+                execGitSync(["fetch", "origin", "--", defaultBranch], { cwd });
+                hasLocalDefaultBranch = true;
+              } catch {
+                // Fetch failed (likely due to persist-credentials: false in cross-repo checkout)
+                // We'll try other strategies below
+              }
+            }
+
+            if (hasLocalDefaultBranch) {
+              baseRef = execGitSync(["merge-base", "--", `origin/${defaultBranch}`, branchName], { cwd }).trim();
+            } else {
+              // No remote refs available - fall through to Strategy 2
+              throw new Error("No remote refs available for merge-base calculation");
+            }
           }
         }
 
@@ -149,25 +170,90 @@ function generateGitPatch(branchName, options = {}) {
       } else if (currentHead === githubSha) {
         // No commits have been made since checkout
       } else {
-        // Check if GITHUB_SHA is an ancestor of current HEAD
+        // First verify GITHUB_SHA exists in this repo's git history
+        // In cross-repo checkout scenarios, GITHUB_SHA is from the workflow repo,
+        // not the target repo that's currently checked out
+        let shaExistsInRepo = false;
         try {
-          execGitSync(["merge-base", "--is-ancestor", githubSha, "HEAD"], { cwd });
+          execGitSync(["cat-file", "-e", githubSha], { cwd });
+          shaExistsInRepo = true;
+        } catch {
+          // GITHUB_SHA doesn't exist in this repo - likely a cross-repo checkout
+          // This is expected when workflow repo != checked out repo
+        }
 
-          // Count commits between GITHUB_SHA and HEAD
-          const commitCount = parseInt(execGitSync(["rev-list", "--count", `${githubSha}..HEAD`], { cwd }).trim(), 10);
+        if (shaExistsInRepo) {
+          // Check if GITHUB_SHA is an ancestor of current HEAD
+          try {
+            execGitSync(["merge-base", "--is-ancestor", githubSha, "HEAD"], { cwd });
 
-          if (commitCount > 0) {
-            // Generate patch from GITHUB_SHA to HEAD
-            const patchContent = execGitSync(["format-patch", `${githubSha}..HEAD`, "--stdout"], { cwd });
+            // Count commits between GITHUB_SHA and HEAD
+            const commitCount = parseInt(execGitSync(["rev-list", "--count", `${githubSha}..HEAD`], { cwd }).trim(), 10);
 
-            if (patchContent && patchContent.trim()) {
-              fs.writeFileSync(patchPath, patchContent, "utf8");
-              patchGenerated = true;
+            if (commitCount > 0) {
+              // Generate patch from GITHUB_SHA to HEAD
+              const patchContent = execGitSync(["format-patch", `${githubSha}..HEAD`, "--stdout"], { cwd });
+
+              if (patchContent && patchContent.trim()) {
+                fs.writeFileSync(patchPath, patchContent, "utf8");
+                patchGenerated = true;
+              }
+            }
+          } catch {
+            // GITHUB_SHA is not an ancestor of HEAD - repository state has diverged
+          }
+        }
+      }
+    }
+
+    // Strategy 3: Cross-repo fallback - find commits not reachable from any remote ref
+    // This handles cases where:
+    // - Cross-repo checkout with persist-credentials: false (can't fetch)
+    // - GITHUB_SHA is from a different repo
+    // - No origin/<defaultBranch> available locally
+    if (!patchGenerated && branchName) {
+      try {
+        // Get all remote refs
+        const remoteRefsOutput = execGitSync(["for-each-ref", "--format=%(refname)", "refs/remotes/"], { cwd }).trim();
+
+        if (remoteRefsOutput) {
+          // Build exclusion list from all remote refs
+          const remoteRefs = remoteRefsOutput.split("\n").filter(r => r);
+
+          if (remoteRefs.length > 0) {
+            // Find commits on current branch not reachable from any remote ref
+            // This gets commits the agent added that haven't been pushed anywhere
+            const excludeArgs = remoteRefs.flatMap(ref => ["--not", ref]);
+            const revListArgs = ["rev-list", "--count", branchName, ...excludeArgs];
+
+            const commitCount = parseInt(execGitSync(revListArgs, { cwd }).trim(), 10);
+
+            if (commitCount > 0) {
+              // Get the merge-base with the first remote ref (typically origin/HEAD or origin/main)
+              // to determine the starting point for the patch
+              let baseCommit;
+              for (const ref of remoteRefs) {
+                try {
+                  baseCommit = execGitSync(["merge-base", ref, branchName], { cwd }).trim();
+                  if (baseCommit) break;
+                } catch {
+                  // Try next ref
+                }
+              }
+
+              if (baseCommit) {
+                const patchContent = execGitSync(["format-patch", `${baseCommit}..${branchName}`, "--stdout"], { cwd });
+
+                if (patchContent && patchContent.trim()) {
+                  fs.writeFileSync(patchPath, patchContent, "utf8");
+                  patchGenerated = true;
+                }
+              }
             }
           }
-        } catch {
-          // GITHUB_SHA is not an ancestor of HEAD - repository state has diverged
         }
+      } catch {
+        // Strategy 3 failed - no remote refs available at all
       }
     }
   } catch (error) {

--- a/actions/setup/js/git_patch_integration.test.cjs
+++ b/actions/setup/js/git_patch_integration.test.cjs
@@ -12,10 +12,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-const fs = require("fs");
-const path = require("path");
-const { spawnSync } = require("child_process");
-const os = require("os");
+import fs from "fs";
+import path from "path";
+import { spawnSync } from "child_process";
+import os from "os";
+import { generateGitPatch } from "./generate_git_patch.cjs";
 
 /**
  * Execute git command safely with args array
@@ -546,8 +547,6 @@ describe("git patch integration tests", () => {
       execGit(["update-ref", "-d", "refs/remotes/origin/feature-branch"], { cwd: workingRepo });
 
       // Generate patch in incremental mode
-      const { generateGitPatch } = require("./generate_git_patch.cjs");
-
       // Set environment
       const origWorkspace = process.env.GITHUB_WORKSPACE;
       const origDefaultBranch = process.env.DEFAULT_BRANCH;
@@ -593,8 +592,6 @@ describe("git patch integration tests", () => {
 
       // Don't push - origin/local-only-branch doesn't exist
 
-      const { generateGitPatch } = require("./generate_git_patch.cjs");
-
       const origWorkspace = process.env.GITHUB_WORKSPACE;
       const origDefaultBranch = process.env.DEFAULT_BRANCH;
       process.env.GITHUB_WORKSPACE = workingRepo;
@@ -633,8 +630,6 @@ describe("git patch integration tests", () => {
 
       // Fetch origin/main so merge-base can work
       execGit(["fetch", "origin", "main"], { cwd: workingRepo });
-
-      const { generateGitPatch } = require("./generate_git_patch.cjs");
 
       const origWorkspace = process.env.GITHUB_WORKSPACE;
       const origDefaultBranch = process.env.DEFAULT_BRANCH;

--- a/actions/setup/js/git_patch_integration.test.cjs
+++ b/actions/setup/js/git_patch_integration.test.cjs
@@ -486,4 +486,181 @@ describe("git patch integration tests", () => {
       expect(logResult.stdout).toContain("Launch feature");
     });
   });
+
+  // ──────────────────────────────────────────────────────
+  // Incremental Mode Tests
+  // ──────────────────────────────────────────────────────
+
+  describe("incremental mode", () => {
+    let bareRepoDir;
+    let workingRepo;
+
+    beforeEach(() => {
+      // Create a bare repo to simulate remote
+      bareRepoDir = fs.mkdtempSync(path.join(os.tmpdir(), "bare-incremental-"));
+      execGit(["init", "--bare", "--initial-branch=main"], { cwd: bareRepoDir });
+
+      // Clone the bare repo
+      workingRepo = fs.mkdtempSync(path.join(os.tmpdir(), "working-incremental-"));
+      execGit(["clone", bareRepoDir, "."], { cwd: workingRepo });
+
+      // Set up git config (after clone, we have a proper repo)
+      execGit(["config", "user.email", "test@test.com"], { cwd: workingRepo });
+      execGit(["config", "user.name", "Test User"], { cwd: workingRepo });
+
+      // Checkout main (might be master on some systems)
+      execGit(["checkout", "-b", "main"], { cwd: workingRepo, allowFailure: true });
+
+      // Create initial commit on main
+      fs.writeFileSync(path.join(workingRepo, "README.md"), "# Initial\n");
+      execGit(["add", "README.md"], { cwd: workingRepo });
+      execGit(["commit", "-m", "Initial commit"], { cwd: workingRepo });
+
+      // Push main to origin (this MUST succeed for full mode tests)
+      execGit(["push", "-u", "origin", "main"], { cwd: workingRepo });
+    });
+
+    afterEach(() => {
+      // Clean up
+      cleanupTestRepo(bareRepoDir);
+      cleanupTestRepo(workingRepo);
+    });
+
+    it("should only include new commits after origin/branch in incremental mode", () => {
+      // Create a feature branch with first commit
+      execGit(["checkout", "-b", "feature-branch"], { cwd: workingRepo });
+      fs.writeFileSync(path.join(workingRepo, "feature.txt"), "First commit content\n");
+      execGit(["add", "feature.txt"], { cwd: workingRepo });
+      execGit(["commit", "-m", "First commit on feature branch"], { cwd: workingRepo });
+
+      // Push to origin
+      execGit(["push", "-u", "origin", "feature-branch"], { cwd: workingRepo });
+
+      // Add a second commit (the "new" commit)
+      fs.writeFileSync(path.join(workingRepo, "feature2.txt"), "Second commit content\n");
+      execGit(["add", "feature2.txt"], { cwd: workingRepo });
+      execGit(["commit", "-m", "Second commit - the new one"], { cwd: workingRepo });
+
+      // Delete the origin/feature-branch tracking ref to simulate a fresh checkout
+      // that hasn't fetched the remote branch yet
+      execGit(["update-ref", "-d", "refs/remotes/origin/feature-branch"], { cwd: workingRepo });
+
+      // Generate patch in incremental mode
+      const { generateGitPatch } = require("./generate_git_patch.cjs");
+
+      // Set environment
+      const origWorkspace = process.env.GITHUB_WORKSPACE;
+      const origDefaultBranch = process.env.DEFAULT_BRANCH;
+      process.env.GITHUB_WORKSPACE = workingRepo;
+      process.env.DEFAULT_BRANCH = "main";
+
+      try {
+        const result = generateGitPatch("feature-branch", { mode: "incremental" });
+
+        expect(result.success).toBe(true);
+        expect(result.patchPath).toBeDefined();
+
+        // Read the patch content
+        const patchContent = fs.readFileSync(result.patchPath, "utf8");
+
+        // Should only have ONE patch [PATCH 1/1], not [PATCH 1/2], [PATCH 2/2]
+        expect(patchContent).toContain("Subject:");
+
+        // Should contain the second commit
+        expect(patchContent).toContain("Second commit - the new one");
+
+        // Should NOT contain the first commit (it's already on origin/feature-branch)
+        expect(patchContent).not.toContain("First commit on feature branch");
+
+        // Verify it's [PATCH 1/1] or just [PATCH], not [PATCH 1/2]
+        const patchHeaders = patchContent.match(/\[PATCH[^\]]*\]/g);
+        // If there are numbered patches, should be just 1
+        if (patchHeaders) {
+          expect(patchHeaders.length).toBe(1);
+        }
+      } finally {
+        process.env.GITHUB_WORKSPACE = origWorkspace;
+        process.env.DEFAULT_BRANCH = origDefaultBranch;
+      }
+    });
+
+    it("should fail clearly when origin/branch doesnt exist in incremental mode", () => {
+      // Create a local branch without pushing
+      execGit(["checkout", "-b", "local-only-branch"], { cwd: workingRepo });
+      fs.writeFileSync(path.join(workingRepo, "local.txt"), "Local content\n");
+      execGit(["add", "local.txt"], { cwd: workingRepo });
+      execGit(["commit", "-m", "Local commit"], { cwd: workingRepo });
+
+      // Don't push - origin/local-only-branch doesn't exist
+
+      const { generateGitPatch } = require("./generate_git_patch.cjs");
+
+      const origWorkspace = process.env.GITHUB_WORKSPACE;
+      const origDefaultBranch = process.env.DEFAULT_BRANCH;
+      process.env.GITHUB_WORKSPACE = workingRepo;
+      process.env.DEFAULT_BRANCH = "main";
+
+      try {
+        const result = generateGitPatch("local-only-branch", { mode: "incremental" });
+
+        // Should fail with a clear error message
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Cannot generate incremental patch");
+        expect(result.error).toContain("origin/local-only-branch");
+      } finally {
+        process.env.GITHUB_WORKSPACE = origWorkspace;
+        process.env.DEFAULT_BRANCH = origDefaultBranch;
+      }
+    });
+
+    it("should include all commits in full mode even when origin/branch exists", () => {
+      // Create a feature branch with first commit
+      execGit(["checkout", "-b", "full-mode-branch"], { cwd: workingRepo });
+      fs.writeFileSync(path.join(workingRepo, "full1.txt"), "First commit\n");
+      execGit(["add", "full1.txt"], { cwd: workingRepo });
+      execGit(["commit", "-m", "First commit in full mode test"], { cwd: workingRepo });
+
+      // Push to origin
+      execGit(["push", "-u", "origin", "full-mode-branch"], { cwd: workingRepo });
+
+      // Add second commit
+      fs.writeFileSync(path.join(workingRepo, "full2.txt"), "Second commit\n");
+      execGit(["add", "full2.txt"], { cwd: workingRepo });
+      execGit(["commit", "-m", "Second commit in full mode test"], { cwd: workingRepo });
+
+      // Delete origin ref to force merge-base fallback
+      execGit(["update-ref", "-d", "refs/remotes/origin/full-mode-branch"], { cwd: workingRepo });
+
+      // Fetch origin/main so merge-base can work
+      execGit(["fetch", "origin", "main"], { cwd: workingRepo });
+
+      const { generateGitPatch } = require("./generate_git_patch.cjs");
+
+      const origWorkspace = process.env.GITHUB_WORKSPACE;
+      const origDefaultBranch = process.env.DEFAULT_BRANCH;
+      process.env.GITHUB_WORKSPACE = workingRepo;
+      process.env.DEFAULT_BRANCH = "main";
+
+      try {
+        // Full mode (default) - should fall back to merge-base and include all commits
+        const result = generateGitPatch("full-mode-branch", { mode: "full" });
+
+        // Debug output if test fails
+        if (!result.success) {
+          console.log("Full mode test failed with error:", result.error);
+        }
+
+        expect(result.success).toBe(true);
+
+        const patchContent = fs.readFileSync(result.patchPath, "utf8");
+
+        // Should contain BOTH commits (using merge-base with main)
+        expect(patchContent).toContain("First commit in full mode test");
+        expect(patchContent).toContain("Second commit in full mode test");
+      } finally {
+        process.env.GITHUB_WORKSPACE = origWorkspace;
+        process.env.DEFAULT_BRANCH = origDefaultBranch;
+      }
+    });
+  });
 });

--- a/actions/setup/js/git_patch_integration.test.cjs
+++ b/actions/setup/js/git_patch_integration.test.cjs
@@ -380,7 +380,7 @@ describe("git patch integration tests", () => {
 
       // Fetch in working repo 2 and make changes
       execGit(["fetch", "origin"], { cwd: workingRepo2 });
-      execGit(["checkout", "pr-branch"], { cwd: workingRepo2 });
+      execGit(["checkout", "-b", "pr-branch", "--track", "origin/pr-branch"], { cwd: workingRepo2 });
 
       fs.writeFileSync(path.join(workingRepo2, "file2.txt"), "User 2 content\n");
       execGit(["add", "file2.txt"], { cwd: workingRepo2 });

--- a/actions/setup/js/git_patch_integration.test.cjs
+++ b/actions/setup/js/git_patch_integration.test.cjs
@@ -1,0 +1,489 @@
+/**
+ * Integration tests for git patch generation and application
+ *
+ * These tests run REAL git commands to verify:
+ * 1. git format-patch generates valid patches
+ * 2. git am can apply patches correctly
+ * 3. Emoji and unicode in commit messages work
+ * 4. Merge conflict detection works
+ * 5. Concurrent push scenarios are handled
+ *
+ * These tests require git to be installed and create temporary git repos.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const os = require("os");
+
+/**
+ * Execute git command safely with args array
+ */
+function execGit(args, options = {}) {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    ...options,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+  return result;
+}
+
+/**
+ * Create a temporary git repository for testing
+ */
+function createTestRepo() {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-patch-test-"));
+
+  execGit(["init"], { cwd: repoDir });
+  execGit(["config", "user.name", "Test User"], { cwd: repoDir });
+  execGit(["config", "user.email", "test@example.com"], { cwd: repoDir });
+
+  // Create initial commit on main branch
+  fs.writeFileSync(path.join(repoDir, "README.md"), "# Test Repo\n");
+  execGit(["add", "."], { cwd: repoDir });
+  execGit(["commit", "-m", "Initial commit"], { cwd: repoDir });
+
+  // Create main as the default branch
+  execGit(["branch", "-M", "main"], { cwd: repoDir });
+
+  return repoDir;
+}
+
+/**
+ * Clean up test repository
+ */
+function cleanupTestRepo(repoDir) {
+  if (repoDir && fs.existsSync(repoDir)) {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+}
+
+describe("git patch integration tests", () => {
+  let repoDir;
+  let patchDir;
+
+  beforeEach(() => {
+    repoDir = createTestRepo();
+    patchDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-patch-output-"));
+  });
+
+  afterEach(() => {
+    cleanupTestRepo(repoDir);
+    cleanupTestRepo(patchDir);
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Basic Patch Generation and Application
+  // ──────────────────────────────────────────────────────
+
+  describe("basic patch generation and application", () => {
+    it("should generate and apply a simple patch", () => {
+      // Create feature branch with changes
+      execGit(["checkout", "-b", "feature-branch"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "test.txt"), "Hello World\n");
+      execGit(["add", "test.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Add test file"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "test.patch");
+      const patchResult = execGit(["format-patch", "main..feature-branch", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Verify patch has content
+      const patchContent = fs.readFileSync(patchPath, "utf8");
+      expect(patchContent).toContain("Subject:");
+      expect(patchContent).toContain("Add test file");
+      expect(patchContent).toContain("Hello World");
+
+      // Create a clean branch to test apply
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-test"], { cwd: repoDir });
+
+      // Apply patch
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+
+      // Verify file was created
+      const fileContent = fs.readFileSync(path.join(repoDir, "test.txt"), "utf8");
+      expect(fileContent).toBe("Hello World\n");
+    });
+
+    it("should handle multi-commit patches", () => {
+      execGit(["checkout", "-b", "multi-commit"], { cwd: repoDir });
+
+      // First commit
+      fs.writeFileSync(path.join(repoDir, "file1.txt"), "File 1\n");
+      execGit(["add", "file1.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Add file 1"], { cwd: repoDir });
+
+      // Second commit
+      fs.writeFileSync(path.join(repoDir, "file2.txt"), "File 2\n");
+      execGit(["add", "file2.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Add file 2"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "multi.patch");
+      const patchResult = execGit(["format-patch", "main..multi-commit", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Apply to clean branch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-multi"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+
+      // Verify both files exist
+      expect(fs.existsSync(path.join(repoDir, "file1.txt"))).toBe(true);
+      expect(fs.existsSync(path.join(repoDir, "file2.txt"))).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Emoji and Unicode in Commit Messages
+  // ──────────────────────────────────────────────────────
+
+  describe("emoji and unicode handling", () => {
+    it("should handle emoji in commit message", () => {
+      execGit(["checkout", "-b", "emoji-branch"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "emoji.txt"), "Bug fixed!\n");
+      execGit(["add", "emoji.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "🐛 Fix bug with login"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "emoji.patch");
+      const patchResult = execGit(["format-patch", "main..emoji-branch", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Check patch content - git may RFC2047 encode or keep UTF-8
+      const patchContent = fs.readFileSync(patchPath, "utf8");
+      // Either raw emoji or RFC2047 encoded is acceptable
+      const hasEmoji = patchContent.includes("🐛") || patchContent.includes("=?UTF-8?");
+      expect(hasEmoji).toBe(true);
+
+      // Apply to clean branch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-emoji"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+
+      // Verify commit message was preserved
+      const logResult = execGit(["log", "-1", "--format=%s"], { cwd: repoDir });
+      expect(logResult.stdout.trim()).toContain("Fix bug");
+    });
+
+    it("should handle unicode characters in commit message", () => {
+      execGit(["checkout", "-b", "unicode-branch"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "unicode.txt"), "International text\n");
+      execGit(["add", "unicode.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "日本語のコミットメッセージ"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "unicode.patch");
+      const patchResult = execGit(["format-patch", "main..unicode-branch", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Apply to clean branch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-unicode"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+    });
+
+    it("should handle multi-line commit messages", () => {
+      execGit(["checkout", "-b", "multiline-branch"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "multiline.txt"), "Content\n");
+      execGit(["add", "multiline.txt"], { cwd: repoDir });
+
+      // Commit with multi-line message
+      const commitMsg = "Short title\n\nThis is the body of the commit.\nIt has multiple lines.\n\n- Item 1\n- Item 2";
+      execGit(["commit", "-m", commitMsg], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "multiline.patch");
+      const patchResult = execGit(["format-patch", "main..multiline-branch", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Verify patch structure
+      const patchContent = fs.readFileSync(patchPath, "utf8");
+      expect(patchContent).toContain("Subject:");
+      expect(patchContent).toContain("Short title");
+
+      // Apply to clean branch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-multiline"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+
+      // Verify body was preserved
+      const logResult = execGit(["log", "-1", "--format=%B"], { cwd: repoDir });
+      expect(logResult.stdout).toContain("body of the commit");
+    });
+
+    it("should handle special characters in commit message", () => {
+      execGit(["checkout", "-b", "special-chars"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "special.txt"), "Content\n");
+      execGit(["add", "special.txt"], { cwd: repoDir });
+
+      // Commit with special characters that might cause issues
+      const commitMsg = "Fix: Handle \"quotes\" and 'apostrophes' and $variables and `backticks`";
+      execGit(["commit", "-m", commitMsg], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "special.patch");
+      const patchResult = execGit(["format-patch", "main..special-chars", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Apply to clean branch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-special"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Merge Conflict Scenarios
+  // ──────────────────────────────────────────────────────
+
+  describe("merge conflict scenarios", () => {
+    it("should detect and report patch application failure due to conflict", () => {
+      // Create conflicting changes
+      fs.writeFileSync(path.join(repoDir, "conflict.txt"), "Original content\n");
+      execGit(["add", "conflict.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Add conflict file"], { cwd: repoDir });
+
+      // Create feature branch with one change
+      execGit(["checkout", "-b", "feature-conflict"], { cwd: repoDir });
+      fs.writeFileSync(path.join(repoDir, "conflict.txt"), "Feature branch content\n");
+      execGit(["add", "conflict.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Feature change"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "conflict.patch");
+      const patchResult = execGit(["format-patch", "main~1..feature-conflict", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Go back to main and make a different change
+      execGit(["checkout", "main"], { cwd: repoDir });
+      fs.writeFileSync(path.join(repoDir, "conflict.txt"), "Main branch different content\n");
+      execGit(["add", "conflict.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Main change"], { cwd: repoDir });
+
+      // Try to apply patch - should fail
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir, allowFailure: true });
+      expect(applyResult.status).not.toBe(0);
+      // Error message varies - could be "patch does not apply" or "already exists in index"
+      const errorOutput = applyResult.stderr.toLowerCase();
+      expect(errorOutput.includes("patch does not apply") || errorOutput.includes("already exists") || errorOutput.includes("conflict")).toBe(true);
+
+      // Abort the failed am
+      execGit(["am", "--abort"], { cwd: repoDir, allowFailure: true });
+    });
+
+    it("should handle patch based on old commit that no longer exists in history", () => {
+      // This simulates force-push scenario where base commit was rewritten
+      execGit(["checkout", "-b", "force-push-branch"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "force.txt"), "Content\n");
+      execGit(["add", "force.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Initial force change"], { cwd: repoDir });
+
+      // Get the commit SHA
+      const shaResult = execGit(["rev-parse", "HEAD"], { cwd: repoDir });
+      const originalSha = shaResult.stdout.trim();
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "force.patch");
+      const patchResult = execGit(["format-patch", "main..force-push-branch", "--stdout"], { cwd: repoDir });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Simulate force-push by amending the commit
+      fs.writeFileSync(path.join(repoDir, "force.txt"), "Different content\n");
+      execGit(["add", "force.txt"], { cwd: repoDir });
+      execGit(["commit", "--amend", "-m", "Amended force change"], { cwd: repoDir });
+
+      // The original SHA should no longer match HEAD
+      const newShaResult = execGit(["rev-parse", "HEAD"], { cwd: repoDir });
+      expect(newShaResult.stdout.trim()).not.toBe(originalSha);
+
+      // The patch should still be applicable to main (it's based on main)
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-force"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Concurrent Push Scenarios
+  // ──────────────────────────────────────────────────────
+
+  describe("concurrent push scenarios", () => {
+    let bareRepoDir;
+    let workingRepo1;
+    let workingRepo2;
+
+    beforeEach(() => {
+      // Create a bare repository to simulate remote
+      bareRepoDir = fs.mkdtempSync(path.join(os.tmpdir(), "bare-repo-"));
+      execGit(["init", "--bare"], { cwd: bareRepoDir });
+
+      // Clone it twice to simulate two workers
+      workingRepo1 = fs.mkdtempSync(path.join(os.tmpdir(), "working1-"));
+      execGit(["clone", bareRepoDir, "."], { cwd: workingRepo1 });
+      execGit(["config", "user.name", "User 1"], { cwd: workingRepo1 });
+      execGit(["config", "user.email", "user1@example.com"], { cwd: workingRepo1 });
+
+      // Make initial commit
+      fs.writeFileSync(path.join(workingRepo1, "README.md"), "# Repo\n");
+      execGit(["add", "."], { cwd: workingRepo1 });
+      execGit(["commit", "-m", "Initial"], { cwd: workingRepo1 });
+      execGit(["push", "-u", "origin", "main"], { cwd: workingRepo1, allowFailure: true });
+
+      workingRepo2 = fs.mkdtempSync(path.join(os.tmpdir(), "working2-"));
+      execGit(["clone", bareRepoDir, "."], { cwd: workingRepo2 });
+      execGit(["config", "user.name", "User 2"], { cwd: workingRepo2 });
+      execGit(["config", "user.email", "user2@example.com"], { cwd: workingRepo2 });
+    });
+
+    afterEach(() => {
+      cleanupTestRepo(bareRepoDir);
+      cleanupTestRepo(workingRepo1);
+      cleanupTestRepo(workingRepo2);
+    });
+
+    it("should fail when branch was updated after patch was generated", () => {
+      // Create PR branch in working repo 1
+      execGit(["checkout", "-b", "pr-branch"], { cwd: workingRepo1 });
+      fs.writeFileSync(path.join(workingRepo1, "file1.txt"), "User 1 content\n");
+      execGit(["add", "file1.txt"], { cwd: workingRepo1 });
+      execGit(["commit", "-m", "User 1 commit"], { cwd: workingRepo1 });
+      execGit(["push", "-u", "origin", "pr-branch"], { cwd: workingRepo1 });
+
+      // Fetch in working repo 2 and make changes
+      execGit(["fetch", "origin"], { cwd: workingRepo2 });
+      execGit(["checkout", "pr-branch"], { cwd: workingRepo2 });
+
+      fs.writeFileSync(path.join(workingRepo2, "file2.txt"), "User 2 content\n");
+      execGit(["add", "file2.txt"], { cwd: workingRepo2 });
+      execGit(["commit", "-m", "User 2 commit"], { cwd: workingRepo2 });
+
+      // Generate patch in repo 2 (before pushing)
+      const patchPath = path.join(patchDir, "concurrent.patch");
+      const patchResult = execGit(["format-patch", "origin/pr-branch..pr-branch", "--stdout"], { cwd: workingRepo2 });
+      fs.writeFileSync(patchPath, patchResult.stdout);
+
+      // Simulate concurrent push - User 1 pushes first
+      fs.writeFileSync(path.join(workingRepo1, "file3.txt"), "Another User 1 commit\n");
+      execGit(["add", "file3.txt"], { cwd: workingRepo1 });
+      execGit(["commit", "-m", "Concurrent commit from User 1"], { cwd: workingRepo1 });
+      execGit(["push", "origin", "pr-branch"], { cwd: workingRepo1 });
+
+      // Now User 2 tries to push (without fetching) - should fail with non-fast-forward
+      const pushResult = execGit(["push", "origin", "pr-branch"], { cwd: workingRepo2, allowFailure: true });
+      expect(pushResult.status).not.toBe(0);
+      // Error message varies by git version but contains rejection info
+      const errorOutput = pushResult.stderr.toLowerCase();
+      expect(errorOutput.includes("rejected") || errorOutput.includes("failed") || errorOutput.includes("non-fast-forward")).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Commit Title Suffix Modification
+  // ──────────────────────────────────────────────────────
+
+  describe("commit title suffix modification", () => {
+    it("should correctly modify Subject line to add suffix", () => {
+      execGit(["checkout", "-b", "suffix-test"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "suffix.txt"), "Content\n");
+      execGit(["add", "suffix.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "Original title"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "suffix.patch");
+      const patchResult = execGit(["format-patch", "main..suffix-test", "--stdout"], { cwd: repoDir });
+      let patchContent = patchResult.stdout;
+
+      // Simulate the suffix modification logic from push_to_pull_request_branch.cjs
+      const commitTitleSuffix = " [bot]";
+      patchContent = patchContent.replace(/^Subject: (?:\[PATCH\] )?(.*)$/gm, (match, title) => `Subject: [PATCH] ${title}${commitTitleSuffix}`);
+
+      fs.writeFileSync(patchPath, patchContent);
+
+      // Verify the modification
+      const modifiedPatch = fs.readFileSync(patchPath, "utf8");
+      expect(modifiedPatch).toContain("Subject: [PATCH] Original title [bot]");
+
+      // Apply the modified patch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-suffix"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+
+      // Verify commit message has suffix
+      const logResult = execGit(["log", "-1", "--format=%s"], { cwd: repoDir });
+      expect(logResult.stdout.trim()).toBe("Original title [bot]");
+    });
+
+    it("should handle emoji in commit title with suffix modification", () => {
+      execGit(["checkout", "-b", "emoji-suffix"], { cwd: repoDir });
+
+      fs.writeFileSync(path.join(repoDir, "emoji.txt"), "Content\n");
+      execGit(["add", "emoji.txt"], { cwd: repoDir });
+      execGit(["commit", "-m", "🚀 Launch feature"], { cwd: repoDir });
+
+      // Generate patch
+      const patchPath = path.join(patchDir, "emoji-suffix.patch");
+      const patchResult = execGit(["format-patch", "main..emoji-suffix", "--stdout"], { cwd: repoDir });
+      let patchContent = patchResult.stdout;
+
+      // Check if emoji is RFC2047 encoded
+      const isEncoded = patchContent.includes("=?UTF-8?");
+
+      // Apply suffix modification
+      const commitTitleSuffix = " [bot]";
+
+      if (isEncoded) {
+        // For RFC2047 encoded subjects, we need different handling
+        // This test documents the current limitation
+        console.log("Note: Emoji commit titles are RFC2047 encoded - suffix cannot be applied with simple regex");
+        // The regex won't match encoded subjects properly
+      } else {
+        // If not encoded, apply the suffix
+        patchContent = patchContent.replace(/^Subject: (?:\[PATCH\] )?(.*)$/gm, (match, title) => `Subject: [PATCH] ${title}${commitTitleSuffix}`);
+      }
+
+      fs.writeFileSync(patchPath, patchContent);
+
+      // Apply the patch
+      execGit(["checkout", "main"], { cwd: repoDir });
+      execGit(["checkout", "-b", "apply-emoji-suffix"], { cwd: repoDir });
+
+      const applyResult = execGit(["am", patchPath], { cwd: repoDir });
+      expect(applyResult.status).toBe(0);
+
+      // The commit should be applied (suffix may or may not be present depending on encoding)
+      const logResult = execGit(["log", "-1", "--format=%s"], { cwd: repoDir });
+      expect(logResult.stdout).toContain("Launch feature");
+    });
+  });
+});

--- a/actions/setup/js/handle_noop_message.test.cjs
+++ b/actions/setup/js/handle_noop_message.test.cjs
@@ -108,8 +108,13 @@ This issue helps you:
   });
 
   afterEach(() => {
-    // Restore environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
 
     // Restore fs.readFileSync
     if (originalReadFileSync) {

--- a/actions/setup/js/interpolate_prompt.test.cjs
+++ b/actions/setup/js/interpolate_prompt.test.cjs
@@ -112,7 +112,11 @@ describe("interpolate_prompt", () => {
           core.setFailed.mockClear());
       }),
         afterEach(() => {
-          (tmpDir && fs.existsSync(tmpDir) && fs.rmSync(tmpDir, { recursive: !0, force: !0 }), Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv));
+          (tmpDir && fs.existsSync(tmpDir) && fs.rmSync(tmpDir, { recursive: !0, force: !0 }),
+            Object.keys(process.env).forEach(k => {
+              if (!(k in originalEnv)) delete process.env[k];
+            }),
+            Object.assign(process.env, originalEnv));
         }),
         it("should fail when GH_AW_PROMPT is not set", () => {
           delete process.env.GH_AW_PROMPT;

--- a/actions/setup/js/interpolate_prompt.test.cjs
+++ b/actions/setup/js/interpolate_prompt.test.cjs
@@ -112,7 +112,7 @@ describe("interpolate_prompt", () => {
           core.setFailed.mockClear());
       }),
         afterEach(() => {
-          (tmpDir && fs.existsSync(tmpDir) && fs.rmSync(tmpDir, { recursive: !0, force: !0 }), (process.env = originalEnv));
+          (tmpDir && fs.existsSync(tmpDir) && fs.rmSync(tmpDir, { recursive: !0, force: !0 }), Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv));
         }),
         it("should fail when GH_AW_PROMPT is not set", () => {
           delete process.env.GH_AW_PROMPT;

--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -9,6 +9,7 @@ const { getErrorMessage } = require("./error_helpers.cjs");
 const { replaceTemporaryIdReferences } = require("./temporary_id.cjs");
 const { normalizeBranchName } = require("./normalize_branch_name.cjs");
 const { pushExtraEmptyCommit } = require("./extra_empty_commit.cjs");
+const { detectForkPR } = require("./pr_helpers.cjs");
 
 /**
  * @typedef {import('./types/handler-factory').HandlerFactoryFunction} HandlerFactoryFunction
@@ -200,12 +201,14 @@ async function main(config = {}) {
     }
 
     // Fetch the specific PR to get its head branch, title, and labels
+    let pullRequest;
     try {
-      const { data: pullRequest } = await github.rest.pulls.get({
+      const response = await github.rest.pulls.get({
         owner: context.repo.owner,
         repo: context.repo.repo,
         pull_number: pullNumber,
       });
+      pullRequest = response.data;
       branchName = pullRequest.head.ref;
       prTitle = pullRequest.title || "";
       prLabels = pullRequest.labels.map(label => label.name);
@@ -213,6 +216,20 @@ async function main(config = {}) {
       core.info(`Warning: Could not fetch PR ${pullNumber} details: ${getErrorMessage(error)}`);
       return { success: false, error: `Failed to determine branch name for PR ${pullNumber}` };
     }
+
+    // SECURITY: Check if this is a fork PR - we cannot push to fork branches
+    // The workflow token only has access to the base repository, not the fork
+    const { isFork, reason: forkReason } = detectForkPR(pullRequest);
+    if (isFork) {
+      core.error(`Cannot push to fork PR branch: ${forkReason}`);
+      core.error("The workflow token does not have permission to push to fork repositories.");
+      core.error("Fork PRs must be updated by the fork owner or through other mechanisms.");
+      return {
+        success: false,
+        error: `Cannot push to fork PR: ${forkReason}. The workflow token does not have permission to push to fork repositories.`,
+      };
+    }
+    core.info(`Fork PR check: not a fork (${forkReason})`);
 
     // SECURITY: Sanitize branch name to prevent shell injection (CWE-78)
     // Branch names from GitHub API must be normalized before use in git commands
@@ -283,6 +300,10 @@ async function main(config = {}) {
     }
 
     // Apply the patch using git CLI (skip if empty)
+    // Track number of new commits added so we can restrict the extra empty commit
+    // to branches with exactly one new commit (security: prevents use of CI trigger
+    // token on multi-commit branches where workflow files may have been modified).
+    let newCommitCount = 0;
     if (hasChanges) {
       core.info("Applying patch...");
       try {
@@ -310,12 +331,33 @@ async function main(config = {}) {
         }
 
         // Apply patch
+        // Capture HEAD before applying patch to compute new-commit count later
+        let remoteHeadBeforePatch = "";
+        try {
+          const { stdout } = await exec.getExecOutput("git", ["rev-parse", "HEAD"]);
+          remoteHeadBeforePatch = stdout.trim();
+        } catch {
+          // Non-fatal - extra empty commit will be skipped
+        }
+
         await exec.exec(`git am ${patchFilePath}`);
         core.info("Patch applied successfully");
 
         // Push the applied commits to the branch
         await exec.exec(`git push origin ${branchName}`);
         core.info(`Changes committed and pushed to branch: ${branchName}`);
+
+        // Count new commits pushed for the CI trigger decision
+        if (remoteHeadBeforePatch) {
+          try {
+            const { stdout: countStr } = await exec.getExecOutput("git", ["rev-list", "--count", `${remoteHeadBeforePatch}..HEAD`]);
+            newCommitCount = parseInt(countStr.trim(), 10);
+            core.info(`${newCommitCount} new commit(s) pushed to branch`);
+          } catch {
+            // Non-fatal - newCommitCount stays 0, extra empty commit will be skipped
+            core.info("Could not count new commits - extra empty commit will be skipped");
+          }
+        }
       } catch (error) {
         core.error(`Failed to apply patch: ${getErrorMessage(error)}`);
 
@@ -403,13 +445,16 @@ async function main(config = {}) {
 
     await core.summary.addRaw(summaryContent).write();
 
-    // Push an extra empty commit if a token is configured and changes were pushed.
+    // Push an extra empty commit if a token is configured and exactly 1 new commit was pushed.
     // This works around the GITHUB_TOKEN limitation where pushes don't trigger CI events.
+    // Restricting to exactly 1 new commit prevents the CI trigger token being used on
+    // multi-commit branches where workflow files may have been iteratively modified.
     if (hasChanges) {
       const ciTriggerResult = await pushExtraEmptyCommit({
         branchName,
         repoOwner: context.repo.owner,
         repoName: context.repo.repo,
+        newCommitCount,
       });
       if (ciTriggerResult.success && !ciTriggerResult.skipped) {
         core.info("Extra empty commit pushed - CI checks should start shortly");

--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -340,7 +340,9 @@ async function main(config = {}) {
           // Non-fatal - extra empty commit will be skipped
         }
 
-        await exec.exec(`git am ${patchFilePath}`);
+        // Use --3way to handle cross-repo patches where the patch base may differ from target repo
+        // This allows git to resolve create-vs-modify mismatches when a file exists in target but not source
+        await exec.exec(`git am --3way ${patchFilePath}`);
         core.info("Patch applied successfully");
 
         // Push the applied commits to the branch

--- a/actions/setup/js/push_to_pull_request_branch.test.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.test.cjs
@@ -158,8 +158,14 @@ describe("push_to_pull_request_branch.cjs", () => {
   });
 
   afterEach(() => {
-    // Restore environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    // (replacing process.env with a plain object breaks Node's special env handling)
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
 
     // Clean up temp directory
     if (tempDir && fs.existsSync(tempDir)) {

--- a/actions/setup/js/push_to_pull_request_branch.test.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.test.cjs
@@ -158,8 +158,17 @@ describe("push_to_pull_request_branch.cjs", () => {
   });
 
   afterEach(() => {
-    // Restore environment
-    process.env = originalEnv;
+    // Restore environment without replacing process.env object
+    // Remove any keys that were added during the test
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    // Restore original keys and values
+    for (const [key, value] of Object.entries(originalEnv)) {
+      process.env[key] = value;
+    }
 
     // Clean up temp directory
     if (tempDir && fs.existsSync(tempDir)) {

--- a/actions/setup/js/push_to_pull_request_branch.test.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.test.cjs
@@ -1,0 +1,1072 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+/**
+ * Test Matrix for push_to_pull_request_branch.cjs
+ *
+ * This test file covers the following scenarios:
+ *
+ * 1. GitHub Actions Context Scenarios:
+ *    - pull_request event (direct PR trigger)
+ *    - issue_comment event (comment on PR)
+ *    - schedule event (scheduled task)
+ *    - workflow_dispatch (manual trigger)
+ *
+ * 2. Repository State Scenarios:
+ *    - PR branch has had new pushes (needs merge/rebase)
+ *    - Base branch (main/default) has new commits
+ *    - PR branch has been force-pushed
+ *    - Normal push scenario
+ *
+ * 3. Empty Commit Handling:
+ *    - if-no-changes: warn (default)
+ *    - if-no-changes: error
+ *    - if-no-changes: ignore
+ *
+ * 4. Fork PR Scenarios:
+ *    - Fork PR detection
+ *    - Early failure for fork PRs (no push access)
+ *    - Same-repo PR (normal case)
+ *
+ * 5. Error Scenarios:
+ *    - git fetch failure
+ *    - git checkout failure
+ *    - git am (patch apply) failure
+ *    - git push failure
+ *    - Patch size too large
+ *    - Patch file not found
+ *    - Invalid patch content
+ */
+
+describe("push_to_pull_request_branch.cjs", () => {
+  let mockCore;
+  let mockExec;
+  let mockContext;
+  let mockGithub;
+  let tempDir;
+  let originalEnv;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+
+    // Create temp directory for test artifacts
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "push-to-pr-test-"));
+
+    // Mock core actions methods
+    mockCore = {
+      info: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      setFailed: vi.fn(),
+      setOutput: vi.fn(),
+      startGroup: vi.fn(),
+      endGroup: vi.fn(),
+      summary: {
+        addRaw: vi.fn().mockReturnThis(),
+        write: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    // Default exec mock
+    mockExec = {
+      exec: vi.fn().mockResolvedValue(0),
+      getExecOutput: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
+    };
+
+    // Default pull request context
+    mockContext = {
+      eventName: "pull_request",
+      sha: "abc123def456",
+      repo: {
+        owner: "test-owner",
+        repo: "test-repo",
+      },
+      payload: {
+        pull_request: {
+          number: 123,
+          state: "open",
+          title: "Test PR",
+          labels: [],
+          head: {
+            ref: "feature-branch",
+            sha: "head-sha-123",
+            repo: {
+              full_name: "test-owner/test-repo",
+              fork: false,
+              owner: {
+                login: "test-owner",
+              },
+            },
+          },
+          base: {
+            ref: "main",
+            sha: "base-sha-456",
+            repo: {
+              full_name: "test-owner/test-repo",
+              owner: {
+                login: "test-owner",
+              },
+            },
+          },
+        },
+        repository: {
+          html_url: "https://github.com/test-owner/test-repo",
+        },
+      },
+    };
+
+    // Default GitHub API mock
+    mockGithub = {
+      rest: {
+        pulls: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              head: {
+                ref: "feature-branch",
+                repo: {
+                  full_name: "test-owner/test-repo",
+                  fork: false,
+                },
+              },
+              base: {
+                repo: {
+                  full_name: "test-owner/test-repo",
+                },
+              },
+              title: "Test PR",
+              labels: [],
+            },
+          }),
+        },
+      },
+      graphql: vi.fn(),
+    };
+
+    global.core = mockCore;
+    global.exec = mockExec;
+    global.context = mockContext;
+    global.github = mockGithub;
+
+    // Clear module cache
+    delete require.cache[require.resolve("./push_to_pull_request_branch.cjs")];
+    delete require.cache[require.resolve("./staged_preview.cjs")];
+    delete require.cache[require.resolve("./update_activation_comment.cjs")];
+    delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+
+    // Clean up temp directory
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    // Clean up globals
+    delete global.core;
+    delete global.exec;
+    delete global.context;
+    delete global.github;
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Helper to load the module with mocked dependencies
+   */
+  async function loadModule() {
+    // Module loads when imported
+    const module = require("./push_to_pull_request_branch.cjs");
+    return module;
+  }
+
+  /**
+   * Helper to create a valid patch file
+   */
+  function createPatchFile(content = null) {
+    const patchPath = path.join(tempDir, "test.patch");
+    const defaultPatch = `From abc123 Mon Sep 17 00:00:00 2001
+From: Test Author <test@example.com>
+Date: Mon, 1 Jan 2024 00:00:00 +0000
+Subject: [PATCH] Test commit
+
+Test changes
+
+diff --git a/test.txt b/test.txt
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/test.txt
+@@ -0,0 +1 @@
++Hello World
+--
+2.34.1
+`;
+    fs.writeFileSync(patchPath, content !== null ? content : defaultPatch);
+    return patchPath;
+  }
+
+  // ──────────────────────────────────────────────────────
+  // Configuration Parsing Tests
+  // ──────────────────────────────────────────────────────
+
+  describe("configuration parsing", () => {
+    it('should default target to "triggering" when not specified', async () => {
+      const module = await loadModule();
+      const handler = await module.main({});
+
+      expect(mockCore.info).toHaveBeenCalledWith("Target: triggering");
+    });
+
+    it("should accept target from config", async () => {
+      const module = await loadModule();
+      const handler = await module.main({ target: "*" });
+
+      expect(mockCore.info).toHaveBeenCalledWith("Target: *");
+    });
+
+    it("should accept numeric target for specific PR", async () => {
+      const module = await loadModule();
+      const handler = await module.main({ target: "456" });
+
+      expect(mockCore.info).toHaveBeenCalledWith("Target: 456");
+    });
+
+    it('should default if_no_changes to "warn"', async () => {
+      const module = await loadModule();
+      const handler = await module.main({});
+
+      expect(mockCore.info).toHaveBeenCalledWith("If no changes: warn");
+    });
+
+    it("should accept title_prefix configuration", async () => {
+      const module = await loadModule();
+      const handler = await module.main({ title_prefix: "[bot] " });
+
+      expect(mockCore.info).toHaveBeenCalledWith("Title prefix: [bot] ");
+    });
+
+    it("should accept labels configuration as array", async () => {
+      const module = await loadModule();
+      const handler = await module.main({ labels: ["automated", "bot"] });
+
+      expect(mockCore.info).toHaveBeenCalledWith("Required labels: automated, bot");
+    });
+
+    it("should accept labels configuration as comma-separated string", async () => {
+      const module = await loadModule();
+      const handler = await module.main({ labels: "automated,bot" });
+
+      expect(mockCore.info).toHaveBeenCalledWith("Required labels: automated, bot");
+    });
+
+    it("should default max_patch_size to 1024 KB", async () => {
+      const module = await loadModule();
+      const handler = await module.main({});
+
+      expect(mockCore.info).toHaveBeenCalledWith("Max patch size: 1024 KB");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // GitHub Actions Context Tests
+  // ──────────────────────────────────────────────────────
+
+  describe("GitHub Actions context scenarios", () => {
+    it('should handle pull_request event with target "triggering"', async () => {
+      mockContext.eventName = "pull_request";
+      const patchPath = createPatchFile();
+
+      // Mock git commands
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "triggering" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockGithub.rest.pulls.get).toHaveBeenCalledWith({
+        owner: "test-owner",
+        repo: "test-repo",
+        pull_number: 123,
+      });
+    });
+
+    it("should handle issue_comment event (comment on PR)", async () => {
+      mockContext.eventName = "issue_comment";
+      mockContext.payload.issue = { number: 123 };
+      const patchPath = createPatchFile();
+
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "triggering" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail for schedule event with target "triggering"', async () => {
+      mockContext.eventName = "schedule";
+      delete mockContext.payload.pull_request;
+      delete mockContext.payload.issue;
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "triggering" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("pull request context");
+    });
+
+    it('should handle schedule event with target "*" and explicit PR number', async () => {
+      mockContext.eventName = "schedule";
+      delete mockContext.payload.pull_request;
+      const patchPath = createPatchFile();
+
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "*" });
+      const result = await handler({ patch_path: patchPath, pull_request_number: 456 }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockGithub.rest.pulls.get).toHaveBeenCalledWith({
+        owner: "test-owner",
+        repo: "test-repo",
+        pull_number: 456,
+      });
+    });
+
+    it("should handle workflow_dispatch event with explicit PR number", async () => {
+      mockContext.eventName = "workflow_dispatch";
+      delete mockContext.payload.pull_request;
+      const patchPath = createPatchFile();
+
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "789" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockGithub.rest.pulls.get).toHaveBeenCalledWith({
+        owner: "test-owner",
+        repo: "test-repo",
+        pull_number: 789,
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Fork PR Detection Tests
+  // ──────────────────────────────────────────────────────
+
+  describe("fork PR detection and handling", () => {
+    it("should detect fork PR via different repository names and fail early", async () => {
+      // Set up fork scenario - head repo is different from base repo
+      mockContext.payload.pull_request.head.repo.full_name = "fork-owner/test-repo";
+      mockContext.payload.pull_request.head.repo.owner.login = "fork-owner";
+
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: {
+              full_name: "fork-owner/test-repo",
+              fork: true,
+            },
+          },
+          base: {
+            repo: {
+              full_name: "test-owner/test-repo",
+            },
+          },
+          title: "Fork PR",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "triggering" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      // Fork PRs should fail early with a clear error
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fork");
+      expect(mockCore.error).toHaveBeenCalledWith(expect.stringContaining("Cannot push to fork PR"));
+      // Should not attempt any git operations
+      expect(mockExec.exec).not.toHaveBeenCalled();
+    });
+
+    it("should detect fork PR via fork flag and fail early", async () => {
+      mockContext.payload.pull_request.head.repo.fork = true;
+
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: {
+              full_name: "test-owner/test-repo",
+              fork: true,
+            },
+          },
+          base: {
+            repo: {
+              full_name: "test-owner/test-repo",
+            },
+          },
+          title: "Fork PR",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "triggering" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      // Fork PRs should fail early with a clear error
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fork");
+      expect(mockCore.error).toHaveBeenCalledWith(expect.stringContaining("Cannot push to fork PR"));
+    });
+
+    it("should handle deleted head repo (likely a fork) and fail early", async () => {
+      delete mockContext.payload.pull_request.head.repo;
+
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: null, // Deleted fork
+          },
+          base: {
+            repo: {
+              full_name: "test-owner/test-repo",
+            },
+          },
+          title: "Deleted Fork PR",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({ target: "triggering" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      // When head.repo is null, this is likely a deleted fork
+      // The handler should give a clear error about the fork
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fork");
+      expect(mockCore.error).toHaveBeenCalledWith(expect.stringContaining("Cannot push to fork PR"));
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Repository State Scenarios
+  // ──────────────────────────────────────────────────────
+
+  describe("repository state scenarios", () => {
+    it("should handle successful normal push", async () => {
+      const patchPath = createPatchFile();
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(result.branch_name).toBe("feature-branch");
+      expect(result.commit_url).toContain("test-owner/test-repo/commit/");
+    });
+
+    it("should handle git fetch failure", async () => {
+      const patchPath = createPatchFile();
+
+      // First exec call (git fetch) fails
+      mockExec.exec.mockRejectedValueOnce(new Error("Failed to fetch: network error"));
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to fetch branch");
+    });
+
+    it("should handle branch not existing on origin", async () => {
+      const patchPath = createPatchFile();
+
+      // git fetch succeeds, but git rev-parse fails
+      mockExec.exec.mockResolvedValueOnce(0); // fetch
+      mockExec.exec.mockRejectedValueOnce(new Error("fatal: Needed a single revision"));
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("does not exist on origin");
+    });
+
+    it("should handle git checkout failure", async () => {
+      const patchPath = createPatchFile();
+
+      mockExec.exec.mockResolvedValueOnce(0); // fetch
+      mockExec.exec.mockResolvedValueOnce(0); // rev-parse
+      mockExec.exec.mockRejectedValueOnce(new Error("checkout failed"));
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to checkout branch");
+    });
+
+    it("should handle git am (patch apply) failure with investigation", async () => {
+      const patchPath = createPatchFile();
+
+      // Set up successful fetch, rev-parse, checkout
+      mockExec.exec.mockResolvedValueOnce(0); // fetch
+      mockExec.exec.mockResolvedValueOnce(0); // rev-parse
+      mockExec.exec.mockResolvedValueOnce(0); // checkout
+
+      // git rev-parse HEAD for commit tracking
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "before-sha\n", stderr: "" });
+
+      // git am fails
+      mockExec.exec.mockRejectedValueOnce(new Error("Patch does not apply"));
+
+      // Investigation commands succeed
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "M file.txt\n", stderr: "" }); // git status
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "abc123 commit 1\n", stderr: "" }); // git log
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" }); // git diff
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "patch diff", stderr: "" }); // git am --show-current-patch=diff
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "full patch", stderr: "" }); // git am --show-current-patch
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to apply patch");
+      expect(mockCore.info).toHaveBeenCalledWith("Investigating patch failure...");
+    });
+
+    it("should handle git push rejection (concurrent changes)", async () => {
+      const patchPath = createPatchFile();
+
+      // Set up successful operations until push
+      mockExec.exec.mockResolvedValueOnce(0); // fetch
+      mockExec.exec.mockResolvedValueOnce(0); // rev-parse
+      mockExec.exec.mockResolvedValueOnce(0); // checkout
+
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "before-sha\n", stderr: "" });
+
+      mockExec.exec.mockResolvedValueOnce(0); // git am
+      mockExec.exec.mockRejectedValueOnce(new Error("! [rejected] feature-branch -> feature-branch (non-fast-forward)"));
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      // The error happens during push, which currently shows in patch apply failure
+      expect(result.success).toBe(false);
+    });
+
+    it("should detect force-pushed branch via ref mismatch", async () => {
+      const patchPath = createPatchFile();
+
+      // This tests the scenario where the branch SHA we have doesn't match remote
+      // The current implementation doesn't explicitly detect this, but git operations would fail
+      mockContext.payload.pull_request.head.sha = "old-sha-123";
+
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            sha: "new-sha-456", // Remote has different SHA
+          },
+          title: "Test PR",
+          labels: [],
+        },
+      });
+
+      mockExec.exec.mockResolvedValueOnce(0); // fetch
+      mockExec.exec.mockResolvedValueOnce(0); // rev-parse
+      mockExec.exec.mockResolvedValueOnce(0); // checkout
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "new-sha-456\n", stderr: "" });
+      mockExec.exec.mockResolvedValueOnce(0); // git am
+      mockExec.exec.mockResolvedValueOnce(0); // git push
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "final-sha\n", stderr: "" });
+      mockExec.getExecOutput.mockResolvedValueOnce({ exitCode: 0, stdout: "1\n", stderr: "" }); // commit count
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      // The push proceeds - force-push detection would need to be added
+      expect(mockGithub.rest.pulls.get).toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Empty Commit / No Changes Handling
+  // ──────────────────────────────────────────────────────
+
+  describe("empty commit / no changes handling", () => {
+    it("should warn when patch is empty and if-no-changes is warn", async () => {
+      const patchPath = createPatchFile(""); // Empty patch
+
+      const module = await loadModule();
+      const handler = await module.main({ if_no_changes: "warn" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.skipped).toBe(true);
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("noop"));
+    });
+
+    it("should error when patch is empty and if-no-changes is error", async () => {
+      const patchPath = createPatchFile(""); // Empty patch
+
+      const module = await loadModule();
+      const handler = await module.main({ if_no_changes: "error" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No changes");
+    });
+
+    it("should silently skip when patch is empty and if-no-changes is ignore", async () => {
+      const patchPath = createPatchFile(""); // Empty patch
+
+      const module = await loadModule();
+      const handler = await module.main({ if_no_changes: "ignore" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.skipped).toBe(true);
+    });
+
+    it("should handle missing patch file", async () => {
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: "/nonexistent/path.patch" }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No patch file");
+    });
+
+    it("should handle patch file with error message", async () => {
+      const patchPath = createPatchFile("Failed to generate patch: some error");
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("error message");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Patch Size Validation
+  // ──────────────────────────────────────────────────────
+
+  describe("patch size validation", () => {
+    it("should reject patches exceeding max size", async () => {
+      // Create a patch larger than 1KB
+      const largePatch = "x".repeat(2 * 1024 * 1024); // 2MB
+      const patchPath = createPatchFile(largePatch);
+
+      const module = await loadModule();
+      const handler = await module.main({ max_patch_size: 1024 }); // 1MB max
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("exceeds maximum");
+    });
+
+    it("should accept patches within max size", async () => {
+      const patchPath = createPatchFile(); // Small valid patch
+
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ max_patch_size: 1024 });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockCore.info).toHaveBeenCalledWith("Patch size validation passed");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Title Prefix and Labels Validation
+  // ──────────────────────────────────────────────────────
+
+  describe("title prefix and labels validation", () => {
+    it("should reject PR without required title prefix", async () => {
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: { full_name: "test-owner/test-repo", fork: false },
+          },
+          base: { repo: { full_name: "test-owner/test-repo" } },
+          title: "Some PR Title",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({ title_prefix: "[bot] " });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("does not start with required prefix");
+    });
+
+    it("should accept PR with required title prefix", async () => {
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: { full_name: "test-owner/test-repo", fork: false },
+          },
+          base: { repo: { full_name: "test-owner/test-repo" } },
+          title: "[bot] Automated PR",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ title_prefix: "[bot] " });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockCore.info).toHaveBeenCalledWith('✓ Title prefix validation passed: "[bot] "');
+    });
+
+    it("should reject PR without required labels", async () => {
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: { full_name: "test-owner/test-repo", fork: false },
+          },
+          base: { repo: { full_name: "test-owner/test-repo" } },
+          title: "Test PR",
+          labels: [{ name: "bug" }],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({ labels: ["automated", "enhancement"] });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("missing required labels");
+    });
+
+    it("should accept PR with all required labels", async () => {
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature-branch",
+            repo: { full_name: "test-owner/test-repo", fork: false },
+          },
+          base: { repo: { full_name: "test-owner/test-repo" } },
+          title: "Test PR",
+          labels: [{ name: "automated" }, { name: "enhancement" }],
+        },
+      });
+
+      const patchPath = createPatchFile();
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ labels: ["automated", "enhancement"] });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockCore.info).toHaveBeenCalledWith("✓ Labels validation passed: automated, enhancement");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Commit Title Suffix
+  // ──────────────────────────────────────────────────────
+
+  describe("commit title suffix", () => {
+    it("should append suffix to commit messages in patch", async () => {
+      const patchPath = createPatchFile();
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ commit_title_suffix: " [skip ci]" });
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(mockCore.info).toHaveBeenCalledWith('Appending commit title suffix: " [skip ci]"');
+
+      // Verify patch was modified
+      const modifiedPatch = fs.readFileSync(patchPath, "utf8");
+      expect(modifiedPatch).toContain("[skip ci]");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Staged Mode
+  // ──────────────────────────────────────────────────────
+
+  describe("staged mode", () => {
+    it("should generate preview instead of pushing in staged mode", async () => {
+      process.env.GH_AW_SAFE_OUTPUTS_STAGED = "true";
+      const patchPath = createPatchFile();
+
+      // Re-import the module to pick up env var
+      delete require.cache[require.resolve("./push_to_pull_request_branch.cjs")];
+
+      const module = require("./push_to_pull_request_branch.cjs");
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      expect(result.staged).toBe(true);
+      // Should not have made any git commands
+      expect(mockExec.exec).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Max Count Limiting
+  // ──────────────────────────────────────────────────────
+
+  describe("max count limiting", () => {
+    it("should skip messages after max count reached", async () => {
+      const patchPath = createPatchFile();
+      mockExec.getExecOutput.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const module = await loadModule();
+      const handler = await module.main({ max: 1 });
+
+      // First call succeeds
+      const result1 = await handler({ patch_path: patchPath }, {});
+      expect(result1.success).toBe(true);
+
+      // Second call is skipped
+      const result2 = await handler({ patch_path: patchPath }, {});
+      expect(result2.success).toBe(false);
+      expect(result2.skipped).toBe(true);
+      expect(result2.error).toContain("Max count");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Branch Name Sanitization
+  // ──────────────────────────────────────────────────────
+
+  describe("branch name sanitization", () => {
+    it("should sanitize branch names with shell metacharacters", async () => {
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: "feature;rm -rf /",
+            repo: { full_name: "test-owner/test-repo", fork: false },
+          },
+          base: { repo: { full_name: "test-owner/test-repo" } },
+          title: "Test PR",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      // The normalizeBranchName should sanitize dangerous characters
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("Branch name sanitized"));
+    });
+
+    it("should reject empty branch name after sanitization", async () => {
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: {
+          head: {
+            ref: ";$`|&", // All dangerous chars
+            repo: { full_name: "test-owner/test-repo", fork: false },
+          },
+          base: { repo: { full_name: "test-owner/test-repo" } },
+          title: "Test PR",
+          labels: [],
+        },
+      });
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid branch name");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // PR API Error Handling
+  // ──────────────────────────────────────────────────────
+
+  describe("PR API error handling", () => {
+    it("should handle PR not found error", async () => {
+      mockGithub.rest.pulls.get.mockRejectedValue(new Error("Not Found"));
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to determine branch name");
+    });
+
+    it("should handle network error fetching PR", async () => {
+      mockGithub.rest.pulls.get.mockRejectedValue(new Error("Network timeout"));
+
+      const patchPath = createPatchFile();
+
+      const module = await loadModule();
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to determine branch name");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Extra Empty Commit (CI Trigger)
+  // ──────────────────────────────────────────────────────
+
+  describe("extra empty commit for CI trigger", () => {
+    it("should push extra empty commit when CI trigger token is set", async () => {
+      process.env.GH_AW_CI_TRIGGER_TOKEN = "ghp_test_token";
+
+      // Re-import modules to pick up env var
+      delete require.cache[require.resolve("./push_to_pull_request_branch.cjs")];
+      delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+
+      const patchPath = createPatchFile();
+
+      // Mock successful commands
+      mockExec.exec.mockResolvedValue(0);
+      mockExec.getExecOutput.mockImplementation(async (cmd, args) => {
+        if (args && args[0] === "rev-parse") {
+          return { exitCode: 0, stdout: "abc123\n", stderr: "" };
+        }
+        if (args && args[0] === "rev-list") {
+          return { exitCode: 0, stdout: "1\n", stderr: "" }; // 1 new commit
+        }
+        if (args && args[0] === "log") {
+          return { exitCode: 0, stdout: "COMMIT:abc\nfile.txt\n", stderr: "" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+      const module = require("./push_to_pull_request_branch.cjs");
+      const handler = await module.main({});
+      const result = await handler({ patch_path: patchPath }, {});
+
+      expect(result.success).toBe(true);
+      // The extra empty commit should have been attempted
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("Extra empty commit"));
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // Handler Type Export
+  // ──────────────────────────────────────────────────────
+
+  describe("module exports", () => {
+    it("should export HANDLER_TYPE as push_to_pull_request_branch", async () => {
+      const module = await loadModule();
+
+      expect(module.HANDLER_TYPE).toBe("push_to_pull_request_branch");
+    });
+
+    it("should export main function", async () => {
+      const module = await loadModule();
+
+      expect(typeof module.main).toBe("function");
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────
+// Integration Test Recommendations
+// ──────────────────────────────────────────────────────
+
+/**
+ * INTEGRATION TEST RECOMMENDATIONS
+ *
+ * The following scenarios require integration testing with real Git repositories.
+ * These tests should be added to a separate file (e.g., push_to_pull_request_branch.integration.test.cjs)
+ * and run in a CI environment with actual Git operations.
+ *
+ * 1. CONCURRENT PUSH SCENARIOS:
+ *    - Create a test repo with a PR branch
+ *    - Push a commit to the PR branch from another process
+ *    - Attempt to push from the handler
+ *    - Verify proper error handling for non-fast-forward rejection
+ *
+ * 2. FORCE-PUSH DETECTION:
+ *    - Create a test repo with a PR branch
+ *    - Force-push to rewrite the branch history
+ *    - Attempt to apply a patch based on old history
+ *    - Verify proper error message about force-push
+ *
+ * 3. BASE BRANCH UPDATES:
+ *    - Create a test repo with a PR branch
+ *    - Push commits to the base branch
+ *    - Verify that pushing to PR branch still works
+ *    - (Note: This should work as PR branch is independent)
+ *
+ * 4. MERGE CONFLICT SCENARIOS:
+ *    - Create a test repo with conflicting changes
+ *    - Attempt to apply a patch that conflicts
+ *    - Verify clear error message about merge conflict
+ *
+ * 5. FORK PR EARLY FAILURE:
+ *    - Create a fork repository (or simulate fork context)
+ *    - Verify early failure before attempting push
+ *    - Verify clear error message about fork permissions
+ *
+ * TEST SETUP RECOMMENDATIONS:
+ * - Use GitHub API to create test repositories
+ * - Use git commands to set up test scenarios
+ * - Clean up test repos after each test
+ * - Run these tests on a schedule, not on every commit
+ */

--- a/actions/setup/js/safe_outputs_branch_detection.test.cjs
+++ b/actions/setup/js/safe_outputs_branch_detection.test.cjs
@@ -15,7 +15,11 @@ describe("safe_outputs_mcp_server.cjs branch detection", () => {
       (process.env.GH_AW_SAFE_OUTPUTS = tempOutputFile));
   }),
     afterEach(() => {
-      (Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
+      (Object.keys(process.env).forEach(k => {
+        if (!(k in originalEnv)) delete process.env[k];
+      }),
+        Object.assign(process.env, originalEnv),
+        fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
     }),
     it("should use git branch when provided branch equals base branch", () => {
       const testRepoDir = path.join(tempOutputDir, "test_repo");

--- a/actions/setup/js/safe_outputs_branch_detection.test.cjs
+++ b/actions/setup/js/safe_outputs_branch_detection.test.cjs
@@ -15,7 +15,7 @@ describe("safe_outputs_mcp_server.cjs branch detection", () => {
       (process.env.GH_AW_SAFE_OUTPUTS = tempOutputFile));
   }),
     afterEach(() => {
-      ((process.env = originalEnv), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
+      (Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
     }),
     it("should use git branch when provided branch equals base branch", () => {
       const testRepoDir = path.join(tempOutputDir, "test_repo");

--- a/actions/setup/js/safe_outputs_handlers.cjs
+++ b/actions/setup/js/safe_outputs_handlers.cjs
@@ -319,9 +319,11 @@ function createHandlers(server, appendSafeOutput, config = {}) {
       entry.branch = detectedBranch;
     }
 
-    // Generate git patch
-    server.debug(`Generating patch for push_to_pull_request_branch with branch: ${entry.branch}`);
-    const patchResult = generateGitPatch(entry.branch);
+    // Generate git patch in incremental mode
+    // Incremental mode only includes commits since origin/branchName,
+    // preventing patches that include already-existing commits
+    server.debug(`Generating incremental patch for push_to_pull_request_branch with branch: ${entry.branch}`);
+    const patchResult = generateGitPatch(entry.branch, { mode: "incremental" });
 
     if (!patchResult.success) {
       // Patch generation failed or patch is empty

--- a/actions/setup/js/safe_outputs_handlers.cjs
+++ b/actions/setup/js/safe_outputs_handlers.cjs
@@ -283,6 +283,25 @@ function createHandlers(server, appendSafeOutput, config = {}) {
    * Generates git patch for the changes
    */
   const pushToPullRequestBranchHandler = args => {
+    // Check if this is a fork PR - fail early with clear error message
+    // GH_AW_IS_FORK_PR is set by checkout_pr_branch.cjs during PR checkout
+    const isForkPR = process.env.GH_AW_IS_FORK_PR === "true";
+    if (isForkPR) {
+      server.debug("Rejecting push_to_pull_request_branch: fork PR detected");
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              result: "error",
+              error: `${ERR_VALIDATION}: Cannot push to fork PR branches. The push_to_pull_request_branch tool only works for PRs from branches within the same repository. Fork PRs require contributors to push to their own fork.`,
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
+
     const entry = { ...args, type: "push_to_pull_request_branch" };
     const baseBranch = getBaseBranch();
 

--- a/actions/setup/js/safe_outputs_handlers.test.cjs
+++ b/actions/setup/js/safe_outputs_handlers.test.cjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import path from "path";

--- a/actions/setup/js/safe_outputs_handlers.test.cjs
+++ b/actions/setup/js/safe_outputs_handlers.test.cjs
@@ -340,7 +340,7 @@ describe("safe_outputs_handlers", () => {
       // The error should be about patch generation, not about forks
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.error).not.toContain("fork PR");
-      expect(responseData.error).toContain("Failed to generate patch");
+      expect(responseData.error).toContain("does not exist locally");
 
       // Clean up
       delete process.env.GH_AW_IS_FORK_PR;
@@ -359,7 +359,7 @@ describe("safe_outputs_handlers", () => {
 
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.error).not.toContain("fork PR");
-      expect(responseData.error).toContain("Failed to generate patch");
+      expect(responseData.error).toContain("does not exist locally");
     });
 
     it("should return error response when patch generation fails (not throw)", () => {
@@ -382,7 +382,7 @@ describe("safe_outputs_handlers", () => {
       const responseData = JSON.parse(result.content[0].text);
       expect(responseData.result).toBe("error");
       expect(responseData.error).toBeDefined();
-      expect(responseData.error).toContain("Failed to generate patch");
+      expect(responseData.error).toContain("does not exist locally");
       expect(responseData.details).toBeDefined();
       expect(responseData.details).toContain("push to the pull request branch");
       expect(responseData.details).toContain("git add and git commit");

--- a/actions/setup/js/safe_outputs_handlers.test.cjs
+++ b/actions/setup/js/safe_outputs_handlers.test.cjs
@@ -298,6 +298,70 @@ describe("safe_outputs_handlers", () => {
       expect(handlers.pushToPullRequestBranchHandler).toBeDefined();
     });
 
+    it("should reject fork PRs with early error before patch generation", () => {
+      // Set up fork PR environment
+      process.env.GH_AW_IS_FORK_PR = "true";
+
+      const args = {
+        branch: "feature-branch",
+      };
+
+      const result = handlers.pushToPullRequestBranchHandler(args);
+
+      // Verify it returns an error response
+      expect(result).toBeDefined();
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBe(true);
+
+      // Parse the response
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.result).toBe("error");
+      expect(responseData.error).toContain("fork PR");
+      expect(responseData.error).toContain("Cannot push to fork PR branches");
+
+      // Should not have tried to append any safe output
+      expect(mockAppendSafeOutput).not.toHaveBeenCalled();
+
+      // Clean up
+      delete process.env.GH_AW_IS_FORK_PR;
+    });
+
+    it("should allow same-repo PRs when GH_AW_IS_FORK_PR is false", () => {
+      // Set up same-repo PR environment
+      process.env.GH_AW_IS_FORK_PR = "false";
+
+      const args = {
+        branch: "feature-branch",
+      };
+
+      // Will fail at patch generation (no git repo), but should NOT fail at fork check
+      const result = handlers.pushToPullRequestBranchHandler(args);
+
+      // The error should be about patch generation, not about forks
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.error).not.toContain("fork PR");
+      expect(responseData.error).toContain("Failed to generate patch");
+
+      // Clean up
+      delete process.env.GH_AW_IS_FORK_PR;
+    });
+
+    it("should allow PRs when GH_AW_IS_FORK_PR is not set", () => {
+      // Ensure env var is not set
+      delete process.env.GH_AW_IS_FORK_PR;
+
+      const args = {
+        branch: "feature-branch",
+      };
+
+      // Will fail at patch generation, but should NOT fail at fork check
+      const result = handlers.pushToPullRequestBranchHandler(args);
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData.error).not.toContain("fork PR");
+      expect(responseData.error).toContain("Failed to generate patch");
+    });
+
     it("should return error response when patch generation fails (not throw)", () => {
       // This test verifies the error is returned as content, not thrown
       const args = {

--- a/actions/setup/js/safe_outputs_mcp_large_content.test.cjs
+++ b/actions/setup/js/safe_outputs_mcp_large_content.test.cjs
@@ -17,7 +17,7 @@ describe.sequential("safe_outputs_mcp_server.cjs large content handling", () => 
     fs.writeFileSync(toolsJsonPath, toolsJsonContent);
   }),
     afterEach(() => {
-      ((process.env = originalEnv), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
+      (Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
     }),
     it("should write large content to file when exceeding 16000 tokens", async () => {
       ((process.env.GH_AW_SAFE_OUTPUTS = tempOutputFile), (process.env.GH_AW_SAFE_OUTPUTS_CONFIG_PATH = tempConfigFile), (process.env.GH_AW_SAFE_OUTPUTS_TOOLS_PATH = path.join(tempOutputDir, "tools.json")));

--- a/actions/setup/js/safe_outputs_mcp_large_content.test.cjs
+++ b/actions/setup/js/safe_outputs_mcp_large_content.test.cjs
@@ -17,7 +17,11 @@ describe.sequential("safe_outputs_mcp_server.cjs large content handling", () => 
     fs.writeFileSync(toolsJsonPath, toolsJsonContent);
   }),
     afterEach(() => {
-      (Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
+      (Object.keys(process.env).forEach(k => {
+        if (!(k in originalEnv)) delete process.env[k];
+      }),
+        Object.assign(process.env, originalEnv),
+        fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
     }),
     it("should write large content to file when exceeding 16000 tokens", async () => {
       ((process.env.GH_AW_SAFE_OUTPUTS = tempOutputFile), (process.env.GH_AW_SAFE_OUTPUTS_CONFIG_PATH = tempConfigFile), (process.env.GH_AW_SAFE_OUTPUTS_TOOLS_PATH = path.join(tempOutputDir, "tools.json")));

--- a/actions/setup/js/safe_outputs_mcp_server_defaults.test.cjs
+++ b/actions/setup/js/safe_outputs_mcp_server_defaults.test.cjs
@@ -17,7 +17,12 @@ import { spawn } from "child_process";
     fs.writeFileSync(toolsJsonPath, toolsJsonContent);
   }),
     afterEach(() => {
-      (Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv), fs.existsSync(tempConfigFile) && fs.unlinkSync(tempConfigFile), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
+      (Object.keys(process.env).forEach(k => {
+        if (!(k in originalEnv)) delete process.env[k];
+      }),
+        Object.assign(process.env, originalEnv),
+        fs.existsSync(tempConfigFile) && fs.unlinkSync(tempConfigFile),
+        fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
     }),
     it("should use default output file when GH_AW_SAFE_OUTPUTS is not set", async () => {
       (delete process.env.GH_AW_SAFE_OUTPUTS, delete process.env.GH_AW_SAFE_OUTPUTS_CONFIG_PATH, fs.existsSync("/opt/gh-aw/safeoutputs") || fs.mkdirSync("/opt/gh-aw/safeoutputs", { recursive: !0 }));

--- a/actions/setup/js/safe_outputs_mcp_server_defaults.test.cjs
+++ b/actions/setup/js/safe_outputs_mcp_server_defaults.test.cjs
@@ -17,7 +17,7 @@ import { spawn } from "child_process";
     fs.writeFileSync(toolsJsonPath, toolsJsonContent);
   }),
     afterEach(() => {
-      ((process.env = originalEnv), fs.existsSync(tempConfigFile) && fs.unlinkSync(tempConfigFile), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
+      (Object.keys(process.env).forEach(k => { if (!(k in originalEnv)) delete process.env[k]; }), Object.assign(process.env, originalEnv), fs.existsSync(tempConfigFile) && fs.unlinkSync(tempConfigFile), fs.existsSync(tempOutputDir) && fs.rmSync(tempOutputDir, { recursive: !0, force: !0 }));
     }),
     it("should use default output file when GH_AW_SAFE_OUTPUTS is not set", async () => {
       (delete process.env.GH_AW_SAFE_OUTPUTS, delete process.env.GH_AW_SAFE_OUTPUTS_CONFIG_PATH, fs.existsSync("/opt/gh-aw/safeoutputs") || fs.mkdirSync("/opt/gh-aw/safeoutputs", { recursive: !0 }));

--- a/actions/setup/js/workflow_metadata_helpers.test.cjs
+++ b/actions/setup/js/workflow_metadata_helpers.test.cjs
@@ -23,8 +23,13 @@ describe("getWorkflowMetadata", () => {
   });
 
   afterEach(() => {
-    // Restore original environment
-    process.env = originalEnv;
+    // Restore environment by mutating process.env in place
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
 
     // Restore original context
     global.context = originalContext;

--- a/docs/src/content/docs/reference/safe-outputs.md
+++ b/docs/src/content/docs/reference/safe-outputs.md
@@ -826,6 +826,10 @@ safe-outputs:
 
 Pushes changes to a PR's branch. Validates via `title-prefix` and `labels` to ensure only approved PRs receive changes. Multiple pushes per run are supported by setting `max` higher than 1.
 
+:::caution[Fork PRs Not Supported]
+This safe output **cannot push to PRs from forks**. Fork PRs will fail early with a clear error message. This is a security restriction—the workflow does not have write access to fork repositories.
+:::
+
 ```yaml wrap
 safe-outputs:
   push-to-pull-request-branch:


### PR DESCRIPTION
## Summary

- **Fork PR guard**: Exports `GH_AW_IS_FORK_PR` env var during checkout and blocks `push_to_pull_request_branch` early—at both the MCP handler and git-push layers—when a fork PR is detected, preventing permission errors and clarifying the limitation in docs.
- **CI trigger token hardening**: The extra empty commit (used to trigger CI events) is now restricted to branches with **exactly 1 new commit**, preventing the CI trigger token from being used on multi-commit branches where workflow files may have been iteratively modified.
- **New tests**: Adds a full unit test suite for `push_to_pull_request_branch.cjs` and a real-git integration test suite (`git_patch_integration.test.cjs`) covering patch generation/application, unicode/emoji handling, merge conflicts, concurrent pushes, and commit title suffix modification.