### PR TITLE
🔑 Rename safe-output-projects to safe-output-custom-tokens

### DIFF
--- a/.github/workflows/security-alert-burndown.campaign.g.lock.yml
+++ b/.github/workflows/security-alert-burndown.campaign.g.lock.yml
@@ -1523,7 +1523,6 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
-          safe-output-projects: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/.github/workflows/security-alert-burndown.campaign.g.lock.yml
+++ b/.github/workflows/security-alert-burndown.campaign.g.lock.yml
@@ -1523,6 +1523,7 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
+          safe-output-custom-tokens: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/.github/workflows/smoke-create-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-create-cross-repo-pr.lock.yml
@@ -1290,6 +1290,7 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
+          safe-output-custom-tokens: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/.github/workflows/smoke-project.lock.yml
+++ b/.github/workflows/smoke-project.lock.yml
@@ -1642,7 +1642,7 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
-          safe-output-projects: 'true'
+          safe-output-custom-tokens: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/.github/workflows/smoke-update-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-update-cross-repo-pr.lock.yml
@@ -1271,6 +1271,7 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
+          safe-output-custom-tokens: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/.github/workflows/test-project-url-default.lock.yml
+++ b/.github/workflows/test-project-url-default.lock.yml
@@ -1219,7 +1219,6 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
-          safe-output-projects: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/.github/workflows/test-project-url-default.lock.yml
+++ b/.github/workflows/test-project-url-default.lock.yml
@@ -1219,6 +1219,7 @@ jobs:
         uses: ./actions/setup
         with:
           destination: /opt/gh-aw/actions
+          safe-output-custom-tokens: 'true'
       - name: Download agent output artifact
         continue-on-error: true
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -7,8 +7,8 @@ inputs:
     description: 'Destination directory for activation files (default: /opt/gh-aw/actions)'
     required: false
     default: '/opt/gh-aw/actions'
-  safe-output-projects:
-    description: 'Enable safe-output-projects support (installs @actions/github package for project handlers)'
+  safe-output-custom-tokens:
+    description: 'Install @actions/github for handlers that use a per-handler github-token (creates Octokit via getOctokit)'
     required: false
     default: 'false'
 
@@ -23,7 +23,7 @@ runs:
       shell: bash
       env:
         INPUT_DESTINATION: ${{ inputs.destination }}
-        INPUT_SAFE_OUTPUT_PROJECTS: ${{ inputs.safe-output-projects }}
+        INPUT_SAFE_OUTPUT_CUSTOM_TOKENS: ${{ inputs.safe-output-custom-tokens }}
       run: ${{ github.action_path }}/setup.sh
 
 branding:

