### PR TITLE
📂 Fix relative import resolution for nested remote files

### DIFF
--- a/pkg/parser/import_processor.go
+++ b/pkg/parser/import_processor.go
@@ -539,7 +539,9 @@ func processImportsFromFrontmatterWithManifestAndSource(frontmatter map[string]a
 
 						resolvedPath = fmt.Sprintf("%s/%s/%s/%s@%s",
 							item.remoteOrigin.Owner, item.remoteOrigin.Repo, basePath, cleanPath, item.remoteOrigin.Ref)
-						nestedRemoteOrigin = item.remoteOrigin
+						// Parse a new remoteOrigin from resolvedPath to get the correct BasePath
+						// for THIS file's nested imports, not the parent's BasePath
+						nestedRemoteOrigin = parseRemoteOrigin(resolvedPath)
 						importLog.Printf("Resolving nested import as remote workflowspec: %s -> %s (basePath=%s)", nestedFilePath, resolvedPath, basePath)
 					} else if isWorkflowSpec(nestedFilePath) {
 						// Nested import is itself a workflowspec - parse its remote origin


### PR DESCRIPTION
Fixes https://github.com/github/gh-aw/issues/17620

## Summary

- **Bug fix**: Nested remote imports now resolve relative to their immediate parent file's directory, not the top-level workflow's directory
- **Root cause**: `nestedRemoteOrigin` was reusing the parent's `remoteOrigin` (with the wrong `BasePath`); it now calls `parseRemoteOrigin(resolvedPath)` to derive the correct `BasePath` for each file
- **Regression test**: Added a two-level nesting test covering the case where `workflows/workflow.md` → `shared/file1.md` → `file2.md` correctly resolves to `workflows/shared/file2.md` instead of `workflows/file2.md`