### PR TITLE
fix: query repo default branch instead of hardcoding 'main' (#20098)

### DIFF
--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -257,10 +257,17 @@ async function main(config = {}) {
     const { repo: itemRepo, repoParts } = repoResult;
     core.info(`Target repository: ${itemRepo}`);
 
+    // Resolve base branch for this target repository
+    // Use config value if set, otherwise resolve dynamically for the specific target repo
+    // Dynamic resolution is needed for issue_comment events on PRs where the base branch
+    // is not available in GitHub Actions expressions and requires an API call
+    // NOTE: Must be resolved before checkout so cross-repo checkout uses the correct branch
+    let baseBranch = configBaseBranch || (await getBaseBranch(repoParts));
+
     // Multi-repo support: Switch checkout to target repo if different from current
     // This enables creating PRs in multiple repos from a single workflow run
     if (checkoutManager && itemRepo) {
-      const switchResult = await checkoutManager.switchTo(itemRepo, { baseBranch: configBaseBranch });
+      const switchResult = await checkoutManager.switchTo(itemRepo, { baseBranch });
       if (!switchResult.success) {
         core.warning(`Failed to switch to repository ${itemRepo}: ${switchResult.error}`);
         return {
@@ -272,12 +279,6 @@ async function main(config = {}) {
         core.info(`Switched checkout to repository: ${itemRepo}`);
       }
     }
-
-    // Resolve base branch for this target repository
-    // Use config value if set, otherwise resolve dynamically for the specific target repo
-    // Dynamic resolution is needed for issue_comment events on PRs where the base branch
-    // is not available in GitHub Actions expressions and requires an API call
-    let baseBranch = configBaseBranch || (await getBaseBranch(repoParts));
 
     // SECURITY: Sanitize dynamically resolved base branch to prevent shell injection
     const originalBaseBranch = baseBranch;

--- a/actions/setup/js/dynamic_checkout.cjs
+++ b/actions/setup/js/dynamic_checkout.cjs
@@ -108,13 +108,7 @@ async function checkoutRepo(repoSlug, token, options = {}) {
     try {
       await exec.exec("git", ["checkout", "-B", baseBranch, `origin/${baseBranch}`]);
     } catch {
-      // Try 'master' if 'main' doesn't exist
-      if (baseBranch === "main") {
-        core.info("main branch not found, trying master");
-        await exec.exec("git", ["checkout", "-B", "master", "origin/master"]);
-      } else {
-        throw new Error(`Base branch ${baseBranch} not found in ${repoSlug}`);
-      }
+      throw new Error(`Base branch ${baseBranch} not found in ${repoSlug}`);
     }
 
     // Clean up any local changes

--- a/actions/setup/js/dynamic_checkout.test.cjs
+++ b/actions/setup/js/dynamic_checkout.test.cjs
@@ -167,6 +167,40 @@ describe("checkoutRepo slug validation", () => {
       expect(result.error).not.toContain("Invalid repository slug");
     }
   });
+
+  it("should fail with error when specified branch does not exist, not silently fall back", async () => {
+    // Simulate git checkout failing for the specified branch
+    let callCount = 0;
+    mockExec.exec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args && args[0] === "checkout") {
+        throw new Error("fatal: Remote branch develop not found");
+      }
+      return Promise.resolve(0);
+    });
+
+    const result = await checkoutRepo("owner/repo", "fake-token", { baseBranch: "develop" });
+
+    // Should fail with an error about the branch, NOT silently fall back to master
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("develop");
+    expect(result.error).not.toContain("master");
+  });
+
+  it("should fail with error when 'main' branch does not exist, not silently fall back to master", async () => {
+    // Simulate git checkout failing for 'main' - previously this would silently try 'master'
+    mockExec.exec = vi.fn().mockImplementation((_cmd, args) => {
+      if (args && args[0] === "checkout") {
+        throw new Error("fatal: Remote branch main not found");
+      }
+      return Promise.resolve(0);
+    });
+
+    const result = await checkoutRepo("owner/repo", "fake-token", { baseBranch: "main" });
+
+    // Should fail rather than silently trying 'master'
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("main");
+  });
 });
 
 describe("getCurrentCheckoutRepo URL parsing", () => {

--- a/actions/setup/js/get_base_branch.cjs
+++ b/actions/setup/js/get_base_branch.cjs
@@ -11,10 +11,11 @@ const { validateTargetRepo, parseAllowedRepos, getDefaultTargetRepo } = require(
  * 2. github.base_ref env var (set for pull_request/pull_request_target events)
  * 3. Pull request payload base ref (pull_request_review, pull_request_review_comment events)
  * 4. API lookup for issue_comment events on PRs (the PR's base ref is not in the payload)
- * 5. Fallback to DEFAULT_BRANCH env var or "main"
+ * 5. API lookup for repository default branch (handles repos where default branch != "main")
+ * 6. Fallback to DEFAULT_BRANCH env var or "main"
  *
  * @param {{owner: string, repo: string}|null} [targetRepo] - Optional target repository.
- *   If provided, API calls (step 4) use this instead of context.repo,
+ *   If provided, API calls (steps 4 and 5) use this instead of context.repo,
  *   which is needed for cross-repo scenarios where the target repo differs
  *   from the workflow repository.
  * @returns {Promise<string>} The base branch name
@@ -72,7 +73,43 @@ async function getBaseBranch(targetRepo = null) {
     }
   }
 
-  // 5. Fallback to DEFAULT_BRANCH env var or "main"
+  // 5. API lookup for repository default branch
+  // This handles repos where the default branch is not "main" (e.g., "master", "develop")
+  if (typeof github !== "undefined") {
+    try {
+      const repoOwner = targetRepo?.owner ?? (typeof context !== "undefined" ? context.repo.owner : null);
+      const repoName = targetRepo?.repo ?? (typeof context !== "undefined" ? context.repo.repo : null);
+
+      if (repoOwner && repoName) {
+        // SECURITY: Validate target repo against allowlist before any API calls
+        const targetRepoSlug = `${repoOwner}/${repoName}`;
+        const allowedRepos = parseAllowedRepos(process.env.GH_AW_ALLOWED_REPOS);
+        if (allowedRepos.size > 0) {
+          const defaultRepo = getDefaultTargetRepo();
+          const validation = validateTargetRepo(targetRepoSlug, defaultRepo, allowedRepos);
+          if (!validation.valid) {
+            if (typeof core !== "undefined") {
+              core.warning(`ERR_VALIDATION: ${validation.error}`);
+            }
+            return process.env.DEFAULT_BRANCH || "main";
+          }
+        }
+
+        const { data: repoData } = await github.rest.repos.get({
+          owner: repoOwner,
+          repo: repoName,
+        });
+        return repoData.default_branch;
+      }
+    } catch (/** @type {any} */ error) {
+      // Fall through to default if API call fails
+      if (typeof core !== "undefined") {
+        core.warning(`Failed to fetch repository default branch: ${error.message}`);
+      }
+    }
+  }
+
+  // 6. Fallback to DEFAULT_BRANCH env var or "main"
   return process.env.DEFAULT_BRANCH || "main";
 }
 

--- a/actions/setup/js/get_base_branch.cjs
+++ b/actions/setup/js/get_base_branch.cjs
@@ -2,6 +2,7 @@
 /// <reference types="@actions/github-script" />
 
 const { validateTargetRepo, parseAllowedRepos, getDefaultTargetRepo } = require("./repo_helpers.cjs");
+const { getErrorMessage } = require("./error_helpers.cjs");
 
 /**
  * Get the base branch name, resolving dynamically based on event context.
@@ -69,7 +70,7 @@ async function getBaseBranch(targetRepo = null) {
     } catch (/** @type {any} */ error) {
       // Fall through to default if API call fails
       if (typeof core !== "undefined") {
-        core.warning(`Failed to fetch PR base branch: ${error.message}`);
+        core.warning(`Failed to fetch PR base branch: ${getErrorMessage(error)}`);
       }
     }
   }
