### PR TITLE
fix: use preprocessExpiresField for create-pull-request integer expires conversion

### DIFF
--- a/pkg/workflow/config_parsing_helpers_test.go
+++ b/pkg/workflow/config_parsing_helpers_test.go
@@ -328,6 +328,46 @@ func TestParsePullRequestsConfigWithHelpers(t *testing.T) {
 	}
 }
 
+func TestParsePullRequestsConfigIntegerExpires(t *testing.T) {
+	compiler := &Compiler{}
+	outputMap := map[string]any{
+		"create-pull-request": map[string]any{
+			"expires": 14,
+		},
+	}
+
+	result := compiler.parsePullRequestsConfig(outputMap)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Integer expires values are in days and should be converted to hours
+	expectedHours := 14 * 24
+	if result.Expires != expectedHours {
+		t.Errorf("expected expires %d hours (14 days), got %d", expectedHours, result.Expires)
+	}
+}
+
+func TestParsePullRequestsConfigStringExpires(t *testing.T) {
+	compiler := &Compiler{}
+	outputMap := map[string]any{
+		"create-pull-request": map[string]any{
+			"expires": "7d",
+		},
+	}
+
+	result := compiler.parsePullRequestsConfig(outputMap)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// String "7d" should be converted to 168 hours
+	expectedHours := 7 * 24
+	if result.Expires != expectedHours {
+		t.Errorf("expected expires %d hours (7 days), got %d", expectedHours, result.Expires)
+	}
+}
+
 func TestParseDiscussionsConfigWithHelpers(t *testing.T) {
 	compiler := &Compiler{}
 	outputMap := map[string]any{

--- a/pkg/workflow/create_pull_request.go
+++ b/pkg/workflow/create_pull_request.go
@@ -64,7 +64,10 @@ func (c *Compiler) parsePullRequestsConfig(outputMap map[string]any) *CreatePull
 	// Pre-process the expires field (convert to hours before unmarshaling)
 	// Use preprocessExpiresField to handle all types: integers (days), strings (time specs), and boolean false
 	// This is consistent with how parseIssuesConfig and parseDiscussionsConfig handle expires
-	preprocessExpiresField(configData, createPRLog)
+	expiresDisabled := preprocessExpiresField(configData, createPRLog)
+	if expiresDisabled {
+		createPRLog.Print("Pull request expiration disabled")
+	}
 
 	// Pre-process templatable bool fields: convert literal booleans to strings so that
 	// GitHub Actions expression strings (e.g. "${{ inputs.draft-prs }}") are also accepted.

--- a/pkg/workflow/create_pull_request.go
+++ b/pkg/workflow/create_pull_request.go
@@ -61,19 +61,10 @@ func (c *Compiler) parsePullRequestsConfig(outputMap map[string]any) *CreatePull
 		}
 	}
 
-	// Pre-process the expires field if it's a string (convert to int before unmarshaling)
-	if configData != nil {
-		if expires, exists := configData["expires"]; exists {
-			if _, ok := expires.(string); ok {
-				// Parse the string format and replace with int
-				expiresInt := parseExpiresFromConfig(configData)
-				if expiresInt > 0 {
-					configData["expires"] = expiresInt
-					createPRLog.Printf("Converted expires from relative time format to hours: %d", expiresInt)
-				}
-			}
-		}
-	}
+	// Pre-process the expires field (convert to hours before unmarshaling)
+	// Use preprocessExpiresField to handle all types: integers (days), strings (time specs), and boolean false
+	// This is consistent with how parseIssuesConfig and parseDiscussionsConfig handle expires
+	preprocessExpiresField(configData, createPRLog)
 
 	// Pre-process templatable bool fields: convert literal booleans to strings so that
 	// GitHub Actions expression strings (e.g. "${{ inputs.draft-prs }}") are also accepted.


### PR DESCRIPTION
## Summary

Fixes #20230

`parsePullRequestsConfig` only converted `expires` values to hours when they were strings (e.g., `"14d"`), but skipped the conversion for integer values (e.g., `expires: 14`). This caused integer values (representing days) to be stored as-is instead of being converted to hours, leading to:

1. **Overly aggressive maintenance schedule** — `expires: 14` (14 days) was interpreted as 14 hours ≈ 1 day, triggering an every-2-hours cron schedule instead of daily
2. **Potential premature PR closure** — the handler config JSON contained the unconverted value, so the runtime close handler may close PRs after 14 hours instead of 14 days

## Changes

### `pkg/workflow/create_pull_request.go`

Replaced the string-only expires preprocessing with `preprocessExpiresField()`, which handles all value types (integers, strings, booleans) and is already used by `parseIssuesConfig` and `parseDiscussionsConfig`.

### `pkg/workflow/config_parsing_helpers_test.go`

Added two new tests:
- `TestParsePullRequestsConfigIntegerExpires` — verifies `expires: 14` (integer) is converted to `336` hours
- `TestParsePullRequestsConfigStringExpires` — verifies `expires: "7d"` (string) is converted to `168` hours