### PR TITLE
Add ecosystem domains for R, Julia, OCaml, Bazel, Lua

### DIFF
--- a/pkg/workflow/data/ecosystem_domains.json
+++ b/pkg/workflow/data/ecosystem_domains.json
@@ -55,6 +55,7 @@
     "oneocsp.microsoft.com",
     "*.vsblob.vsassets.io"
   ],
+  "bazel": ["releases.bazel.build", "mirror.bazel.build", "bcr.bazel.build", "blog.bazel.build"],
   "clojure": ["repo.clojars.org", "clojars.org"],
   "dart": ["pub.dev", "pub.dartlang.org", "storage.googleapis.com"],
   "fonts": ["fonts.googleapis.com", "fonts.gstatic.com"],
@@ -73,6 +74,7 @@
   "terraform": ["releases.hashicorp.com", "apt.releases.hashicorp.com", "yum.releases.hashicorp.com", "registry.terraform.io"],
   "haskell": ["haskell.org", "*.hackage.haskell.org", "get-ghcup.haskell.org", "downloads.haskell.org"],
   "kotlin": ["ge.jetbrains.com", "packages.jetbrains.team", "kotlin.bintray.com"],
+  "julia": ["pkg.julialang.org", "julialang.org", "julialang-s3.julialang.org"],
   "java": [
     "www.java.com",
     "jdk.java.net",
@@ -122,6 +124,7 @@
     "download.opensuse.org",
     "cdn.redhat.com"
   ],
+  "lua": ["luarocks.org", "www.luarocks.org"],
   "node": [
     "npmjs.org",
     "npmjs.com",
@@ -151,6 +154,7 @@
     "telemetry.vercel.com"
   ],
   "node-cdns": ["cdn.jsdelivr.net", "data.jsdelivr.com", "code.jquery.com", "cdn.sheetjs.com"],
+  "ocaml": ["opam.ocaml.org", "ocaml.org", "erratique.ch"],
   "perl": ["cpan.org", "www.cpan.org", "metacpan.org", "cpan.metacpan.org"],
   "php": ["repo.packagist.org", "packagist.org", "getcomposer.org", "bitbucket.org"],
   "playwright": ["playwright.download.prss.microsoft.com", "cdn.playwright.dev"],
@@ -171,6 +175,7 @@
     "index.crates.io",
     "static.crates.io"
   ],
+  "r": ["cloud.r-project.org", "cran.r-project.org", "cran.rstudio.com", "r-project.org"],
   "ruby": ["rubygems.org", "api.rubygems.org", "rubygems.pkg.github.com", "bundler.rubygems.org", "gems.rubyforge.org", "gems.rubyonrails.org", "index.rubygems.org", "cache.ruby-lang.org", "*.rvm.io"],
   "rust": ["crates.io", "index.crates.io", "static.crates.io", "sh.rustup.rs", "static.rust-lang.org"],
   "scala": ["repo.scala-sbt.org", "scala-ci.typesafe.com", "repo.typesafe.com", "jitpack.io", "dl.bintray.com"],

--- a/pkg/workflow/ecosystem_domains_test.go
+++ b/pkg/workflow/ecosystem_domains_test.go
@@ -241,6 +241,104 @@ func TestEcosystemDomainExpansion(t *testing.T) {
 		}
 	})
 
