### PR TITLE
Please Ignore

### DIFF
--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -88,9 +88,16 @@ async function main(config = {}) {
 
     processedCount++;
 
-    // Determine the patch file path from the message (set by the MCP server handler)
+    // Determine the patch/bundle file paths from the message (set by the MCP server handler)
     const patchFilePath = message.patch_path;
+    const bundleFilePath = message.bundle_path;
     core.info(`Patch file path: ${patchFilePath || "(not set)"}`);
+    if (bundleFilePath) {
+      core.info(`Bundle file path: ${bundleFilePath}`);
+      if (!fs.existsSync(bundleFilePath)) {
+        core.warning(`Bundle file not found at '${bundleFilePath}'. Falling back to patch apply.`);
+      }
+    }
 
     // Check if patch file exists and has valid content
     if (!patchFilePath || !fs.existsSync(patchFilePath)) {

--- a/pkg/workflow/compiler_yaml_main_job.go
+++ b/pkg/workflow/compiler_yaml_main_job.go
@@ -426,6 +426,7 @@ func (c *Compiler) generateMainJobSteps(yaml *strings.Builder, data *WorkflowDat
 	// tools are called, providing immediate error feedback if no changes are present.
 	if usesPatchesAndCheckouts(data.SafeOutputs) {
 		artifactPaths = append(artifactPaths, "/tmp/gh-aw/aw-*.patch")
+		artifactPaths = append(artifactPaths, "/tmp/gh-aw/aw-*.bundle")
 	}
 
 	// Add post-steps (if any) after AI execution

--- a/pkg/workflow/compiler_yaml_main_job_test.go
+++ b/pkg/workflow/compiler_yaml_main_job_test.go
@@ -627,6 +627,7 @@ func TestGenerateMainJobSteps(t *testing.T) {
 			expectInOutput: []string{
 				"- name: Checkout repository",
 				"/tmp/gh-aw/aw-*.patch", // Git patch glob path should be collected
+				"/tmp/gh-aw/aw-*.bundle",
 			},
 			shouldError: false,
 		},

--- a/pkg/workflow/git_patch_test.go
+++ b/pkg/workflow/git_patch_test.go
@@ -98,6 +98,11 @@ Please do the following tasks:
 		t.Error("Expected artifact path '/tmp/gh-aw/aw-*.patch' in unified upload")
 	}
 
+	// Verify the bundle path is included in the unified upload for bundle-first transfer
+	if !strings.Contains(lockContent, "/tmp/gh-aw/aw-*.bundle") {
+		t.Error("Expected artifact path '/tmp/gh-aw/aw-*.bundle' in unified upload")
+	}
+
 	// Verify the upload step has ignore for missing files
 	if !strings.Contains(lockContent, "if-no-files-found: ignore") {
 		t.Error("Expected 'if-no-files-found: ignore' in upload step")


### PR DESCRIPTION
## Summary
- include `/tmp/gh-aw/aw-*.bundle` in unified `agent-artifacts` upload when safe-outputs uses PR patch workflows
- keep existing patch artifact upload and add a bundle artifact path for bundle-first transfer
- add an explicit warning in `push_to_pull_request_branch.cjs` when `bundle_path` is present but the bundle file is missing, before fallback to `git am`
- add/update workflow tests to assert bundle artifact path emission

## Test plan
- [x] `go test -v -run "TestGenerateMainJobSteps|TestGitPatchGeneration" ./pkg/workflow`
- [x] `npm test -- push_to_pull_request_branch.test.cjs` (in `actions/setup/js`)

Made with [Cursor](https://cursor.com)