@@ -113,7 +114,7 @@ async function getBaseBranch(targetRepo = null) {
       } catch (/** @type {any} */ error) {
         // Fall through to default if API call fails
         if (typeof core !== "undefined") {
-          core.warning(`Failed to fetch repository default branch: ${error.message}`);
+          core.warning(`Failed to fetch repository default branch: ${getErrorMessage(error)}`);
         }
       }
     }

--- a/actions/setup/js/get_base_branch.cjs
+++ b/actions/setup/js/get_base_branch.cjs
@@ -11,7 +11,8 @@ const { validateTargetRepo, parseAllowedRepos, getDefaultTargetRepo } = require(
  * 2. github.base_ref env var (set for pull_request/pull_request_target events)
  * 3. Pull request payload base ref (pull_request_review, pull_request_review_comment events)
  * 4. API lookup for issue_comment events on PRs (the PR's base ref is not in the payload)
- * 5. API lookup for repository default branch (handles repos where default branch != "main")
+ * 5. context.payload.repository.default_branch (included in most event payloads, no API call)
+ * 5b. API lookup via repos.get() when payload doesn't have it (e.g. cross-repo scenarios)
  * 6. Fallback to DEFAULT_BRANCH env var or "main"
  *
  * @param {{owner: string, repo: string}|null} [targetRepo] - Optional target repository.
@@ -73,14 +74,23 @@ async function getBaseBranch(targetRepo = null) {
     }
   }
 
-  // 5. API lookup for repository default branch
-  // This handles repos where the default branch is not "main" (e.g., "master", "develop")
-  if (typeof github !== "undefined") {
-    try {
-      const repoOwner = targetRepo?.owner ?? (typeof context !== "undefined" ? context.repo.owner : null);
-      const repoName = targetRepo?.repo ?? (typeof context !== "undefined" ? context.repo.repo : null);
+  // 5. Repository default branch - from payload first, then API lookup
+  // Many events include context.payload.repository.default_branch, so we check that
+  // first to avoid an unnecessary API call and reduce rate-limit risk.
+  // Only fall back to repos.get() when the payload doesn't have the value
+  // (e.g. cross-repo scenarios where targetRepo differs from the workflow repo).
+  {
+    const repoOwner = targetRepo?.owner ?? (typeof context !== "undefined" ? context.repo?.owner : null);
+    const repoName = targetRepo?.repo ?? (typeof context !== "undefined" ? context.repo?.repo : null);
 
-      if (repoOwner && repoName) {
+    // If no targetRepo override, check the payload first (free - no API call)
+    if (!targetRepo && typeof context !== "undefined" && context.payload?.repository?.default_branch) {
+      return context.payload.repository.default_branch;
+    }
+
+    // Otherwise fall back to repos.get() API call
+    if (repoOwner && repoName && typeof github !== "undefined") {
+      try {
         // SECURITY: Validate target repo against allowlist before any API calls
         const targetRepoSlug = `${repoOwner}/${repoName}`;
         const allowedRepos = parseAllowedRepos(process.env.GH_AW_ALLOWED_REPOS);
@@ -100,11 +110,11 @@ async function getBaseBranch(targetRepo = null) {
           repo: repoName,
         });
         return repoData.default_branch;
-      }
-    } catch (/** @type {any} */ error) {
-      // Fall through to default if API call fails
-      if (typeof core !== "undefined") {
-        core.warning(`Failed to fetch repository default branch: ${error.message}`);
+      } catch (/** @type {any} */ error) {
+        // Fall through to default if API call fails
+        if (typeof core !== "undefined") {
+          core.warning(`Failed to fetch repository default branch: ${error.message}`);
+        }
       }
     }
   }

--- a/actions/setup/js/get_base_branch.test.cjs
+++ b/actions/setup/js/get_base_branch.test.cjs
@@ -99,4 +99,77 @@ describe("getBaseBranch", () => {
     const result3 = await getBaseBranch();
     expect(result3).toBe("custom-branch");
   });
+
+  it("should query GitHub API for repo default branch when github is available", async () => {
+    const mockGetRepo = vi.fn().mockResolvedValue({ data: { default_branch: "master" } });
+    global.github = {
+      rest: {
+        repos: {
+          get: mockGetRepo,
+        },
+      },
+    };
+    global.context = {
+      repo: { owner: "test-owner", repo: "test-repo" },
+      eventName: "workflow_dispatch",
+    };
+
+    const { getBaseBranch } = await import("./get_base_branch.cjs");
+    const result = await getBaseBranch();
+
+    expect(mockGetRepo).toHaveBeenCalledWith({ owner: "test-owner", repo: "test-repo" });
+    expect(result).toBe("master");
+  });
+
+  it("should use targetRepo for API default branch lookup", async () => {
+    const mockGetRepo = vi.fn().mockResolvedValue({ data: { default_branch: "develop" } });
+    global.github = {
+      rest: {
+        repos: {
+          get: mockGetRepo,
+        },
+      },
+    };
+
+    const { getBaseBranch } = await import("./get_base_branch.cjs");
+    const result = await getBaseBranch({ owner: "target-owner", repo: "target-repo" });
+
+    expect(mockGetRepo).toHaveBeenCalledWith({ owner: "target-owner", repo: "target-repo" });
+    expect(result).toBe("develop");
+  });
+
+  it("should fall through to DEFAULT_BRANCH when API lookup for repo default branch fails", async () => {
+    const mockWarning = vi.fn();
+    global.github = {
+      rest: {
+        repos: {
+          get: vi.fn().mockRejectedValue(new Error("API error")),
+        },
+      },
+    };
+    global.core = { warning: mockWarning };
+    process.env.DEFAULT_BRANCH = "trunk";
+
+    const { getBaseBranch } = await import("./get_base_branch.cjs");
+    const result = await getBaseBranch({ owner: "owner", repo: "repo" });
+
+    expect(result).toBe("trunk");
+    expect(mockWarning).toHaveBeenCalledWith(expect.stringContaining("Failed to fetch repository default branch"));
+  });
+
+  it("should fall through to hardcoded main when API lookup fails and no DEFAULT_BRANCH set", async () => {
+    global.github = {
+      rest: {
+        repos: {
+          get: vi.fn().mockRejectedValue(new Error("API error")),
+        },
+      },
+    };
+    global.core = { warning: vi.fn() };
+
+    const { getBaseBranch } = await import("./get_base_branch.cjs");
+    const result = await getBaseBranch({ owner: "owner", repo: "repo" });
+
+    expect(result).toBe("main");
+  });
 });

--- a/actions/setup/js/get_base_branch.test.cjs
+++ b/actions/setup/js/get_base_branch.test.cjs
@@ -100,7 +100,25 @@ describe("getBaseBranch", () => {
     expect(result3).toBe("custom-branch");
   });
 
-  it("should query GitHub API for repo default branch when github is available", async () => {
+  it("should return context.payload.repository.default_branch without an API call", async () => {
+    const mockGetRepo = vi.fn();
+    global.github = {
+      rest: { repos: { get: mockGetRepo } },
+    };
+    global.context = {
+      repo: { owner: "test-owner", repo: "test-repo" },
+      eventName: "push",
+      payload: { repository: { default_branch: "trunk" } },
+    };
+
+    const { getBaseBranch } = await import("./get_base_branch.cjs");
+    const result = await getBaseBranch();
+
+    expect(result).toBe("trunk");
+    expect(mockGetRepo).not.toHaveBeenCalled();
+  });
+
+  it("should query GitHub API for repo default branch when payload does not have it", async () => {
     const mockGetRepo = vi.fn().mockResolvedValue({ data: { default_branch: "master" } });
     global.github = {
       rest: {
@@ -112,6 +130,7 @@ describe("getBaseBranch", () => {
     global.context = {
       repo: { owner: "test-owner", repo: "test-repo" },
       eventName: "workflow_dispatch",
+      payload: {},
     };
 
     const { getBaseBranch } = await import("./get_base_branch.cjs");
@@ -119,6 +138,25 @@ describe("getBaseBranch", () => {
 
     expect(mockGetRepo).toHaveBeenCalledWith({ owner: "test-owner", repo: "test-repo" });
     expect(result).toBe("master");
+  });
+
+  it("should use repos.get() for targetRepo (cross-repo) even when payload has default_branch", async () => {
+    const mockGetRepo = vi.fn().mockResolvedValue({ data: { default_branch: "develop" } });
+    global.github = {
+      rest: { repos: { get: mockGetRepo } },
+    };
+    global.context = {
+      repo: { owner: "workflow-owner", repo: "workflow-repo" },
+      eventName: "issue_comment",
+      payload: { repository: { default_branch: "main" } },
+    };
+
+    const { getBaseBranch } = await import("./get_base_branch.cjs");
+    // targetRepo differs from the workflow repo - must use API, not payload
+    const result = await getBaseBranch({ owner: "target-owner", repo: "target-repo" });
+
+    expect(mockGetRepo).toHaveBeenCalledWith({ owner: "target-owner", repo: "target-repo" });
+    expect(result).toBe("develop");
   });
 
   it("should use targetRepo for API default branch lookup", async () => {


### PR DESCRIPTION
## Problem

When `create_pull_request` runs against a repository whose default branch is not `main` (e.g. `master`, `develop`), `getBaseBranch()` falls back to the hardcoded string `"main"`, causing:

```
Base branch: main
Fetching base branch: main
/usr/bin/git fetch origin main
fatal: couldn't find remote ref main
Error: ✗ Message 12 (create_pull_request) failed: The process '/usr/bin/git' failed with exit code 128
```

Reported in #20098, triggered for https://github.com/fsprojects/FSharpx.Collections/issues/228.

## Changes

### `get_base_branch.cjs` — new resolution steps

The base branch resolution order is now:

1. `GH_AW_CUSTOM_BASE_BRANCH` env var (explicit workflow config)
2. `GITHUB_BASE_REF` env var (`pull_request`/`pull_request_target` events)
3. PR payload base ref (`pull_request_review`, `pull_request_review_comment`)
4. API lookup for PR base ref (`issue_comment` events on PRs)
5. **NEW**: `context.payload.repository.default_branch` — present in most event payloads, zero cost
5b. **NEW**: `repos.get().default_branch` — API fallback when payload lacks it (e.g. cross-repo)
6. `DEFAULT_BRANCH` env var or `"main"` (last resort)

For step 5b, the payload shortcut is skipped when `targetRepo` is explicitly provided, since the payload`s `repository` refers to the workflow repo, not the target.

Also switched `error.message` in catch blocks to `getErrorMessage()` (the repo-standard helper) so non-`Error` rejection values (e.g. `throw null`, `Promise.reject("string")`) don't themselves throw and break the fall-through.

### `create_pull_request.cjs` — resolve branch before checkout

`getBaseBranch()` is now called **before** `checkoutManager.switchTo()`, so cross-repo checkout uses the correctly resolved branch instead of falling through to `"main"`.

### `dynamic_checkout.cjs` — remove hardcoded `"master"` fallback

Removed the silent fallback that tried `"master"` when `"main"` wasn't found. The resolved branch is always passed by the caller now, so this assumption was both wrong and redundant.

## Tests

- **`get_base_branch.test.cjs`** — 6 new tests:
  - Returns `context.payload.repository.default_branch` without an API call
  - Falls back to `repos.get()` when payload lacks `default_branch`
  - Uses `repos.get()` for `targetRepo` (cross-repo) even when payload has a default branch
  - `targetRepo` forwarded correctly to the API call
  - API failure falls through to `DEFAULT_BRANCH` env var
  - API failure with no `DEFAULT_BRANCH` falls through to `"main"`

- **`dynamic_checkout.test.cjs`** — 2 new tests:
  - Non-`"main"` branch failure propagates as an error (no silent `"master"` fallback)
  - `"main"` branch failure propagates as an error (same)