### PR TITLE
fix(perf): hoist regexp.MustCompile to package level

### DIFF
--- a/pkg/workflow/expression_validation.go
+++ b/pkg/workflow/expression_validation.go
@@ -77,6 +77,15 @@ var (
 	stringLiteralRegex = regexp.MustCompile(`^'[^']*'$|^"[^"]*"$|^` + "`[^`]*`$")
 	// numberLiteralRegex matches integer and decimal number literals (with optional leading minus)
 	numberLiteralRegex = regexp.MustCompile(`^-?\d+(\.\d+)?$`)
+
+	// exprPartSplitRe splits expression into parts, handling both dot notation
+	// (e.g., "github.event.issue") and bracket notation (e.g., "release.assets[0].id")
+	// Hoisted from validateExpressionForDangerousProps to avoid repeated compilation.
+	exprPartSplitRe = regexp.MustCompile(`[.\[\]]+`)
+
+	// exprNumericPartRe matches numeric indices (e.g., "0" in "assets[0]")
+	// Hoisted from validateExpressionForDangerousProps to avoid repeated compilation.
+	exprNumericPartRe = regexp.MustCompile(`^\d+$`)
 )
 
 // validateExpressionSafety checks that all GitHub Actions expressions in the markdown content
@@ -209,11 +218,11 @@ func validateExpressionForDangerousProps(expression string) error {
 	// Split expression into parts handling both dot notation (e.g., "github.event.issue")
 	// and bracket notation (e.g., "release.assets[0].id")
 	// Filter out numeric indices (e.g., "0" in "assets[0]")
-	parts := regexp.MustCompile(`[.\[\]]+`).Split(trimmed, -1)
+	parts := exprPartSplitRe.Split(trimmed, -1)
 
 	for _, part := range parts {
 		// Skip empty parts and numeric indices
-		if part == "" || regexp.MustCompile(`^\d+$`).MatchString(part) {
+		if part == "" || exprNumericPartRe.MatchString(part) {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #20026

## Problem
Two `regexp.MustCompile` calls in `validateExpressionForDangerousProps`:
- One at function scope (per-call)
- One inside for loop (per-iteration)

Since `validateSingleExpression` is recursive and called for every expression in every compiled workflow, these allocations accumulate significantly in hot paths.

## Fix
Hoist both regex patterns to package-level vars:
- `exprPartSplitRe`: splits expression into parts
- `exprNumericPartRe`: matches numeric indices

## Impact
Eliminates repeated regex compilation, improving performance for workflow validation.

## Testing
```bash
make test-unit
# or: go test -v -run Test.*Expression ./pkg/workflow/
```

Refs: discussion #19993