### PR TITLE
fix(perf): hoist regexp.MustCompile outside loop in validateExpressionForDangerousProps

### DIFF
--- a/pkg/workflow/expression_validation.go
+++ b/pkg/workflow/expression_validation.go
@@ -77,6 +77,13 @@ var (
 	stringLiteralRegex = regexp.MustCompile(`^'[^']*'$|^"[^"]*"$|^` + "`[^`]*`$")
 	// numberLiteralRegex matches integer and decimal number literals (with optional leading minus)
 	numberLiteralRegex = regexp.MustCompile(`^-?\d+(\.\d+)?$`)
+
+	// exprPartSplitRe splits expressions on dots and brackets (e.g., "github.event.issue" -> ["github", "event", "issue"])
+	// Used in validateExpressionForDangerousProps to parse property access patterns
+	exprPartSplitRe = regexp.MustCompile(`[.\[\]]+`)
+	// exprNumericPartRe matches numeric indices (e.g., "0" in "assets[0]")
+	// Used to filter out array indices when checking for dangerous property names
+	exprNumericPartRe = regexp.MustCompile(`^\d+$`)
 )
 
 // validateExpressionSafety checks that all GitHub Actions expressions in the markdown content
@@ -209,11 +216,11 @@ func validateExpressionForDangerousProps(expression string) error {
 	// Split expression into parts handling both dot notation (e.g., "github.event.issue")
 	// and bracket notation (e.g., "release.assets[0].id")
 	// Filter out numeric indices (e.g., "0" in "assets[0]")
-	parts := regexp.MustCompile(`[.\[\]]+`).Split(trimmed, -1)
+	parts := exprPartSplitRe.Split(trimmed, -1)
 
 	for _, part := range parts {
 		// Skip empty parts and numeric indices
-		if part == "" || regexp.MustCompile(`^\d+$`).MatchString(part) {
+		if part == "" || exprNumericPartRe.MatchString(part) {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #20026

## Problem
Two `regexp.MustCompile` calls in `validateExpressionForDangerousProps`:
1. Line 212: `regexp.MustCompile("[.\\[\\]]+")` - called per function invocation
2. Line 216: `regexp.MustCompile("^\\d+$")` - **called inside for loop, per iteration**

Since `validateSingleExpression` is recursive and called for every expression in every compiled workflow, these allocations accumulate significantly.

## Solution
Hoist both regex patterns to package-level `var` declarations alongside existing regex vars:
```go
var (
    exprPartSplitRe   = regexp.MustCompile(`[.\[\]]+`)
    exprNumericPartRe = regexp.MustCompile(`^\d+$`)
)
```

Replace inline `MustCompile` calls with references to these pre-compiled patterns.

## Impact
- Eliminates repeated regex compilation in hot validation path
- No functional changes, only performance optimization
- Follows existing pattern in the file (lines 66-79)

Reported in discussion #19993 (Sergo audit).