### PR TITLE
chore(gh-aw): add generated metadata files to .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
+# Auto-generated .gitattributes for cross-platform line ending consistency
+# Default: LF for all text files
+* text=auto eol=lf
+
+# Binary files
+*.png binary
+*.woff2 binary
+
+# Preserved custom configuration
 .changeset/*.md linguist-generated=true merge=ours
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 .github/workflows/dev.md merge=ours
@@ -12,5 +21,5 @@ actions/*/index.js linguist-generated=true
 actions/setup-cli/install.sh linguist-generated=true
 specs/artifacts.md linguist-generated=true merge=ours
 
-# Use bd merge for beads JSONL files
 .beads/issues.jsonl merge=beads
+


### PR DESCRIPTION
Adds _open_prs.json, _open_issues.json and other generated metadata files to .gitignore - produced by tooling, change frequently.