### PR TITLE
chore: remove dead functions (phase 8) — parser import system

### DIFF
--- a/pkg/cli/dependency_graph_test.go
+++ b/pkg/cli/dependency_graph_test.go
@@ -884,7 +884,7 @@ tools:
 			// Run the import processor on the same top-level import list and collect
 			// the topologically sorted ImportedFiles (relative paths).
 			fm := map[string]any{"imports": tt.topImports}
-			result, err := parser.ProcessImportsFromFrontmatterWithManifest(fm, workflowsDir, nil)
+			result, err := parser.ProcessImportsFromFrontmatterWithSource(fm, workflowsDir, nil, "", "")
 			if err != nil {
 				t.Fatalf("ProcessImportsFromFrontmatterWithManifest() error = %v", err)
 			}

--- a/pkg/parser/agent_import_integration_test.go
+++ b/pkg/parser/agent_import_integration_test.go
@@ -82,7 +82,7 @@ This workflow imports a custom agent with array-format tools.`
 		},
 	}
 
-	result, err := ProcessImportsFromFrontmatterWithManifest(frontmatter, workflowsDir, nil)
+	result, err := ProcessImportsFromFrontmatterWithSource(frontmatter, workflowsDir, nil, "", "")
 	if err != nil {
 		t.Fatalf("ProcessImportsFromFrontmatterWithManifest() error = %v, want nil", err)
 	}
@@ -165,7 +165,7 @@ func TestMultipleAgentImportsError(t *testing.T) {
 		},
 	}
 
-	_, err := ProcessImportsFromFrontmatterWithManifest(frontmatter, workflowsDir, nil)
+	_, err := ProcessImportsFromFrontmatterWithSource(frontmatter, workflowsDir, nil, "", "")
 	if err == nil {
 		t.Errorf("Expected error when importing multiple agent files, got nil")
 	}

--- a/pkg/parser/frontmatter_utils_test.go
+++ b/pkg/parser/frontmatter_utils_test.go
@@ -465,6 +465,16 @@ func TestIsWorkflowSpec(t *testing.T) {
 	}
 }
 
+// processImportsFromFrontmatter is a test helper that wraps ProcessImportsFromFrontmatterWithSource
+// returning only the merged tools and engines (mirrors the removed production helper).
+func processImportsFromFrontmatter(frontmatter map[string]any, baseDir string) (string, []string, error) {
+	result, err := ProcessImportsFromFrontmatterWithSource(frontmatter, baseDir, nil, "", "")
+	if err != nil {
+		return "", nil, err
+	}
+	return result.MergedTools, result.MergedEngines, nil
+}
+
 func TestProcessImportsFromFrontmatter(t *testing.T) {
 	// Create temp directory for test files
 	tempDir := testutil.TempDir(t, "test-*")
@@ -534,7 +544,7 @@ This is an included file.`
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tools, engines, err := ProcessImportsFromFrontmatter(tt.frontmatter, tempDir)
+			tools, engines, err := processImportsFromFrontmatter(tt.frontmatter, tempDir)
 
 			if tt.wantErr {
 				if err == nil {

--- a/pkg/parser/import_error.go
+++ b/pkg/parser/import_error.go
@@ -26,16 +26,6 @@ type ImportCycleError struct {
 	WorkflowFile string   // The main workflow file being compiled
 }
 
-// Error returns the error message
-func (e *ImportError) Error() string {
-	return fmt.Sprintf("failed to resolve import '%s': %v", e.ImportPath, e.Cause)
-}
-
-// Unwrap returns the underlying error
-func (e *ImportError) Unwrap() error {
-	return e.Cause
-}
-
 // Error returns the error message for ImportCycleError
 func (e *ImportCycleError) Error() string {
 	if len(e.Chain) == 0 {

--- a/pkg/parser/import_error_test.go
+++ b/pkg/parser/import_error_test.go
@@ -10,46 +10,6 @@ import (
 	"github.com/github/gh-aw/pkg/parser"
 )
 
-func TestImportError(t *testing.T) {
-	tests := []struct {
-		name       string
-		err        *parser.ImportError
-		wantString string
-	}{
-		{
-			name: "basic import error",
-			err: &parser.ImportError{
-				ImportPath: "nonexistent.md",
-				FilePath:   "workflow.md",
-				Line:       3,
-				Column:     3,
-				Cause:      errors.New("file not found: /path/to/nonexistent.md"),
-			},
-			wantString: "failed to resolve import 'nonexistent.md': file not found: /path/to/nonexistent.md",
-		},
-		{
-			name: "remote import error",
-			err: &parser.ImportError{
-				ImportPath: "owner/repo/file.md@main",
-				FilePath:   "workflow.md",
-				Line:       5,
-				Column:     5,
-				Cause:      errors.New("failed to download include from owner/repo/file.md@main"),
-			},
-			wantString: "failed to resolve import 'owner/repo/file.md@main': failed to download include from owner/repo/file.md@main",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.err.Error()
-			if got != tt.wantString {
-				t.Errorf("ImportError.Error() = %q, want %q", got, tt.wantString)
-			}
-		})
-	}
-}
-
 func TestFormatImportError(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/parser/import_processor.go
+++ b/pkg/parser/import_processor.go
@@ -69,28 +69,6 @@ type ImportSpec struct {
 	Inputs map[string]any // Optional input values to pass to the imported workflow (values are string, number, or boolean)
 }
 
-// ProcessImportsFromFrontmatter processes imports field from frontmatter
-// Returns merged tools and engines from imported files
-//
-// Type Pattern Note: frontmatter uses map[string]any because it represents parsed YAML with
-// dynamic structure that varies by workflow. This is the appropriate pattern for parsing
-// user-provided configuration files. See scratchpad/go-type-patterns.md for guidance.
-func ProcessImportsFromFrontmatter(frontmatter map[string]any, baseDir string) (mergedTools string, mergedEngines []string, err error) {
-	log.Printf("Processing imports from frontmatter: baseDir=%s", baseDir)
-	result, err := ProcessImportsFromFrontmatterWithManifest(frontmatter, baseDir, nil)
-	if err != nil {
-		return "", nil, err
-	}
-	return result.MergedTools, result.MergedEngines, nil
-}
-
-// ProcessImportsFromFrontmatterWithManifest processes imports field from frontmatter
-// Returns result containing merged tools, engines, markdown content, and list of imported files
-// Uses BFS traversal with queues for deterministic ordering and cycle detection
-func ProcessImportsFromFrontmatterWithManifest(frontmatter map[string]any, baseDir string, cache *ImportCache) (*ImportsResult, error) {
-	return processImportsFromFrontmatterWithManifestAndSource(frontmatter, baseDir, cache, "", "")
-}
-
 // ProcessImportsFromFrontmatterWithSource processes imports field from frontmatter with source tracking
 // This version includes the workflow file path and YAML content for better error reporting
 func ProcessImportsFromFrontmatterWithSource(frontmatter map[string]any, baseDir string, cache *ImportCache, workflowFilePath string, yamlContent string) (*ImportsResult, error) {

--- a/pkg/parser/import_remote_nested_test.go
+++ b/pkg/parser/import_remote_nested_test.go
@@ -160,7 +160,7 @@ func TestLocalImportResolutionBaseline(t *testing.T) {
 		"imports": []any{"shared/local-tools.md"},
 	}
 	cache := NewImportCache(tmpDir)
-	result, err := ProcessImportsFromFrontmatterWithManifest(frontmatter, workflowsDir, cache)
+	result, err := ProcessImportsFromFrontmatterWithSource(frontmatter, workflowsDir, cache, "", "")
 	require.NoError(t, err, "Local import resolution should succeed")
 	assert.NotNil(t, result, "Result should not be nil")
 }

--- a/pkg/parser/import_topological_contract_test.go
+++ b/pkg/parser/import_topological_contract_test.go
@@ -136,7 +136,7 @@ func writeFiles(t *testing.T, dir string, files map[string]string) {
 func runImportProcessor(t *testing.T, dir string, topImports []string) []string {
 	t.Helper()
 	fm := map[string]any{"imports": topImports}
-	result, err := parser.ProcessImportsFromFrontmatterWithManifest(fm, dir, nil)
+	result, err := parser.ProcessImportsFromFrontmatterWithSource(fm, dir, nil, "", "")
 	require.NoError(t, err, "ProcessImportsFromFrontmatterWithManifest must not fail")
 	return result.ImportedFiles
 }

--- a/pkg/parser/import_topological_test.go
+++ b/pkg/parser/import_topological_test.go
@@ -315,7 +315,7 @@ tools:
 			}
 
 			// Process imports
-			result, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+			result, err := parser.ProcessImportsFromFrontmatterWithSource(frontmatter, tempDir, nil, "", "")
 			require.NoError(t, err, "ProcessImportsFromFrontmatterWithManifest should not fail")
 
 			// Verify the order
@@ -368,7 +368,7 @@ Tool configuration here.`,
 		"imports": []string{"a.md"},
 	}
 
-	result, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+	result, err := parser.ProcessImportsFromFrontmatterWithSource(frontmatter, tempDir, nil, "", "")
 	require.NoError(t, err)
 
 	// b.md should come before a.md (even with section reference)
@@ -408,7 +408,7 @@ tools:
 		"imports": []string{"z-root.md", "a-root.md", "m-root.md"},
 	}
 
-	result, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+	result, err := parser.ProcessImportsFromFrontmatterWithSource(frontmatter, tempDir, nil, "", "")
 	require.NoError(t, err)
 
 	// All are roots, should be sorted alphabetically
@@ -446,7 +446,7 @@ tools:
 		"imports": []string{"z-parent.md"},
 	}
 
-	result, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+	result, err := parser.ProcessImportsFromFrontmatterWithSource(frontmatter, tempDir, nil, "", "")
 	require.NoError(t, err, "ProcessImportsFromFrontmatterWithManifest should not fail")
 	assert.Len(t, result.ImportedFiles, 2)
 
@@ -490,7 +490,7 @@ tools:
 
 	var baseline []string
 	for i := range 5 {
-		result, err := parser.ProcessImportsFromFrontmatterWithManifest(frontmatter, tempDir, nil)
+		result, err := parser.ProcessImportsFromFrontmatterWithSource(frontmatter, tempDir, nil, "", "")
 		require.NoError(t, err)
 		if i == 0 {
 			baseline = append([]string(nil), result.ImportedFiles...)

--- a/pkg/parser/yaml_import_copilot_setup_test.go
+++ b/pkg/parser/yaml_import_copilot_setup_test.go
@@ -456,7 +456,7 @@ This workflow imports copilot-setup-steps.yml.
 	require.NoError(t, err, "Failed to extract frontmatter")
 
 	// Process imports
-	importsResult, err := ProcessImportsFromFrontmatterWithManifest(result.Frontmatter, workflowsDir, nil)
+	importsResult, err := ProcessImportsFromFrontmatterWithSource(result.Frontmatter, workflowsDir, nil, "", "")
 	require.NoError(t, err, "Failed to process imports")
 
 	// Verify that steps were extracted to CopilotSetupSteps (not MergedSteps or MergedJobs)

--- a/pkg/parser/yaml_import_e2e_test.go
+++ b/pkg/parser/yaml_import_e2e_test.go
@@ -78,7 +78,7 @@ This workflow imports a YAML workflow and adds additional jobs.`
 	result, err := ExtractFrontmatterFromContent(mdWorkflow)
 	require.NoError(t, err, "Should extract frontmatter")
 
-	importsResult, err := ProcessImportsFromFrontmatterWithManifest(result.Frontmatter, tmpDir, nil)
+	importsResult, err := ProcessImportsFromFrontmatterWithSource(result.Frontmatter, tmpDir, nil, "", "")
 	require.NoError(t, err, "Should process imports")
 
 	// Verify that jobs were imported
@@ -179,7 +179,7 @@ This workflow imports a YAML workflow with services.`
 	result, err := ExtractFrontmatterFromContent(mdWorkflow)
 	require.NoError(t, err, "Should extract frontmatter")
 
-	importsResult, err := ProcessImportsFromFrontmatterWithManifest(result.Frontmatter, tmpDir, nil)
+	importsResult, err := ProcessImportsFromFrontmatterWithSource(result.Frontmatter, tmpDir, nil, "", "")
 	require.NoError(t, err, "Should process imports")
 
 	// Verify that jobs were imported

--- a/pkg/parser/yaml_import_test.go
+++ b/pkg/parser/yaml_import_test.go
@@ -232,7 +232,7 @@ This imports a YAML workflow.`
 	result, err := ExtractFrontmatterFromContent(mdWorkflow)
 	require.NoError(t, err, "Should extract frontmatter")
 
-	importsResult, err := ProcessImportsFromFrontmatterWithManifest(result.Frontmatter, tmpDir, nil)
+	importsResult, err := ProcessImportsFromFrontmatterWithSource(result.Frontmatter, tmpDir, nil, "", "")
 	require.NoError(t, err, "Should process imports")
 
 	// Verify jobs were imported
@@ -272,7 +272,7 @@ imports:
 	result, err := ExtractFrontmatterFromContent(mdWorkflow)
 	require.NoError(t, err, "Should extract frontmatter")
 
-	_, err = ProcessImportsFromFrontmatterWithManifest(result.Frontmatter, tmpDir, nil)
+	_, err = ProcessImportsFromFrontmatterWithSource(result.Frontmatter, tmpDir, nil, "", "")
 	require.Error(t, err, "Should reject .lock.yml import")
 	assert.Contains(t, err.Error(), "cannot import .lock.yml files", "Error should mention .lock.yml rejection")
 	assert.Contains(t, err.Error(), "Import the source .md file instead", "Error should suggest importing .md file")

--- a/pkg/workflow/error_wrapping_test.go
+++ b/pkg/workflow/error_wrapping_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/github/gh-aw/pkg/parser"
 )
 
 // internalHTTPError is a custom error type used in tests to demonstrate
@@ -101,8 +99,7 @@ on:
 				return err
 			},
 			internalErrors: []any{
-				&parser.ImportError{}, // Import errors are internal implementation details
-				&os.PathError{},       // Underlying file errors should be wrapped
+				&os.PathError{}, // Underlying file errors should be wrapped
 			},
 		},
 	}
@@ -132,10 +129,7 @@ on:
 					var target *os.LinkError
 					assert.NotErrorAs(t, err, &target,
 						"internal error type %T should not leak to user", e)
-				case *parser.ImportError:
-					var target *parser.ImportError
-					assert.NotErrorAs(t, err, &target,
-						"internal error type %T should not leak to user", e)
+
 				default:
 					t.Fatalf("Unknown error type in test: %T", e)
 				}


### PR DESCRIPTION
Removes 4 dead functions from the parser import system:

- `ImportError.Error()` and `ImportError.Unwrap()` — struct is still used but never cast to `error` interface; methods were dead from production paths
- `ProcessImportsFromFrontmatter` — thin wrapper now only needed in one test file, moved to local test helper
- `ProcessImportsFromFrontmatterWithManifest` — thin wrapper; all 16 test call sites updated to call `ProcessImportsFromFrontmatterWithSource` directly

Part of systematic dead code cleanup (DEADCODE.md phase 8).