### PR TITLE
🔑 Fix GitHub auth to support custom token in handlers

### DIFF
--- a/actions/setup/js/add_comment.cjs
+++ b/actions/setup/js/add_comment.cjs
@@ -305,6 +305,14 @@ async function main(config = {}) {
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
 
+  // Setup GitHub client - use custom token if provided, otherwise use global github object
+  let githubClient = github;
+  if (config["github-token"]) {
+    core.info("Using custom GitHub token for add_comment handler");
+    const { getOctokit } = await import("@actions/github");
+    githubClient = getOctokit(config["github-token"]);
+  }
+
   // Check if append-only-comments is enabled in messages config
   const messagesConfig = getMessages();
   const appendOnlyComments = messagesConfig?.appendOnlyComments === true;
@@ -453,7 +461,7 @@ async function main(config = {}) {
       if (item.item_number !== undefined && item.item_number !== null) {
         // Explicit item_number: fetch the issue/PR to get its author
         try {
-          const { data: issueData } = await github.rest.issues.get({
+          const { data: issueData } = await githubClient.rest.issues.get({
             owner: repoParts.owner,
             repo: repoParts.repo,
             issue_number: itemNumber,
@@ -556,7 +564,7 @@ async function main(config = {}) {
       // Hide older comments if enabled AND append-only-comments is not enabled
       // When append-only-comments is true, we want to keep all comments visible
       if (hideOlderCommentsEnabled && !appendOnlyComments && workflowId) {
-        await hideOlderComments(github, repoParts.owner, repoParts.repo, itemNumber, workflowId, isDiscussion);
+        await hideOlderComments(githubClient, repoParts.owner, repoParts.repo, itemNumber, workflowId, isDiscussion);
       } else if (hideOlderCommentsEnabled && appendOnlyComments) {
         core.info("Skipping hide-older-comments because append-only-comments is enabled");
       }
@@ -574,7 +582,7 @@ async function main(config = {}) {
             }
           }
         `;
-        const queryResult = await github.graphql(discussionQuery, {
+        const queryResult = await githubClient.graphql(discussionQuery, {
           owner: repoParts.owner,
           repo: repoParts.repo,
           number: itemNumber,
@@ -585,10 +593,10 @@ async function main(config = {}) {
           throw new Error(`${ERR_NOT_FOUND}: Discussion #${itemNumber} not found in ${itemRepo}`);
         }
 
-        comment = await commentOnDiscussion(github, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
+        comment = await commentOnDiscussion(githubClient, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
       } else {
         // Use REST API for issues/PRs
-        const { data } = await github.rest.issues.createComment({
+        const { data } = await githubClient.rest.issues.createComment({
           owner: repoParts.owner,
           repo: repoParts.repo,
           issue_number: itemNumber,
@@ -644,7 +652,7 @@ async function main(config = {}) {
               }
             }
           `;
-          const queryResult = await github.graphql(discussionQuery, {
+          const queryResult = await githubClient.graphql(discussionQuery, {
             owner: repoParts.owner,
             repo: repoParts.repo,
             number: itemNumber,
@@ -656,7 +664,7 @@ async function main(config = {}) {
           }
 
           core.info(`Found discussion #${itemNumber}, adding comment...`);
-          const comment = await commentOnDiscussion(github, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
+          const comment = await commentOnDiscussion(githubClient, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
 
           core.info(`Created comment on discussion: ${comment.html_url}`);
 

--- a/actions/setup/js/add_labels.cjs
+++ b/actions/setup/js/add_labels.cjs
@@ -36,6 +36,14 @@ async function main(config = {}) {
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
 
+  // Setup GitHub client - use custom token if provided, otherwise use global github object
+  let githubClient = github;
+  if (config["github-token"]) {
+    core.info("Using custom GitHub token for add_labels handler");
+    const { getOctokit } = await import("@actions/github");
+    githubClient = getOctokit(config["github-token"]);
+  }
+
   core.info(`Add labels configuration: max=${maxCount}`);
   if (allowedLabels.length > 0) {
     core.info(`Allowed labels: ${allowedLabels.join(", ")}`);
@@ -161,7 +169,7 @@ async function main(config = {}) {
     }
 
     try {
-      await github.rest.issues.addLabels({
+      await githubClient.rest.issues.addLabels({
         owner: repoParts.owner,
         repo: repoParts.repo,
         issue_number: itemNumber,


### PR DESCRIPTION
## Summary

- Added support for a custom `github-token` config option in `add_comment` and `add_labels` handlers
- When a custom token is provided, a dedicated Octokit client is created via `getOctokit`; otherwise, the global `github` object is used as a fallback
- All GitHub API calls (REST and GraphQL) within both handlers now use the resolved `githubClient`
