### PR TITLE
chore: remove dead cli functions (batch 11)

### DIFF
--- a/DEADCODE.md
+++ b/DEADCODE.md
@@ -36,6 +36,8 @@ make fmt
 - `compiler.ParseWorkflowString`
 - `compiler.CompileToYAML`
 
+**`pkg/console/console_wasm.go`** — this file provides WASM-specific stub implementations of many `pkg/console` functions (gated with `//go:build js || wasm`). Before deleting any function from `pkg/console/`, `grep` for it in `console_wasm.go`. If the function is called there, either inline the logic in `console_wasm.go` or delete the call. Batch 10 mistake: deleted `renderTreeSimple` from `render.go` but `console_wasm.go`'s `RenderTree` still called it, breaking the WASM build. Fix: replaced the `RenderTree` body in `console_wasm.go` with an inlined closure that no longer calls the deleted helper.
+
 **`compiler_test_helpers.go`** — shows 3 dead functions but serves as shared test infrastructure for ≥15 test files. Do not delete.
 
 **Constant/embed rescue** — Some otherwise-dead files contain live constants or `//go:embed` directives. Extract them before deleting the file.
@@ -163,7 +165,9 @@ For each batch:
 - [ ] Delete the function
 - [ ] Delete test functions that exclusively call the deleted function (not shared helpers)
 - [ ] Check for now-unused imports in edited files
+- [ ] If editing `pkg/console/`, check `pkg/console/console_wasm.go` for calls to the deleted functions
 - [ ] `go build ./...`
+- [ ] `GOARCH=wasm GOOS=js go build ./pkg/console/...` (if `pkg/console/` was touched)
 - [ ] `go vet ./...`
 - [ ] `go vet -tags=integration ./...`
 - [ ] `make fmt`

--- a/pkg/cli/completions.go
+++ b/pkg/cli/completions.go
@@ -118,43 +118,6 @@ func CompleteEngineNames(cmd *cobra.Command, args []string, toComplete string) (
 	return filtered, cobra.ShellCompDirectiveNoFileComp
 }
 
-// CompleteMCPServerNames provides shell completion for MCP server names
-// If a workflow is specified, it returns the MCP servers defined in that workflow
-func CompleteMCPServerNames(workflowFile string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		completionsLog.Printf("Completing MCP server names for workflow: %s, prefix: %s", workflowFile, toComplete)
-
-		if workflowFile == "" {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// Resolve the workflow path
-		workflowPath, err := ResolveWorkflowPath(workflowFile)
-		if err != nil {
-			completionsLog.Printf("Failed to resolve workflow path: %v", err)
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// Load MCP configs from the workflow
-		// The second parameter is the server filter - empty string means no filtering
-		_, mcpConfigs, err := loadWorkflowMCPConfigs(workflowPath, "" /* serverFilter */)
-		if err != nil {
-			completionsLog.Printf("Failed to load MCP configs: %v", err)
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		servers := sliceutil.FilterMap(mcpConfigs,
-			func(config parser.MCPServerConfig) bool {
-				return toComplete == "" || strings.HasPrefix(config.Name, toComplete)
-			},
-			func(config parser.MCPServerConfig) string { return config.Name },
-		)
-
-		completionsLog.Printf("Found %d matching MCP servers", len(servers))
-		return servers, cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
 // CompleteDirectories provides shell completion for directory paths
 func CompleteDirectories(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	completionsLog.Printf("Completing directories with prefix: %s", toComplete)

--- a/pkg/cli/docker_images.go
+++ b/pkg/cli/docker_images.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -245,15 +243,6 @@ func ResetDockerPullState() {
 	pullState.mockAvailableInUse = false
 }
 
-// ValidateMCPServerDockerAvailability validates that Docker is available for MCP server operations
-// that require static analysis tools
-func ValidateMCPServerDockerAvailability() error {
-	if !isDockerAvailable() {
-		return errors.New("docker is not available - required for zizmor, poutine, and actionlint static analysis tools")
-	}
-	return nil
-}
-
 // SetDockerImageDownloading sets the downloading state for an image (for testing)
 func SetDockerImageDownloading(image string, downloading bool) {
 	pullState.mu.Lock()
@@ -271,13 +260,4 @@ func SetMockImageAvailable(image string, available bool) {
 	defer pullState.mu.Unlock()
 	pullState.mockAvailableInUse = true
 	pullState.mockAvailable[image] = available
-}
-
-// PrintDockerPullStatus prints the current pull status to stderr (for debugging)
-func PrintDockerPullStatus() {
-	pullState.mu.RLock()
-	defer pullState.mu.RUnlock()
-	if len(pullState.downloading) > 0 {
-		fmt.Fprintf(os.Stderr, "Currently downloading images: %v\n", pullState.downloading)
-	}
 }


### PR DESCRIPTION
Removes 6 dead functions/types from `pkg/cli/`:

**pkg/cli/docker_images.go**
- `ValidateMCPServerDockerAvailability` — not used in production or tests
- `PrintDockerPullStatus` — not used in production or tests
- Removed unused `fmt` and `os` imports

**pkg/cli/completions.go**
- `CompleteMCPServerNames` — not used in production or tests

**pkg/cli/preconditions.go**
- `PreconditionCheckResult` type — only used by the deleted function
- `CheckInteractivePreconditions` — not used in production or tests
- `checkGitRepositoryShared` — only called by the deleted `CheckInteractivePreconditions`

Note: Other dead functions in `pkg/cli/` (e.g., `EnableWorkflows`, `ResetDockerPullState`, etc.) were kept because they are used as test helpers or explicitly tested in unit tests.