+	t.Run("bazel ecosystem includes Bazel registry and download domains", func(t *testing.T) {
+		permissions := &NetworkPermissions{
+			Allowed: []string{"bazel"},
+		}
+		domains := GetAllowedDomains(permissions)
+
+		expectedDomains := []string{
+			"releases.bazel.build",
+			"mirror.bazel.build",
+			"bcr.bazel.build",
+		}
+
+		for _, expectedDomain := range expectedDomains {
+			found := slices.Contains(domains, expectedDomain)
+			if !found {
+				t.Errorf("Expected domain '%s' to be included in bazel ecosystem, but it was not found", expectedDomain)
+			}
+		}
+	})
+
+	t.Run("julia ecosystem includes Julia package registry domains", func(t *testing.T) {
+		permissions := &NetworkPermissions{
+			Allowed: []string{"julia"},
+		}
+		domains := GetAllowedDomains(permissions)
+
+		expectedDomains := []string{
+			"pkg.julialang.org",
+			"julialang.org",
+		}
+
+		for _, expectedDomain := range expectedDomains {
+			found := slices.Contains(domains, expectedDomain)
+			if !found {
+				t.Errorf("Expected domain '%s' to be included in julia ecosystem, but it was not found", expectedDomain)
+			}
+		}
+	})
+
+	t.Run("lua ecosystem includes LuaRocks domains", func(t *testing.T) {
+		permissions := &NetworkPermissions{
+			Allowed: []string{"lua"},
+		}
+		domains := GetAllowedDomains(permissions)
+
+		expectedDomains := []string{
+			"luarocks.org",
+			"www.luarocks.org",
+		}
+
+		for _, expectedDomain := range expectedDomains {
+			found := slices.Contains(domains, expectedDomain)
+			if !found {
+				t.Errorf("Expected domain '%s' to be included in lua ecosystem, but it was not found", expectedDomain)
+			}
+		}
+	})
+
+	t.Run("ocaml ecosystem includes opam domains", func(t *testing.T) {
+		permissions := &NetworkPermissions{
+			Allowed: []string{"ocaml"},
+		}
+		domains := GetAllowedDomains(permissions)
+
+		expectedDomains := []string{
+			"opam.ocaml.org",
+			"ocaml.org",
+			"erratique.ch",
+		}
+
+		for _, expectedDomain := range expectedDomains {
+			found := slices.Contains(domains, expectedDomain)
+			if !found {
+				t.Errorf("Expected domain '%s' to be included in ocaml ecosystem, but it was not found", expectedDomain)
+			}
+		}
+	})
+
+	t.Run("r ecosystem includes CRAN domains", func(t *testing.T) {
+		permissions := &NetworkPermissions{
+			Allowed: []string{"r"},
+		}
+		domains := GetAllowedDomains(permissions)
+
+		expectedDomains := []string{
+			"cloud.r-project.org",
+			"cran.r-project.org",
+			"cran.rstudio.com",
+		}
+
+		for _, expectedDomain := range expectedDomains {
+			found := slices.Contains(domains, expectedDomain)
+			if !found {
+				t.Errorf("Expected domain '%s' to be included in r ecosystem, but it was not found", expectedDomain)
+			}
+		}
+	})
+
 	t.Run("multiple ecosystems can be combined", func(t *testing.T) {
 		permissions := &NetworkPermissions{
 			Allowed: []string{"defaults", "dotnet", "python", "example.com"},
@@ -290,9 +388,9 @@ func TestEcosystemDomainExpansion(t *testing.T) {
 func TestAllEcosystemDomainFunctions(t *testing.T) {
 	// Test that all ecosystem categories return non-empty slices
 	ecosystemCategories := []string{
-		"defaults", "containers", "dotnet", "dart", "github", "go",
-		"terraform", "haskell", "java", "linux-distros", "node",
-		"perl", "php", "playwright", "python", "ruby", "rust", "swift",
+		"defaults", "containers", "bazel", "dotnet", "dart", "github", "go",
+		"terraform", "haskell", "java", "julia", "linux-distros", "lua", "node",
+		"ocaml", "perl", "php", "playwright", "python", "r", "ruby", "rust", "swift",
 	}
 
 	for _, category := range ecosystemCategories {
@@ -315,9 +413,9 @@ func TestAllEcosystemDomainFunctions(t *testing.T) {
 func TestEcosystemDomainsUniqueness(t *testing.T) {
 	// Test that each ecosystem category returns unique domains (no duplicates)
 	ecosystemCategories := []string{
-		"defaults", "containers", "dotnet", "dart", "github", "go",
-		"terraform", "haskell", "java", "linux-distros", "node",
-		"perl", "php", "playwright", "python", "ruby", "rust", "swift",
+		"defaults", "containers", "bazel", "dotnet", "dart", "github", "go",
+		"terraform", "haskell", "java", "julia", "linux-distros", "lua", "node",
+		"ocaml", "perl", "php", "playwright", "python", "r", "ruby", "rust", "swift",
 	}
 
 	for _, category := range ecosystemCategories {


### PR DESCRIPTION
## Summary
- Adds package registry domains for 5 new language ecosystems
- Discovered during v6 build-test experiment (gh-aw-build-test)
- These ecosystems had builds fail or require agent workarounds due to blocked domains

## New ecosystems
| Ecosystem | Domains | Impact |
|-----------|---------|--------|
| `bazel` | releases.bazel.build, mirror.bazel.build, bcr.bazel.build | Bazelisk can't download Bazel binary without this |
| `r` | cloud.r-project.org, cran.r-project.org, cran.rstudio.com | R install.packages() completely blocked |
| `julia` | pkg.julialang.org, julialang.org | Julia Pkg.add() needs official registry |
| `ocaml` | opam.ocaml.org, erratique.ch | opam install blocked |
| `lua` | luarocks.org | luarocks install blocked |

## Test plan
- [x] Unit tests pass
- [ ] Recompile build-test workflows with new ecosystem identifiers
- [ ] Re-run v6 test workflows to verify domain access

🤖 Generated with [Claude Code](https://claude.com/claude-code)