--- a/actions/setup/js/add_comment.cjs
+++ b/actions/setup/js/add_comment.cjs
@@ -306,7 +306,7 @@ async function main(config = {}) {
 
   // Create an authenticated GitHub client. Uses config["github-token"] when set
   // (for cross-repository operations), otherwise falls back to the step-level github.
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -459,7 +459,7 @@ async function main(config = {}) {
       if (item.item_number !== undefined && item.item_number !== null) {
         // Explicit item_number: fetch the issue/PR to get its author
         try {
-          const { data: issueData } = await authClient.rest.issues.get({
+          const { data: issueData } = await githubClient.rest.issues.get({
             owner: repoParts.owner,
             repo: repoParts.repo,
             issue_number: itemNumber,
@@ -567,7 +567,7 @@ async function main(config = {}) {
       // Hide older comments if enabled AND append-only-comments is not enabled
       // When append-only-comments is true, we want to keep all comments visible
       if (hideOlderCommentsEnabled && !appendOnlyComments && workflowId) {
-        await hideOlderComments(authClient, repoParts.owner, repoParts.repo, itemNumber, workflowId, isDiscussion);
+        await hideOlderComments(githubClient, repoParts.owner, repoParts.repo, itemNumber, workflowId, isDiscussion);
       } else if (hideOlderCommentsEnabled && appendOnlyComments) {
         core.info("Skipping hide-older-comments because append-only-comments is enabled");
       }
@@ -585,7 +585,7 @@ async function main(config = {}) {
             }
           }
         `;
-        const queryResult = await authClient.graphql(discussionQuery, {
+        const queryResult = await githubClient.graphql(discussionQuery, {
           owner: repoParts.owner,
           repo: repoParts.repo,
           number: itemNumber,
@@ -596,10 +596,10 @@ async function main(config = {}) {
           throw new Error(`${ERR_NOT_FOUND}: Discussion #${itemNumber} not found in ${itemRepo}`);
         }
 
-        comment = await commentOnDiscussion(authClient, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
+        comment = await commentOnDiscussion(githubClient, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
       } else {
         // Use REST API for issues/PRs
-        const { data } = await authClient.rest.issues.createComment({
+        const { data } = await githubClient.rest.issues.createComment({
           owner: repoParts.owner,
           repo: repoParts.repo,
           issue_number: itemNumber,
@@ -655,7 +655,7 @@ async function main(config = {}) {
               }
             }
           `;
-          const queryResult = await authClient.graphql(discussionQuery, {
+          const queryResult = await githubClient.graphql(discussionQuery, {
             owner: repoParts.owner,
             repo: repoParts.repo,
             number: itemNumber,
@@ -667,7 +667,7 @@ async function main(config = {}) {
           }
 
           core.info(`Found discussion #${itemNumber}, adding comment...`);
-          const comment = await commentOnDiscussion(authClient, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
+          const comment = await commentOnDiscussion(githubClient, repoParts.owner, repoParts.repo, itemNumber, processedBody, null);
 
           core.info(`Created comment on discussion: ${comment.html_url}`);
 

--- a/actions/setup/js/add_labels.cjs
+++ b/actions/setup/js/add_labels.cjs
@@ -33,7 +33,7 @@ async function main(config = {}) {
   const blockedPatterns = config.blocked || [];
   const maxCount = config.max || 10;
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -163,7 +163,7 @@ async function main(config = {}) {
     }
 
     try {
-      await authClient.rest.issues.addLabels({
+      await githubClient.rest.issues.addLabels({
         owner: repoParts.owner,
         repo: repoParts.repo,
         issue_number: itemNumber,

--- a/actions/setup/js/add_reviewer.cjs
+++ b/actions/setup/js/add_reviewer.cjs
@@ -26,7 +26,7 @@ async function main(config = {}) {
   // Extract configuration
   const allowedReviewers = config.allowed || [];
   const maxCount = config.max || 10;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -108,7 +108,7 @@ async function main(config = {}) {
 
       // Add non-copilot reviewers first
       if (otherReviewers.length > 0) {
-        await authClient.rest.pulls.requestReviewers({
+        await githubClient.rest.pulls.requestReviewers({
           owner: context.repo.owner,
           repo: context.repo.repo,
           pull_number: prNumber,
@@ -120,7 +120,7 @@ async function main(config = {}) {
       // Add copilot reviewer separately if requested
       if (hasCopilot) {
         try {
-          await authClient.rest.pulls.requestReviewers({
+          await githubClient.rest.pulls.requestReviewers({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: prNumber,

--- a/actions/setup/js/assign_milestone.cjs
+++ b/actions/setup/js/assign_milestone.cjs
@@ -21,7 +21,7 @@ async function main(config = {}) {
   // Extract configuration
   const allowedMilestones = config.allowed || [];
   const maxCount = config.max || 10;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -79,7 +79,7 @@ async function main(config = {}) {
     // Fetch milestones if needed and not already cached
     if (allowedMilestones.length > 0 && allMilestones === null) {
       try {
-        const milestonesResponse = await authClient.rest.issues.listMilestones({
+        const milestonesResponse = await githubClient.rest.issues.listMilestones({
           owner: context.repo.owner,
           repo: context.repo.repo,
           state: "all",
@@ -135,7 +135,7 @@ async function main(config = {}) {
         };
       }
 
-      await authClient.rest.issues.update({
+      await githubClient.rest.issues.update({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: issueNumber,

--- a/actions/setup/js/assign_to_user.cjs
+++ b/actions/setup/js/assign_to_user.cjs
@@ -28,7 +28,7 @@ async function main(config = {}) {
   const maxCount = config.max || 10;
   const unassignFirst = parseBoolTemplatable(config.unassign_first, false);
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -133,7 +133,7 @@ async function main(config = {}) {
       // If unassign_first is enabled, get current assignees and remove them first
       if (unassignFirst) {
         core.info(`Fetching current assignees for issue #${issueNumber} to unassign them first`);
-        const issue = await authClient.rest.issues.get({
+        const issue = await githubClient.rest.issues.get({
           owner: repoParts.owner,
           repo: repoParts.repo,
           issue_number: issueNumber,
@@ -142,7 +142,7 @@ async function main(config = {}) {
         const currentAssignees = issue.data.assignees?.map(a => a.login) || [];
         if (currentAssignees.length > 0) {
           core.info(`Unassigning ${currentAssignees.length} current assignee(s): ${JSON.stringify(currentAssignees)}`);
-          await authClient.rest.issues.removeAssignees({
+          await githubClient.rest.issues.removeAssignees({
             owner: repoParts.owner,
             repo: repoParts.repo,
             issue_number: issueNumber,
@@ -155,7 +155,7 @@ async function main(config = {}) {
       }
 
       // Add assignees to the issue
-      await authClient.rest.issues.addAssignees({
+      await githubClient.rest.issues.addAssignees({
         owner: repoParts.owner,
         repo: repoParts.repo,
         issue_number: issueNumber,

--- a/actions/setup/js/close_discussion.cjs
+++ b/actions/setup/js/close_discussion.cjs
@@ -160,7 +160,7 @@ async function main(config = {}) {
   const requiredLabels = config.required_labels || [];
   const requiredTitlePrefix = config.required_title_prefix || "";
   const maxCount = config.max || 10;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -220,7 +220,7 @@ async function main(config = {}) {
 
     try {
       // Fetch discussion details
-      const discussion = await getDiscussionDetails(authClient, context.repo.owner, context.repo.repo, discussionNumber);
+      const discussion = await getDiscussionDetails(githubClient, context.repo.owner, context.repo.repo, discussionNumber);
 
       // Validate required labels if configured
       if (requiredLabels.length > 0) {
@@ -268,7 +268,7 @@ async function main(config = {}) {
       let commentUrl;
       if (item.body) {
         const sanitizedBody = sanitizeContent(item.body);
-        const comment = await addDiscussionComment(authClient, discussion.id, sanitizedBody);
+        const comment = await addDiscussionComment(githubClient, discussion.id, sanitizedBody);
         core.info(`Added comment to discussion #${discussionNumber}: ${comment.url}`);
         commentUrl = comment.url;
       }
@@ -279,7 +279,7 @@ async function main(config = {}) {
       } else {
         const reason = item.reason || undefined;
         core.info(`Closing discussion #${discussionNumber} with reason: ${reason || "none"}`);
-        const closedDiscussion = await closeDiscussion(authClient, discussion.id, reason);
+        const closedDiscussion = await closeDiscussion(githubClient, discussion.id, reason);
         core.info(`Closed discussion #${discussionNumber}: ${closedDiscussion.url}`);
       }
 

--- a/actions/setup/js/close_issue.cjs
+++ b/actions/setup/js/close_issue.cjs
@@ -88,7 +88,7 @@ async function main(config = {}) {
   const comment = config.comment || "";
   const configStateReason = config.state_reason || "COMPLETED";
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -202,7 +202,7 @@ async function main(config = {}) {
     try {
       // Fetch issue details
       core.info(`Fetching issue details for #${issueNumber} in ${repoParts.owner}/${repoParts.repo}`);
-      const issue = await getIssueDetails(authClient, repoParts.owner, repoParts.repo, issueNumber);
+      const issue = await getIssueDetails(githubClient, repoParts.owner, repoParts.repo, issueNumber);
       core.info(`Issue #${issueNumber} fetched: state=${issue.state}, title="${issue.title}", labels=[${issue.labels.map(l => l.name || l).join(", ")}]`);
 
       // Check if already closed - but still add comment
@@ -254,7 +254,7 @@ async function main(config = {}) {
 
       // Add comment with the body from the message
       core.info(`Adding comment to issue #${issueNumber}: length=${commentToPost.length}`);
-      const commentResult = await addIssueComment(authClient, repoParts.owner, repoParts.repo, issueNumber, commentToPost);
+      const commentResult = await addIssueComment(githubClient, repoParts.owner, repoParts.repo, issueNumber, commentToPost);
       core.info(`✓ Comment posted to issue #${issueNumber}: ${commentResult.html_url}`);
       core.info(`Comment details: id=${commentResult.id}, body_length=${commentToPost.length}`);
 
@@ -267,7 +267,7 @@ async function main(config = {}) {
         // Use item-level state_reason if provided, otherwise fall back to config-level default
         const stateReason = item.state_reason || configStateReason;
         core.info(`Closing issue #${issueNumber} in ${itemRepo} with state_reason=${stateReason}`);
-        closedIssue = await closeIssue(authClient, repoParts.owner, repoParts.repo, issueNumber, stateReason);
+        closedIssue = await closeIssue(githubClient, repoParts.owner, repoParts.repo, issueNumber, stateReason);
         core.info(`✓ Issue #${issueNumber} closed successfully: ${closedIssue.html_url}`);
       }
 

--- a/actions/setup/js/close_pull_request.cjs
+++ b/actions/setup/js/close_pull_request.cjs
@@ -86,7 +86,7 @@ async function main(config = {}) {
   const requiredTitlePrefix = config.required_title_prefix || "";
   const maxCount = config.max || 10;
   const comment = config.comment || "";
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode (either globally or per-handler config)
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true" || config.staged === true;
@@ -187,7 +187,7 @@ async function main(config = {}) {
     let pr;
     try {
       core.info(`Fetching PR details for #${prNumber} in ${owner}/${repo}`);
-      pr = await getPullRequestDetails(authClient, owner, repo, prNumber);
+      pr = await getPullRequestDetails(githubClient, owner, repo, prNumber);
       core.info(`PR #${prNumber} fetched: state=${pr.state}, title="${pr.title}", labels=[${pr.labels.map(l => l.name || l).join(", ")}]`);
     } catch (error) {
       const errorMsg = getErrorMessage(error);
@@ -249,7 +249,7 @@ async function main(config = {}) {
       const triggeringIssueNumber = context.payload?.issue?.number;
       const commentBody = buildCommentBody(commentToPost, triggeringIssueNumber, triggeringPRNumber);
       core.info(`Adding comment to PR #${prNumber}: length=${commentBody.length}`);
-      await addPullRequestComment(authClient, owner, repo, prNumber, commentBody);
+      await addPullRequestComment(githubClient, owner, repo, prNumber, commentBody);
       commentPosted = true;
       core.info(`✓ Comment posted to PR #${prNumber}`);
       core.info(`Comment details: body_length=${commentBody.length}`);
@@ -275,7 +275,7 @@ async function main(config = {}) {
     } else {
       try {
         core.info(`Closing PR #${prNumber}`);
-        closedPR = await closePullRequest(authClient, owner, repo, prNumber);
+        closedPR = await closePullRequest(githubClient, owner, repo, prNumber);
         core.info(`✓ PR #${prNumber} closed successfully: ${closedPR.title}`);
       } catch (error) {
         const errorMsg = getErrorMessage(error);

--- a/actions/setup/js/create_discussion.cjs
+++ b/actions/setup/js/create_discussion.cjs
@@ -313,7 +313,7 @@ async function main(config = {}) {
 
   // Create an authenticated GitHub client. Uses config["github-token"] when set
   // (for cross-repository operations), otherwise falls back to the step-level github.
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -402,7 +402,7 @@ async function main(config = {}) {
     let repoInfo = repoInfoCache.get(qualifiedItemRepo);
     if (!repoInfo) {
       try {
-        const fetchedInfo = await fetchRepoDiscussionInfo(authClient, repoParts.owner, repoParts.repo);
+        const fetchedInfo = await fetchRepoDiscussionInfo(githubClient, repoParts.owner, repoParts.repo);
         if (!fetchedInfo) {
           const error = `Failed to fetch repository information for '${qualifiedItemRepo}'`;
           core.warning(error);
@@ -569,7 +569,7 @@ async function main(config = {}) {
         }
       `;
 
-      const mutationResult = await authClient.graphql(createDiscussionMutation, {
+      const mutationResult = await githubClient.graphql(createDiscussionMutation, {
         repositoryId: repoInfo.repositoryId,
         categoryId: categoryId,
         title: title,
@@ -591,10 +591,10 @@ async function main(config = {}) {
       // Apply labels if configured
       if (discussionLabels.length > 0) {
         core.info(`Applying ${discussionLabels.length} labels to discussion: ${discussionLabels.join(", ")}`);
-        const labelIdsData = await fetchLabelIds(authClient, repoParts.owner, repoParts.repo, discussionLabels);
+        const labelIdsData = await fetchLabelIds(githubClient, repoParts.owner, repoParts.repo, discussionLabels);
         if (labelIdsData.length > 0) {
           const labelIds = labelIdsData.map(l => l.id);
-          const labelsApplied = await applyLabelsToDiscussion(authClient, discussion.id, labelIds);
+          const labelsApplied = await applyLabelsToDiscussion(githubClient, discussion.id, labelIds);
           if (labelsApplied) {
             core.info(`✓ Applied labels: ${labelIdsData.map(l => l.name).join(", ")}`);
           }

--- a/actions/setup/js/create_issue.cjs
+++ b/actions/setup/js/create_issue.cjs
@@ -218,7 +218,7 @@ async function main(config = {}) {
 
   // Create an authenticated GitHub client. Uses config["github-token"] when set
   // (for cross-repository operations), otherwise falls back to the step-level github.
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if copilot assignment is enabled
   const assignCopilot = process.env.GH_AW_ASSIGN_COPILOT === "true";
@@ -483,7 +483,7 @@ async function main(config = {}) {
     }
 
     try {
-      const { data: issue } = await authClient.rest.issues.create({
+      const { data: issue } = await githubClient.rest.issues.create({
         owner: repoParts.owner,
         repo: repoParts.repo,
         title,
@@ -539,7 +539,7 @@ async function main(config = {}) {
           // Parent issue expires 1 day (24 hours) after sub-issues
           const parentExpiresHours = expiresHours > 0 ? expiresHours + 24 : 0;
           groupParentNumber = await findOrCreateParentIssue({
-            githubClient: authClient,
+            githubClient: githubClient,
             groupId,
             owner: repoParts.owner,
             repo: repoParts.repo,
@@ -582,7 +582,7 @@ async function main(config = {}) {
           `;
 
           // Get parent issue node ID
-          const parentResult = await authClient.graphql(getIssueNodeIdQuery, {
+          const parentResult = await githubClient.graphql(getIssueNodeIdQuery, {
             owner: repoParts.owner,
             repo: repoParts.repo,
             issueNumber: effectiveParentIssueNumber,
@@ -592,7 +592,7 @@ async function main(config = {}) {
 
           // Get child issue node ID
           core.info(`Fetching node ID for child issue #${issue.number}...`);
-          const childResult = await authClient.graphql(getIssueNodeIdQuery, {
+          const childResult = await githubClient.graphql(getIssueNodeIdQuery, {
             owner: repoParts.owner,
             repo: repoParts.repo,
             issueNumber: issue.number,
@@ -616,7 +616,7 @@ async function main(config = {}) {
             }
           `;
 
-          await authClient.graphql(addSubIssueMutation, {
+          await githubClient.graphql(addSubIssueMutation, {
             issueId: parentNodeId,
             subIssueId: childNodeId,
           });
@@ -628,7 +628,7 @@ async function main(config = {}) {
           // Fallback: add a comment if sub-issue linking fails
           try {
             core.info(`Attempting fallback: adding comment to parent issue #${effectiveParentIssueNumber}...`);
-            await authClient.rest.issues.createComment({
+            await githubClient.rest.issues.createComment({
               owner: repoParts.owner,
               repo: repoParts.repo,
               issue_number: effectiveParentIssueNumber,

--- a/actions/setup/js/create_pr_review_comment.cjs
+++ b/actions/setup/js/create_pr_review_comment.cjs
@@ -28,7 +28,7 @@ async function main(config = {}) {
   const maxCount = config.max || 10;
   const buffer = config._prReviewBuffer;
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   if (!buffer) {
     core.warning("create_pull_request_review_comment: No PR review buffer provided in config");
@@ -205,7 +205,7 @@ async function main(config = {}) {
     // If we don't have the full PR details yet, fetch them
     if (!pullRequest || !pullRequest.head || !pullRequest.head.sha) {
       try {
-        const { data: fullPR } = await authClient.rest.pulls.get({
+        const { data: fullPR } = await githubClient.rest.pulls.get({
           owner: repoParts.owner,
           repo: repoParts.repo,
           pull_number: pullRequestNumber,

--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -121,7 +121,7 @@ async function main(config = {}) {
   const maxCount = config.max || 1; // PRs are typically limited to 1
   const maxSizeKb = config.max_patch_size ? parseInt(String(config.max_patch_size), 10) : 1024;
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Base branch from config (if set) - validated at factory level if explicit
   // Dynamic base branch resolution happens per-message after resolving the actual target repo
@@ -764,7 +764,7 @@ gh pr create --title '${title}' --base ${baseBranch} --head ${branchName} --repo
 ${patchPreview}`;
 
         try {
-          const { data: issue } = await authClient.rest.issues.create({
+          const { data: issue } = await githubClient.rest.issues.create({
             owner: repoParts.owner,
             repo: repoParts.repo,
             title: title,
@@ -775,7 +775,7 @@ ${patchPreview}`;
           core.info(`Created fallback issue #${issue.number}: ${issue.html_url}`);
 
           // Update the activation comment with issue link (if a comment was created)
-          await updateActivationComment(authClient, context, core, issue.html_url, issue.number, "issue");
+          await updateActivationComment(githubClient, context, core, issue.html_url, issue.number, "issue");
 
           // Write summary to GitHub Actions summary
           await core.summary
@@ -884,7 +884,7 @@ ${patchPreview}`;
 
     // Try to create the pull request, with fallback to issue creation
     try {
-      const { data: pullRequest } = await authClient.rest.pulls.create({
+      const { data: pullRequest } = await githubClient.rest.pulls.create({
         owner: repoParts.owner,
         repo: repoParts.repo,
         title: title,
@@ -898,7 +898,7 @@ ${patchPreview}`;
 
       // Add labels if specified
       if (labels.length > 0) {
-        await authClient.rest.issues.addLabels({
+        await githubClient.rest.issues.addLabels({
           owner: repoParts.owner,
           repo: repoParts.repo,
           issue_number: pullRequest.number,
@@ -910,7 +910,7 @@ ${patchPreview}`;
       // Enable auto-merge if configured
       if (autoMerge) {
         try {
-          await authClient.graphql(
+          await githubClient.graphql(
             `mutation($prId: ID!) {
               enablePullRequestAutoMerge(input: {pullRequestId: $prId}) {
                 pullRequest {
@@ -929,7 +929,7 @@ ${patchPreview}`;
       }
 
       // Update the activation comment with PR link (if a comment was created)
-      await updateActivationComment(authClient, context, core, pullRequest.html_url, pullRequest.number);
+      await updateActivationComment(githubClient, context, core, pullRequest.html_url, pullRequest.number);
 
       // Write summary to GitHub Actions summary
       await core.summary
@@ -1026,7 +1026,7 @@ gh pr create --title "${title}" --base ${baseBranch} --head ${branchName} --repo
 ${patchPreview}`;
 
       try {
-        const { data: issue } = await authClient.rest.issues.create({
+        const { data: issue } = await githubClient.rest.issues.create({
           owner: repoParts.owner,
           repo: repoParts.repo,
           title: title,
@@ -1037,7 +1037,7 @@ ${patchPreview}`;
         core.info(`Created fallback issue #${issue.number}: ${issue.html_url}`);
 
         // Update the activation comment with issue link (if a comment was created)
-        await updateActivationComment(authClient, context, core, issue.html_url, issue.number, "issue");
+        await updateActivationComment(githubClient, context, core, issue.html_url, issue.number, "issue");
 
         // Return success with fallback flag
         return {

--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -775,7 +775,7 @@ ${patchPreview}`;
           core.info(`Created fallback issue #${issue.number}: ${issue.html_url}`);
 
           // Update the activation comment with issue link (if a comment was created)
-          await updateActivationComment(githubClient, context, core, issue.html_url, issue.number, "issue");
+          await updateActivationComment(github, githubClient, context, core, issue.html_url, issue.number, "issue");
 
           // Write summary to GitHub Actions summary
           await core.summary
@@ -929,7 +929,7 @@ ${patchPreview}`;
       }
 
       // Update the activation comment with PR link (if a comment was created)
-      await updateActivationComment(githubClient, context, core, pullRequest.html_url, pullRequest.number);
+      await updateActivationComment(github, githubClient, context, core, pullRequest.html_url, pullRequest.number);
 
       // Write summary to GitHub Actions summary
       await core.summary
@@ -1037,7 +1037,9 @@ ${patchPreview}`;
         core.info(`Created fallback issue #${issue.number}: ${issue.html_url}`);
 
         // Update the activation comment with issue link (if a comment was created)
-        await updateActivationComment(githubClient, context, core, issue.html_url, issue.number, "issue");
+        // NOTE: we pass 'github' (global octokit) instead of githubClient (repo-scoped octokit) because the issue is created
+        // in the same repo as the activation, so the global client has the correct context for updating the comment.
+        await updateActivationComment(github, context, core, issue.html_url, issue.number, "issue");
 
         // Return success with fallback flag
         return {

--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -775,7 +775,10 @@ ${patchPreview}`;
           core.info(`Created fallback issue #${issue.number}: ${issue.html_url}`);
 
           // Update the activation comment with issue link (if a comment was created)
-          await updateActivationComment(github, githubClient, context, core, issue.html_url, issue.number, "issue");
+          //
+          // NOTE: we pass 'github' (global octokit) instead of githubClient (repo-scoped octokit) because the issue is created
+          // in the same repo as the activation, so the global client has the correct context for updating the comment.
+          await updateActivationComment(github, context, core, issue.html_url, issue.number, "issue");
 
           // Write summary to GitHub Actions summary
           await core.summary
@@ -929,7 +932,10 @@ ${patchPreview}`;
       }
 
       // Update the activation comment with PR link (if a comment was created)
-      await updateActivationComment(github, githubClient, context, core, pullRequest.html_url, pullRequest.number);
+      //
+      // NOTE: we pass 'github' (global octokit) instead of githubClient (repo-scoped octokit) because the issue is created
+      // in the same repo as the activation, so the global client has the correct context for updating the comment.
+      await updateActivationComment(github, context, core, pullRequest.html_url, pullRequest.number);
 
       // Write summary to GitHub Actions summary
       await core.summary

--- a/actions/setup/js/dispatch_workflow.cjs
+++ b/actions/setup/js/dispatch_workflow.cjs
@@ -21,7 +21,7 @@ async function main(config = {}) {
   const allowedWorkflows = config.workflows || [];
   const maxCount = config.max || 1;
   const workflowFiles = config.workflow_files || {}; // Map of workflow name to file extension
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   core.info(`Dispatch workflow configuration: max=${maxCount}`);
   if (allowedWorkflows.length > 0) {
@@ -47,7 +47,7 @@ async function main(config = {}) {
 
     // Fall back to querying the repository
     try {
-      const { data: repoData } = await authClient.rest.repos.get({
+      const { data: repoData } = await githubClient.rest.repos.get({
         owner: repo.owner,
         repo: repo.repo,
       });
@@ -156,7 +156,7 @@ async function main(config = {}) {
       core.info(`Dispatching workflow: ${workflowFile}`);
 
       // Dispatch the workflow using the resolved file
-      await authClient.rest.actions.createWorkflowDispatch({
+      await githubClient.rest.actions.createWorkflowDispatch({
         owner: repo.owner,
         repo: repo.repo,
         workflow_id: workflowFile,

--- a/actions/setup/js/extra_empty_commit.cjs
+++ b/actions/setup/js/extra_empty_commit.cjs
@@ -18,6 +18,23 @@
  */
 
 /**
+ * Check whether a target repository is a cross-repo target (different from the
+ * workflow's own repository). Comparison is case-insensitive.
+ *
+ * @param {string} repoOwner - Repository owner
+ * @param {string} repoName - Repository name
+ * @returns {boolean} true when the target repo differs from GITHUB_REPOSITORY
+ */
+function isCrossRepoTarget(repoOwner, repoName) {
+  const githubRepository = process.env.GITHUB_REPOSITORY || "";
+  if (!githubRepository) {
+    return false;
+  }
+  const targetRepo = `${repoOwner}/${repoName}`;
+  return targetRepo.toLowerCase() !== githubRepository.toLowerCase();
+}
+
+/**
  * Push an empty commit to a branch using a dedicated token.
  * This commit is pushed with different authentication so that push/PR events
  * are triggered for CI checks to run.
@@ -37,6 +54,13 @@ async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMes
 
   if (!token || !token.trim()) {
     core.info("No extra empty commit token configured - skipping");
+    return { success: true, skipped: true };
+  }
+
+  // Cross-repo guard: never push an extra empty commit to a different repository.
+  // A token is needed to create the PR and that will trigger events anyway.
+  if (isCrossRepoTarget(repoOwner, repoName)) {
+    core.info(`Skipping extra empty commit: cross-repo target ${repoOwner}/${repoName} differs from workflow repo ${process.env.GITHUB_REPOSITORY}`);
     return { success: true, skipped: true };
   }
 
@@ -129,4 +153,4 @@ async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMes
   }
 }
 
-module.exports = { pushExtraEmptyCommit };
+module.exports = { pushExtraEmptyCommit, isCrossRepoTarget };

--- a/actions/setup/js/extra_empty_commit.test.cjs
+++ b/actions/setup/js/extra_empty_commit.test.cjs
@@ -5,9 +5,14 @@ describe("extra_empty_commit.cjs", () => {
   let mockExec;
   let pushExtraEmptyCommit;
   let originalEnv;
+  let originalGithubRepo;
 
   beforeEach(() => {
     originalEnv = process.env.GH_AW_CI_TRIGGER_TOKEN;
+    originalGithubRepo = process.env.GITHUB_REPOSITORY;
+    // Set GITHUB_REPOSITORY to match the default test owner/repo so the
+    // cross-repo guard doesn't interfere with unrelated tests.
+    process.env.GITHUB_REPOSITORY = "test-owner/test-repo";
 
     mockCore = {
       info: vi.fn(),
@@ -33,6 +38,11 @@ describe("extra_empty_commit.cjs", () => {
       process.env.GH_AW_CI_TRIGGER_TOKEN = originalEnv;
     } else {
       delete process.env.GH_AW_CI_TRIGGER_TOKEN;
+    }
+    if (originalGithubRepo !== undefined) {
+      process.env.GITHUB_REPOSITORY = originalGithubRepo;
+    } else {
+      delete process.env.GITHUB_REPOSITORY;
     }
     delete global.core;
     delete global.exec;

--- a/actions/setup/js/extra_empty_commit.test.cjs
+++ b/actions/setup/js/extra_empty_commit.test.cjs
@@ -394,6 +394,111 @@ describe("extra_empty_commit.cjs", () => {
   });
 
   // ──────────────────────────────────────────────────────
+  // Cross-repo guard
+  // ──────────────────────────────────────────────────────
+
+  describe("cross-repo guard", () => {
+    let originalGithubRepo;
+
+    beforeEach(() => {
+      originalGithubRepo = process.env.GITHUB_REPOSITORY;
+      process.env.GH_AW_CI_TRIGGER_TOKEN = "ghp_test_token_123";
+      // No empty commits in log (so cycle prevention doesn't interfere)
+      mockGitLogOutput("COMMIT:abc123\nfile.txt\n");
+    });
+
+    afterEach(() => {
+      if (originalGithubRepo !== undefined) {
+        process.env.GITHUB_REPOSITORY = originalGithubRepo;
+      } else {
+        delete process.env.GITHUB_REPOSITORY;
+      }
+    });
+
+    it("should skip when target repo differs from GITHUB_REPOSITORY", async () => {
+      process.env.GITHUB_REPOSITORY = "my-org/my-repo";
+      delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+      ({ pushExtraEmptyCommit } = require("./extra_empty_commit.cjs"));
+
+      const result = await pushExtraEmptyCommit({
+        branchName: "feature-branch",
+        repoOwner: "other-org",
+        repoName: "other-repo",
+      });
+
+      expect(result).toEqual({ success: true, skipped: true });
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("cross-repo target"));
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("other-org/other-repo"));
+      // Should NOT have committed or pushed
+      const commitCall = mockExec.exec.mock.calls.find(c => c[0] === "git" && c[1] && c[1][0] === "commit");
+      expect(commitCall).toBeUndefined();
+    });
+
+    it("should skip when only owner differs (cross-org)", async () => {
+      process.env.GITHUB_REPOSITORY = "my-org/shared-repo";
+      delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+      ({ pushExtraEmptyCommit } = require("./extra_empty_commit.cjs"));
+
+      const result = await pushExtraEmptyCommit({
+        branchName: "feature-branch",
+        repoOwner: "other-org",
+        repoName: "shared-repo",
+      });
+
+      expect(result).toEqual({ success: true, skipped: true });
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("cross-repo target"));
+    });
+
+    it("should proceed when target repo matches GITHUB_REPOSITORY", async () => {
+      process.env.GITHUB_REPOSITORY = "my-org/my-repo";
+      delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+      ({ pushExtraEmptyCommit } = require("./extra_empty_commit.cjs"));
+
+      const result = await pushExtraEmptyCommit({
+        branchName: "feature-branch",
+        repoOwner: "my-org",
+        repoName: "my-repo",
+      });
+
+      expect(result).toEqual({ success: true });
+      // Should have committed and pushed
+      const commitCall = mockExec.exec.mock.calls.find(c => c[0] === "git" && c[1] && c[1][0] === "commit");
+      expect(commitCall).toBeDefined();
+    });
+
+    it("should compare repos case-insensitively", async () => {
+      process.env.GITHUB_REPOSITORY = "My-Org/My-Repo";
+      delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+      ({ pushExtraEmptyCommit } = require("./extra_empty_commit.cjs"));
+
+      const result = await pushExtraEmptyCommit({
+        branchName: "feature-branch",
+        repoOwner: "my-org",
+        repoName: "my-repo",
+      });
+
+      expect(result).toEqual({ success: true });
+      // Should have committed and pushed (same repo, different case)
+      const commitCall = mockExec.exec.mock.calls.find(c => c[0] === "git" && c[1] && c[1][0] === "commit");
+      expect(commitCall).toBeDefined();
+    });
+
+    it("should proceed when GITHUB_REPOSITORY is not set", async () => {
+      delete process.env.GITHUB_REPOSITORY;
+      delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+      ({ pushExtraEmptyCommit } = require("./extra_empty_commit.cjs"));
+
+      const result = await pushExtraEmptyCommit({
+        branchName: "feature-branch",
+        repoOwner: "test-owner",
+        repoName: "test-repo",
+      });
+
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
   // Error handling
   // ──────────────────────────────────────────────────────
 
@@ -458,5 +563,59 @@ describe("extra_empty_commit.cjs", () => {
       const ciTriggerRemoveCall = remoteRemoveCalls.find(args => args[2] === "ci-trigger");
       expect(ciTriggerRemoveCall).toBeDefined();
     });
+  });
+});
+
+describe("isCrossRepoTarget", () => {
+  let originalGithubRepo;
+  let isCrossRepoTarget;
+
+  beforeEach(() => {
+    originalGithubRepo = process.env.GITHUB_REPOSITORY;
+    // Provide minimal globals so the module loads
+    global.core = { info: vi.fn(), warning: vi.fn(), error: vi.fn(), setFailed: vi.fn() };
+    global.exec = { exec: vi.fn().mockResolvedValue(0) };
+    delete require.cache[require.resolve("./extra_empty_commit.cjs")];
+    ({ isCrossRepoTarget } = require("./extra_empty_commit.cjs"));
+  });
+
+  afterEach(() => {
+    if (originalGithubRepo !== undefined) {
+      process.env.GITHUB_REPOSITORY = originalGithubRepo;
+    } else {
+      delete process.env.GITHUB_REPOSITORY;
+    }
+    delete global.core;
+    delete global.exec;
+  });
+
+  it("returns true when target repo differs from GITHUB_REPOSITORY", () => {
+    process.env.GITHUB_REPOSITORY = "my-org/my-repo";
+    expect(isCrossRepoTarget("other-org", "other-repo")).toBe(true);
+  });
+
+  it("returns true when only owner differs", () => {
+    process.env.GITHUB_REPOSITORY = "my-org/shared-repo";
+    expect(isCrossRepoTarget("other-org", "shared-repo")).toBe(true);
+  });
+
+  it("returns false when target repo matches GITHUB_REPOSITORY", () => {
+    process.env.GITHUB_REPOSITORY = "my-org/my-repo";
+    expect(isCrossRepoTarget("my-org", "my-repo")).toBe(false);
+  });
+
+  it("compares case-insensitively", () => {
+    process.env.GITHUB_REPOSITORY = "My-Org/My-Repo";
+    expect(isCrossRepoTarget("my-org", "my-repo")).toBe(false);
+  });
+
+  it("returns false when GITHUB_REPOSITORY is not set", () => {
+    delete process.env.GITHUB_REPOSITORY;
+    expect(isCrossRepoTarget("any-org", "any-repo")).toBe(false);
+  });
+
+  it("returns false when GITHUB_REPOSITORY is empty string", () => {
+    process.env.GITHUB_REPOSITORY = "";
+    expect(isCrossRepoTarget("any-org", "any-repo")).toBe(false);
   });
 });

--- a/actions/setup/js/handler_auth.cjs
+++ b/actions/setup/js/handler_auth.cjs
@@ -28,9 +28,9 @@
  * unchanged (preserving the step-level token from with.github-token).
  *
  * Usage in handlers:
- *   const authClient = await createAuthenticatedGitHubClient(config);
- *   // Use authClient for all GitHub API calls instead of the global github
- *   const { data } = await authClient.rest.issues.create({ ... });
+ *   const githubClient = await createAuthenticatedGitHubClient(config);
+ *   // Use githubClient for all GitHub API calls instead of the global github
+ *   const { data } = await githubClient.rest.issues.create({ ... });
  *
  * @param {Object} config - Handler config object, optionally containing "github-token"
  * @returns {Promise<Object>} Authenticated GitHub client — an Octokit instance created via getOctokit()

--- a/actions/setup/js/hide_comment.cjs
+++ b/actions/setup/js/hide_comment.cjs
@@ -49,7 +49,7 @@ async function main(config = {}) {
   // Extract configuration
   const allowedReasons = config.allowed_reasons || [];
   const maxCount = config.max || 5;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -124,7 +124,7 @@ async function main(config = {}) {
         };
       }
 
-      const hideResult = await hideCommentAPI(authClient, commentId, normalizedReason);
+      const hideResult = await hideCommentAPI(githubClient, commentId, normalizedReason);
 
       if (hideResult.isMinimized) {
         core.info(`Successfully hidden comment: ${commentId}`);

--- a/actions/setup/js/link_sub_issue.cjs
+++ b/actions/setup/js/link_sub_issue.cjs
@@ -19,7 +19,7 @@ async function main(config = {}) {
   const subRequiredLabels = config.sub_required_labels || [];
   const subTitlePrefix = config.sub_title_prefix || "";
   const maxCount = config.max || 5;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -156,7 +156,7 @@ async function main(config = {}) {
     // Fetch parent issue to validate filters
     let parentIssue;
     try {
-      const parentResponse = await authClient.rest.issues.get({
+      const parentResponse = await githubClient.rest.issues.get({
         owner,
         repo,
         issue_number: parentIssueNumber,
@@ -201,7 +201,7 @@ async function main(config = {}) {
     // Fetch sub-issue to validate filters
     let subIssue;
     try {
-      const subResponse = await authClient.rest.issues.get({
+      const subResponse = await githubClient.rest.issues.get({
         owner,
         repo,
         issue_number: subIssueNumber,
@@ -232,7 +232,7 @@ async function main(config = {}) {
           }
         }
       `;
-      const parentCheckResult = await authClient.graphql(parentCheckQuery, {
+      const parentCheckResult = await githubClient.graphql(parentCheckQuery, {
         owner,
         repo,
         number: subIssueNumber,
@@ -299,7 +299,7 @@ async function main(config = {}) {
       }
 
       // Use GraphQL mutation to add sub-issue
-      await authClient.graphql(
+      await githubClient.graphql(
         `
         mutation AddSubIssue($parentId: ID!, $subIssueId: ID!) {
           addSubIssue(input: { issueId: $parentId, subIssueId: $subIssueId }) {

--- a/actions/setup/js/mark_pull_request_as_ready_for_review.cjs
+++ b/actions/setup/js/mark_pull_request_as_ready_for_review.cjs
@@ -84,7 +84,7 @@ async function markPullRequestAsReadyForReview(github, owner, repo, prNumber) {
 async function main(config = {}) {
   // Extract configuration
   const maxCount = config.max || 10;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -149,7 +149,7 @@ async function main(config = {}) {
 
     try {
       // First, get the current PR to check if it's a draft
-      const currentPR = await getPullRequestDetails(authClient, context.repo.owner, context.repo.repo, prNumber);
+      const currentPR = await getPullRequestDetails(githubClient, context.repo.owner, context.repo.repo, prNumber);
 
       // Check if it's already not a draft
       if (!currentPR.draft) {
@@ -178,7 +178,7 @@ async function main(config = {}) {
       }
 
       // Update the PR to mark as ready for review
-      const pr = await markPullRequestAsReadyForReview(authClient, context.repo.owner, context.repo.repo, prNumber);
+      const pr = await markPullRequestAsReadyForReview(githubClient, context.repo.owner, context.repo.repo, prNumber);
 
       // Add comment with reason
       const workflowName = process.env.GH_AW_WORKFLOW_NAME || "GitHub Agentic Workflow";
@@ -195,7 +195,7 @@ async function main(config = {}) {
       const footer = generateFooterWithMessages(workflowName, runUrl, workflowSource, workflowSourceURL, triggeringIssueNumber, triggeringPRNumber, triggeringDiscussionNumber);
       const commentBody = `${sanitizedReason}\n\n${footer}`;
 
-      await addPullRequestComment(authClient, context.repo.owner, context.repo.repo, prNumber, commentBody);
+      await addPullRequestComment(githubClient, context.repo.owner, context.repo.repo, prNumber, commentBody);
 
       core.info(`✓ Marked PR #${prNumber} as ready for review and added comment: ${pr.html_url}`);
 

--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -37,7 +37,7 @@ async function main(config = {}) {
   // Cross-repo support: resolve target repository from config
   // This allows pushing to PRs in a different repository than the workflow
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Base branch from config (if set) - used only for logging at factory level
   // Dynamic base branch resolution happens per-message after resolving the actual target repo
@@ -227,7 +227,7 @@ async function main(config = {}) {
     // Fetch the specific PR to get its head branch, title, and labels
     let pullRequest;
     try {
-      const response = await authClient.rest.pulls.get({
+      const response = await githubClient.rest.pulls.get({
         owner: repoParts.owner,
         repo: repoParts.repo,
         pull_number: pullNumber,

--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -461,6 +461,9 @@ async function main(config = {}) {
 
     // Update the activation comment with commit link (if a comment was created and changes were pushed)
     // Pass pullNumber so a new comment is created on the PR when no activation comment exists (e.g., schedule triggers)
+    //
+    // NOTE: we pass 'github' (global octokit) instead of githubClient (repo-scoped octokit) because the issue is created
+    // in the same repo as the activation, so the global client has the correct context for updating the comment.
     if (hasChanges) {
       await updateActivationCommentWithCommit(github, context, core, commitSha, commitUrl, { targetIssueNumber: pullNumber });
     }

--- a/actions/setup/js/push_to_pull_request_branch.test.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.test.cjs
@@ -51,6 +51,10 @@ describe("push_to_pull_request_branch.cjs", () => {
   beforeEach(async () => {
     originalEnv = { ...process.env };
 
+    // Set GITHUB_REPOSITORY to match the default test owner/repo so the
+    // cross-repo guard in extra_empty_commit doesn't interfere.
+    process.env.GITHUB_REPOSITORY = "test-owner/test-repo";
+
     // Create temp directory for test artifacts
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "push-to-pr-test-"));
 

--- a/actions/setup/js/remove_labels.cjs
+++ b/actions/setup/js/remove_labels.cjs
@@ -25,7 +25,7 @@ async function main(config = {}) {
   const blockedPatterns = config.blocked || [];
   const maxCount = config.max || 10;
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -163,7 +163,7 @@ async function main(config = {}) {
     // Remove labels one at a time (GitHub API doesn't have a bulk remove endpoint)
     for (const label of uniqueLabels) {
       try {
-        await authClient.rest.issues.removeLabel({
+        await githubClient.rest.issues.removeLabel({
           owner: repoParts.owner,
           repo: repoParts.repo,
           issue_number: itemNumber,

--- a/actions/setup/js/reply_to_pr_review_comment.cjs
+++ b/actions/setup/js/reply_to_pr_review_comment.cjs
@@ -35,7 +35,7 @@ async function main(config = {}) {
   const includeFooter = parseBoolTemplatable(config.footer, true);
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Determine the triggering PR number from context
   const triggeringPRNumber = getPRNumber(context.payload);
@@ -164,7 +164,7 @@ async function main(config = {}) {
 
       core.info(`Replying to review comment ${numericCommentId} on PR #${targetPRNumber} (${owner}/${repo})`);
 
-      const result = await authClient.rest.pulls.createReplyForReviewComment({
+      const result = await githubClient.rest.pulls.createReplyForReviewComment({
         owner,
         repo,
         pull_number: targetPRNumber,

--- a/actions/setup/js/resolve_pr_review_thread.cjs
+++ b/actions/setup/js/resolve_pr_review_thread.cjs
@@ -97,7 +97,7 @@ async function main(config = {}) {
   // the raw config keys to distinguish user-configured from default.
   const hasExplicitTargetConfig = !!(config["target-repo"] || config.allowed_repos?.length > 0);
 
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Determine the triggering PR number from context
   const triggeringPRNumber = getPRNumber(context.payload);
@@ -146,7 +146,7 @@ async function main(config = {}) {
       }
 
       // Look up the thread's PR number and repository
-      const threadInfo = await getThreadPullRequestInfo(authClient, threadId);
+      const threadInfo = await getThreadPullRequestInfo(githubClient, threadId);
       if (threadInfo === null) {
         core.warning(`Review thread not found or not a PullRequestReviewThread: ${threadId}`);
         return {
@@ -247,7 +247,7 @@ async function main(config = {}) {
         };
       }
 
-      const resolveResult = await resolveReviewThreadAPI(authClient, threadId);
+      const resolveResult = await resolveReviewThreadAPI(githubClient, threadId);
 
       if (resolveResult.isResolved) {
         core.info(`Successfully resolved review thread: ${threadId}`);

--- a/actions/setup/js/set_issue_type.cjs
+++ b/actions/setup/js/set_issue_type.cjs
@@ -16,14 +16,14 @@ const HANDLER_TYPE = "set_issue_type";
 
 /**
  * Fetches the node ID of an issue for use in GraphQL mutations.
- * @param {Object} authClient - Authenticated GitHub client
+ * @param {Object} githubClient - Authenticated GitHub client
  * @param {string} owner - Repository owner
  * @param {string} repo - Repository name
  * @param {number} issueNumber - Issue number
  * @returns {Promise<string>} Issue node ID
  */
-async function getIssueNodeId(authClient, owner, repo, issueNumber) {
-  const { data } = await authClient.rest.issues.get({
+async function getIssueNodeId(githubClient, owner, repo, issueNumber) {
+  const { data } = await githubClient.rest.issues.get({
     owner,
     repo,
     issue_number: issueNumber,
@@ -34,14 +34,14 @@ async function getIssueNodeId(authClient, owner, repo, issueNumber) {
 /**
  * Fetches the available issue types for the given repository via GraphQL.
  * Returns an array of { id, name } objects, or an empty array if not supported.
- * @param {Object} authClient - Authenticated GitHub client
+ * @param {Object} githubClient - Authenticated GitHub client
  * @param {string} owner - Repository owner
  * @param {string} repo - Repository name
  * @returns {Promise<Array<{id: string, name: string}>>} Available issue types
  */
-async function fetchIssueTypes(authClient, owner, repo) {
+async function fetchIssueTypes(githubClient, owner, repo) {
   try {
-    const result = await authClient.graphql(
+    const result = await githubClient.graphql(
       `query($owner: String!, $repo: String!) {
         repository(owner: $owner, name: $repo) {
           issueTypes(first: 100) {
@@ -68,13 +68,13 @@ async function fetchIssueTypes(authClient, owner, repo) {
 /**
  * Sets the issue type via GraphQL mutation.
  * Passing null for typeId clears the type.
- * @param {Object} authClient - Authenticated GitHub client
+ * @param {Object} githubClient - Authenticated GitHub client
  * @param {string} issueNodeId - GraphQL node ID of the issue
  * @param {string|null} typeId - GraphQL node ID of the issue type, or null to clear
  * @returns {Promise<void>}
  */
-async function setIssueTypeById(authClient, issueNodeId, typeId) {
-  await authClient.graphql(
+async function setIssueTypeById(githubClient, issueNodeId, typeId) {
+  await githubClient.graphql(
     `mutation($issueId: ID!, $typeId: ID) {
       updateIssue(input: { id: $issueId, issueTypeId: $typeId }) {
         issue {
@@ -96,7 +96,7 @@ async function main(config = {}) {
   const allowedTypes = config.allowed || [];
   const maxCount = config.max || 5;
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -218,12 +218,12 @@ async function main(config = {}) {
       const { owner, repo } = repoParts;
 
       // Get the issue's node ID for GraphQL
-      const issueNodeId = await getIssueNodeId(authClient, owner, repo, issueNumber);
+      const issueNodeId = await getIssueNodeId(githubClient, owner, repo, issueNumber);
 
       let typeId = null;
       if (!isClear) {
         // Fetch available issue types and find the matching one
-        const issueTypes = await fetchIssueTypes(authClient, owner, repo);
+        const issueTypes = await fetchIssueTypes(githubClient, owner, repo);
 
         if (issueTypes.length === 0) {
           const error = "No issue types are available for this repository. Issue types must be configured in the repository or organization settings.";
@@ -243,7 +243,7 @@ async function main(config = {}) {
         core.info(`Resolved issue type ${JSON.stringify(issueTypeName)} to node ID: ${typeId}`);
       }
 
-      await setIssueTypeById(authClient, issueNodeId, typeId);
+      await setIssueTypeById(githubClient, issueNodeId, typeId);
 
       const successMsg = isClear ? `Successfully cleared issue type on issue #${issueNumber}` : `Successfully set issue type to ${JSON.stringify(issueTypeName)} on issue #${issueNumber}`;
       core.info(successMsg);

--- a/actions/setup/js/submit_pr_review.cjs
+++ b/actions/setup/js/submit_pr_review.cjs
@@ -33,7 +33,7 @@ async function main(config = {}) {
   const maxCount = config.max || 1;
   const targetConfig = config.target || "triggering";
   const buffer = config._prReviewBuffer;
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   if (!buffer) {
     core.warning("submit_pull_request_review: No PR review buffer provided in config");
@@ -124,7 +124,7 @@ async function main(config = {}) {
           core.info(`Set review context from triggering PR: ${repo}#${payloadPR.number}`);
         } else {
           try {
-            const { data: fetchedPR } = await authClient.rest.pulls.get({
+            const { data: fetchedPR } = await githubClient.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNum,

--- a/actions/setup/js/unassign_from_user.cjs
+++ b/actions/setup/js/unassign_from_user.cjs
@@ -28,7 +28,7 @@ async function main(config = {}) {
 
   // Resolve target repository configuration
   const { defaultTargetRepo, allowedRepos } = resolveTargetRepoConfig(config);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   // Check if we're in staged mode
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
@@ -129,7 +129,7 @@ async function main(config = {}) {
 
     try {
       // Remove assignees from the issue
-      await authClient.rest.issues.removeAssignees({
+      await githubClient.rest.issues.removeAssignees({
         owner: repoParts.owner,
         repo: repoParts.repo,
         issue_number: issueNumber,

--- a/actions/setup/js/update_handler_factory.cjs
+++ b/actions/setup/js/update_handler_factory.cjs
@@ -105,7 +105,7 @@ function createUpdateHandlerFactory(handlerConfig) {
 
     // Create an authenticated GitHub client. Uses config["github-token"] when set
     // (for cross-repository operations), otherwise falls back to the step-level github.
-    const authClient = await createAuthenticatedGitHubClient(config);
+    const githubClient = await createAuthenticatedGitHubClient(config);
 
     // Resolve default target repo and allowed repos for cross-repository routing.
     // If no target-repo is configured, defaults to the current repository.
@@ -234,10 +234,10 @@ function createUpdateHandlerFactory(handlerConfig) {
       }
 
       // Execute the update using the authenticated client and effective context.
-      // authClient uses config["github-token"] when set (for cross-repo), otherwise global github.
+      // githubClient uses config["github-token"] when set (for cross-repo), otherwise global github.
       // effectiveContext.repo contains the target repo owner/name for cross-repo routing.
       try {
-        const updatedItem = await executeUpdate(authClient, effectiveContext, itemNumber, updateData);
+        const updatedItem = await executeUpdate(githubClient, effectiveContext, itemNumber, updateData);
         core.info(`Successfully updated ${itemTypeName} #${itemNumber}: ${updatedItem.html_url || updatedItem.url}`);
 
         // Format and return success result

--- a/actions/setup/js/update_release.cjs
+++ b/actions/setup/js/update_release.cjs
@@ -30,7 +30,7 @@ async function main(config = {}) {
   const isStaged = process.env.GH_AW_SAFE_OUTPUTS_STAGED === "true";
   const workflowName = process.env.GH_AW_WORKFLOW_NAME || "GitHub Agentic Workflow";
   const includeFooter = parseBoolTemplatable(config.footer, true);
-  const authClient = await createAuthenticatedGitHubClient(config);
+  const githubClient = await createAuthenticatedGitHubClient(config);
 
   /**
    * Process a single update-release message
@@ -69,7 +69,7 @@ async function main(config = {}) {
           if (!releaseTag && context.payload.inputs.release_id) {
             const releaseId = context.payload.inputs.release_id;
             core.info(`Fetching release with ID: ${releaseId}`);
-            const { data: release } = await authClient.rest.repos.getRelease({
+            const { data: release } = await githubClient.rest.repos.getRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: parseInt(releaseId, 10),
@@ -86,7 +86,7 @@ async function main(config = {}) {
 
       // Get the release by tag
       core.info(`Fetching release with tag: ${releaseTag}`);
-      const { data: release } = await authClient.rest.repos.getReleaseByTag({
+      const { data: release } = await githubClient.rest.repos.getReleaseByTag({
         owner: context.repo.owner,
         repo: context.repo.repo,
         tag: releaseTag,
@@ -110,7 +110,7 @@ async function main(config = {}) {
       });
 
       // Update the release
-      const { data: updatedRelease } = await authClient.rest.repos.updateRelease({
+      const { data: updatedRelease } = await githubClient.rest.repos.updateRelease({
         owner: context.repo.owner,
         repo: context.repo.repo,
         release_id: release.id,

--- a/actions/setup/setup.sh
+++ b/actions/setup/setup.sh
@@ -27,11 +27,11 @@ create_dir() {
 # Get destination from input or use default
 DESTINATION="${INPUT_DESTINATION:-/opt/gh-aw/actions}"
 
-# Get safe-output-projects flag from input (default: false)
-SAFE_OUTPUT_PROJECTS_ENABLED="${INPUT_SAFE_OUTPUT_PROJECTS:-false}"
+# Get safe-output-custom-tokens flag from input (default: false)
+SAFE_OUTPUT_CUSTOM_TOKENS_ENABLED="${INPUT_SAFE_OUTPUT_CUSTOM_TOKENS:-false}"
 
 echo "Copying activation files to ${DESTINATION}"
-echo "Safe-output-projects support: ${SAFE_OUTPUT_PROJECTS_ENABLED}"
+echo "Safe-output custom tokens support: ${SAFE_OUTPUT_CUSTOM_TOKENS_ENABLED}"
 
 # Create destination directory if it doesn't exist
 create_dir "${DESTINATION}"
@@ -302,11 +302,11 @@ fi
 
 echo "Successfully copied ${SAFE_OUTPUTS_COUNT} safe-outputs files to ${SAFE_OUTPUTS_DEST}"
 
-# Install @actions/github package ONLY if safe-output-projects flag is enabled
-# This package is needed by the unified handler manager to create separate Octokit clients
-# for project operations that require GH_AW_PROJECT_GITHUB_TOKEN
-if [ "${SAFE_OUTPUT_PROJECTS_ENABLED}" = "true" ]; then
-  echo "Safe-output-projects enabled - installing @actions/github package in ${DESTINATION}..."
+# Install @actions/github package if any safe output uses a per-handler github-token.
+# handler_auth.cjs needs getOctokit() from @actions/github to create a new Octokit
+# instance when a handler has its own token (for cross-repo operations, project tokens, etc.).
+if [ "${SAFE_OUTPUT_CUSTOM_TOKENS_ENABLED}" = "true" ]; then
+  echo "Custom tokens enabled - installing @actions/github package in ${DESTINATION}..."
   cd "${DESTINATION}"
 
   # Check if npm is available
@@ -332,7 +332,7 @@ if [ "${SAFE_OUTPUT_PROJECTS_ENABLED}" = "true" ]; then
   # Return to original directory
   cd - > /dev/null
 else
-  echo "Safe-output-projects not enabled - skipping @actions/github installation"
+  echo "Custom tokens not enabled - skipping @actions/github installation"
 fi
 
 # Set output

--- a/pkg/workflow/cjs_require_validation_test.go
+++ b/pkg/workflow/cjs_require_validation_test.go
@@ -86,7 +86,11 @@ func TestCJSFilesNoActionsRequires(t *testing.T) {
 	var failedFiles []string
 	var violations []string
 
-	allowedNpmActionsRequires := map[string][]string{}
+	// Exception: safe_output_unified_handler_manager.cjs is allowed to require @actions/github
+	// because the package is installed at runtime via setup.sh when safe-output-projects flag is enabled
+	allowedNpmActionsRequires := map[string][]string{
+		"handler_auth.cjs": {"@actions/github"},
+	}
 
 	for _, filename := range cjsFiles {
 		filepath := filepath.Join(cjsDir, filename)

--- a/pkg/workflow/cjs_require_validation_test.go
+++ b/pkg/workflow/cjs_require_validation_test.go
@@ -86,8 +86,8 @@ func TestCJSFilesNoActionsRequires(t *testing.T) {
 	var failedFiles []string
 	var violations []string
 
-	// Exception: safe_output_unified_handler_manager.cjs is allowed to require @actions/github
-	// because the package is installed at runtime via setup.sh when safe-output-projects flag is enabled
+	// Exception: handler_auth.cjs is allowed to require @actions/github
+	// because the package is installed at runtime via setup.sh when safe-output-custom-tokens flag is enabled
 	allowedNpmActionsRequires := map[string][]string{
 		"handler_auth.cjs": {"@actions/github"},
 	}

--- a/pkg/workflow/compiler_safe_outputs_core.go
+++ b/pkg/workflow/compiler_safe_outputs_core.go
@@ -6,16 +6,161 @@ import (
 
 var consolidatedSafeOutputsLog = logger.New("workflow:compiler_safe_outputs_consolidated")
 
-// hasProjectRelatedSafeOutputs checks if any project-related safe outputs are configured
-// Project-related safe outputs require the @actions/github package for Octokit instantiation
-func (c *Compiler) hasProjectRelatedSafeOutputs(safeOutputs *SafeOutputsConfig) bool {
+// hasCustomTokenSafeOutputs checks if any safe outputs use a custom github-token.
+// When a per-handler github-token is configured, handler_auth.cjs needs to create a
+// new Octokit instance via getOctokit() from @actions/github, which requires the
+// package to be installed at runtime.
+func (c *Compiler) hasCustomTokenSafeOutputs(safeOutputs *SafeOutputsConfig) bool {
 	if safeOutputs == nil {
 		return false
 	}
 
-	return safeOutputs.UpdateProjects != nil ||
-		safeOutputs.CreateProjects != nil ||
-		safeOutputs.CreateProjectStatusUpdates != nil
+	// Check top-level safe-outputs github-token
+	if safeOutputs.GitHubToken != "" {
+		return true
+	}
+
+	// Check project-specific tokens (these have their own GitHubToken field
+	// separate from BaseSafeOutputConfig)
+	if safeOutputs.UpdateProjects != nil && safeOutputs.UpdateProjects.GitHubToken != "" {
+		return true
+	}
+	if safeOutputs.CreateProjects != nil && safeOutputs.CreateProjects.GitHubToken != "" {
+		return true
+	}
+	if safeOutputs.CreateProjectStatusUpdates != nil && safeOutputs.CreateProjectStatusUpdates.GitHubToken != "" {
+		return true
+	}
+
+	// Check BaseSafeOutputConfig.GitHubToken on all safe output types
+	for _, base := range c.collectBaseSafeOutputConfigs(safeOutputs) {
+		if base != nil && base.GitHubToken != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// collectBaseSafeOutputConfigs returns pointers to the BaseSafeOutputConfig
+// embedded in every configured safe output type. Nil entries are skipped by callers.
+func (c *Compiler) collectBaseSafeOutputConfigs(so *SafeOutputsConfig) []*BaseSafeOutputConfig {
+	var configs []*BaseSafeOutputConfig
+	if so.CreateIssues != nil {
+		configs = append(configs, &so.CreateIssues.BaseSafeOutputConfig)
+	}
+	if so.CreateDiscussions != nil {
+		configs = append(configs, &so.CreateDiscussions.BaseSafeOutputConfig)
+	}
+	if so.UpdateDiscussions != nil {
+		configs = append(configs, &so.UpdateDiscussions.BaseSafeOutputConfig)
+	}
+	if so.CloseDiscussions != nil {
+		configs = append(configs, &so.CloseDiscussions.BaseSafeOutputConfig)
+	}
+	if so.CloseIssues != nil {
+		configs = append(configs, &so.CloseIssues.BaseSafeOutputConfig)
+	}
+	if so.ClosePullRequests != nil {
+		configs = append(configs, &so.ClosePullRequests.BaseSafeOutputConfig)
+	}
+	if so.MarkPullRequestAsReadyForReview != nil {
+		configs = append(configs, &so.MarkPullRequestAsReadyForReview.BaseSafeOutputConfig)
+	}
+	if so.AddComments != nil {
+		configs = append(configs, &so.AddComments.BaseSafeOutputConfig)
+	}
+	if so.CreatePullRequests != nil {
+		configs = append(configs, &so.CreatePullRequests.BaseSafeOutputConfig)
+	}
+	if so.CreatePullRequestReviewComments != nil {
+		configs = append(configs, &so.CreatePullRequestReviewComments.BaseSafeOutputConfig)
+	}
+	if so.SubmitPullRequestReview != nil {
+		configs = append(configs, &so.SubmitPullRequestReview.BaseSafeOutputConfig)
+	}
+	if so.ReplyToPullRequestReviewComment != nil {
+		configs = append(configs, &so.ReplyToPullRequestReviewComment.BaseSafeOutputConfig)
+	}
+	if so.ResolvePullRequestReviewThread != nil {
+		configs = append(configs, &so.ResolvePullRequestReviewThread.BaseSafeOutputConfig)
+	}
+	if so.CreateCodeScanningAlerts != nil {
+		configs = append(configs, &so.CreateCodeScanningAlerts.BaseSafeOutputConfig)
+	}
+	if so.AutofixCodeScanningAlert != nil {
+		configs = append(configs, &so.AutofixCodeScanningAlert.BaseSafeOutputConfig)
+	}
+	if so.AddLabels != nil {
+		configs = append(configs, &so.AddLabels.BaseSafeOutputConfig)
+	}
+	if so.RemoveLabels != nil {
+		configs = append(configs, &so.RemoveLabels.BaseSafeOutputConfig)
+	}
+	if so.AddReviewer != nil {
+		configs = append(configs, &so.AddReviewer.BaseSafeOutputConfig)
+	}
+	if so.AssignMilestone != nil {
+		configs = append(configs, &so.AssignMilestone.BaseSafeOutputConfig)
+	}
+	if so.AssignToAgent != nil {
+		configs = append(configs, &so.AssignToAgent.BaseSafeOutputConfig)
+	}
+	if so.AssignToUser != nil {
+		configs = append(configs, &so.AssignToUser.BaseSafeOutputConfig)
+	}
+	if so.UnassignFromUser != nil {
+		configs = append(configs, &so.UnassignFromUser.BaseSafeOutputConfig)
+	}
+	if so.UpdateIssues != nil {
+		configs = append(configs, &so.UpdateIssues.BaseSafeOutputConfig)
+	}
+	if so.UpdatePullRequests != nil {
+		configs = append(configs, &so.UpdatePullRequests.BaseSafeOutputConfig)
+	}
+	if so.PushToPullRequestBranch != nil {
+		configs = append(configs, &so.PushToPullRequestBranch.BaseSafeOutputConfig)
+	}
+	if so.UploadAssets != nil {
+		configs = append(configs, &so.UploadAssets.BaseSafeOutputConfig)
+	}
+	if so.UpdateRelease != nil {
+		configs = append(configs, &so.UpdateRelease.BaseSafeOutputConfig)
+	}
+	if so.CreateAgentSessions != nil {
+		configs = append(configs, &so.CreateAgentSessions.BaseSafeOutputConfig)
+	}
+	if so.UpdateProjects != nil {
+		configs = append(configs, &so.UpdateProjects.BaseSafeOutputConfig)
+	}
+	if so.CreateProjects != nil {
+		configs = append(configs, &so.CreateProjects.BaseSafeOutputConfig)
+	}
+	if so.CreateProjectStatusUpdates != nil {
+		configs = append(configs, &so.CreateProjectStatusUpdates.BaseSafeOutputConfig)
+	}
+	if so.LinkSubIssue != nil {
+		configs = append(configs, &so.LinkSubIssue.BaseSafeOutputConfig)
+	}
+	if so.HideComment != nil {
+		configs = append(configs, &so.HideComment.BaseSafeOutputConfig)
+	}
+	if so.SetIssueType != nil {
+		configs = append(configs, &so.SetIssueType.BaseSafeOutputConfig)
+	}
+	if so.DispatchWorkflow != nil {
+		configs = append(configs, &so.DispatchWorkflow.BaseSafeOutputConfig)
+	}
+	if so.MissingTool != nil {
+		configs = append(configs, &so.MissingTool.BaseSafeOutputConfig)
+	}
+	if so.MissingData != nil {
+		configs = append(configs, &so.MissingData.BaseSafeOutputConfig)
+	}
+	if so.NoOp != nil {
+		configs = append(configs, &so.NoOp.BaseSafeOutputConfig)
+	}
+	return configs
 }
 
 // SafeOutputStepConfig holds configuration for building a single safe output step

--- a/pkg/workflow/compiler_safe_outputs_core.go
+++ b/pkg/workflow/compiler_safe_outputs_core.go
@@ -24,12 +24,11 @@ func (c *Compiler) hasCustomTokenSafeOutputs(safeOutputs *SafeOutputsConfig) boo
 		return true
 	}
 
-	// Check top-level safe-outputs github-token
-	if safeOutputs.GitHubToken != "" {
-		return true
-	}
-
-	// Check BaseSafeOutputConfig.GitHubToken on all safe output types
+	// Check BaseSafeOutputConfig.GitHubToken on all safe output types.
+	// Note: the top-level safeOutputs.GitHubToken is intentionally NOT checked
+	// here — that token is used as the step-level github-script token and does
+	// not require @actions/github/getOctokit(). Only per-handler tokens trigger
+	// the npm install.
 	for _, base := range c.collectBaseSafeOutputConfigs(safeOutputs) {
 		if base != nil && base.GitHubToken != "" {
 			return true

--- a/pkg/workflow/compiler_safe_outputs_core.go
+++ b/pkg/workflow/compiler_safe_outputs_core.go
@@ -6,29 +6,26 @@ import (
 
 var consolidatedSafeOutputsLog = logger.New("workflow:compiler_safe_outputs_consolidated")
 
-// hasCustomTokenSafeOutputs checks if any safe outputs use a custom github-token.
-// When a per-handler github-token is configured, handler_auth.cjs needs to create a
-// new Octokit instance via getOctokit() from @actions/github, which requires the
-// package to be installed at runtime.
+// hasCustomTokenSafeOutputs checks if any safe outputs require the @actions/github
+// package to be installed at runtime. This is needed when:
+//   - Any safe output has a per-handler github-token (handler_auth.cjs uses getOctokit())
+//   - Project-related safe outputs are configured (they always create their own Octokit instances)
 func (c *Compiler) hasCustomTokenSafeOutputs(safeOutputs *SafeOutputsConfig) bool {
 	if safeOutputs == nil {
 		return false
 	}
 
-	// Check top-level safe-outputs github-token
-	if safeOutputs.GitHubToken != "" {
+	// Project-related safe outputs always need @actions/github — they create
+	// their own Octokit clients internally regardless of whether a custom token
+	// is configured. Preserve the original project-existence check.
+	if safeOutputs.UpdateProjects != nil ||
+		safeOutputs.CreateProjects != nil ||
+		safeOutputs.CreateProjectStatusUpdates != nil {
 		return true
 	}
 
-	// Check project-specific tokens (these have their own GitHubToken field
-	// separate from BaseSafeOutputConfig)
-	if safeOutputs.UpdateProjects != nil && safeOutputs.UpdateProjects.GitHubToken != "" {
-		return true
-	}
-	if safeOutputs.CreateProjects != nil && safeOutputs.CreateProjects.GitHubToken != "" {
-		return true
-	}
-	if safeOutputs.CreateProjectStatusUpdates != nil && safeOutputs.CreateProjectStatusUpdates.GitHubToken != "" {
+	// Check top-level safe-outputs github-token
+	if safeOutputs.GitHubToken != "" {
 		return true
 	}
 

--- a/pkg/workflow/compiler_safe_outputs_job.go
+++ b/pkg/workflow/compiler_safe_outputs_job.go
@@ -44,9 +44,9 @@ func (c *Compiler) buildConsolidatedSafeOutputsJob(data *WorkflowData, mainJobNa
 		// For dev mode (local action path), checkout the actions folder first
 		steps = append(steps, c.generateCheckoutActionsFolder(data)...)
 
-		// Enable safe-output-projects flag if project-related safe outputs are configured
-		enableProjectSupport := c.hasProjectRelatedSafeOutputs(data.SafeOutputs)
-		steps = append(steps, c.generateSetupStep(setupActionRef, SetupActionDestination, enableProjectSupport)...)
+		// Enable custom-tokens flag if any safe output uses a per-handler github-token
+		enableCustomTokens := c.hasCustomTokenSafeOutputs(data.SafeOutputs)
+		steps = append(steps, c.generateSetupStep(setupActionRef, SetupActionDestination, enableCustomTokens)...)
 	}
 
 	// Add artifact download steps after setup

--- a/pkg/workflow/compiler_yaml_helpers.go
+++ b/pkg/workflow/compiler_yaml_helpers.go
@@ -316,10 +316,10 @@ func generateInlineGitHubScriptStep(stepName, script, condition string) string {
 // Parameters:
 //   - setupActionRef: The action reference for setup action (e.g., "./actions/setup" or "github/gh-aw/actions/setup@sha")
 //   - destination: The destination path where files should be copied (e.g., SetupActionDestination)
-//   - enableSafeOutputProjects: Whether to enable safe-output-projects support (installs @actions/github for project handlers)
+//   - enableCustomTokens: Whether to enable custom-token support (installs @actions/github so handler_auth.cjs can create per-handler Octokit clients)
 //
 // Returns a slice of strings representing the YAML lines for the setup step.
-func (c *Compiler) generateSetupStep(setupActionRef string, destination string, enableSafeOutputProjects bool) []string {
+func (c *Compiler) generateSetupStep(setupActionRef string, destination string, enableCustomTokens bool) []string {
 	// Script mode: run the setup.sh script directly
 	if c.actionMode.IsScript() {
 		lines := []string{
@@ -329,8 +329,8 @@ func (c *Compiler) generateSetupStep(setupActionRef string, destination string, 
 			"        env:\n",
 			fmt.Sprintf("          INPUT_DESTINATION: %s\n", destination),
 		}
-		if enableSafeOutputProjects {
-			lines = append(lines, "          INPUT_SAFE_OUTPUT_PROJECTS: 'true'\n")
+		if enableCustomTokens {
+			lines = append(lines, "          INPUT_SAFE_OUTPUT_CUSTOM_TOKENS: 'true'\n")
 		}
 		return lines
 	}
@@ -342,8 +342,8 @@ func (c *Compiler) generateSetupStep(setupActionRef string, destination string, 
 		"        with:\n",
 		fmt.Sprintf("          destination: %s\n", destination),
 	}
-	if enableSafeOutputProjects {
-		lines = append(lines, "          safe-output-projects: 'true'\n")
+	if enableCustomTokens {
+		lines = append(lines, "          safe-output-custom-tokens: 'true'\n")
 	}
 	return lines
 }


### PR DESCRIPTION
## Summary

- Renamed the `safe-output-projects` setup input to `safe-output-custom-tokens`, broadening its scope to cover any per-handler `github-token` (not just project handlers)
- Updated `hasProjectRelatedSafeOutputs` to `hasCustomTokenSafeOutputs`, which now checks all safe output types for a custom token before enabling `@actions/github` installation
- Renamed all internal variables from `authClient` to `githubClient` across handler `.cjs` files for clarity