### PR TITLE
fix: escape handlebars pattern in rendering verifier prompt (#22168)

### DIFF
--- a/.github/workflows/daily-rendering-scripts-verifier.md
+++ b/.github/workflows/daily-rendering-scripts-verifier.md
@@ -308,7 +308,7 @@ Review the outputs from Phases 4 and 5 and determine:
 ### Rendering Issues to Look For
 
 - **Test case failures**: Any of the render_template tests fail → fix the rendering logic
-- **Conditional blocks not handled**: `{{#if ...}}` blocks are left in output → fix template processing
+- **Conditional blocks not handled**: Handlebars if-blocks are left in output → fix template processing
 - **Blank line artifacts**: Extra blank lines around removed blocks → check cleanup logic
 
 ### No Issues Found


### PR DESCRIPTION
## Problem

The Daily Rendering Scripts Verifier workflow has failed on **every single run** (43 of 43) since creation. The activation job fails at the "Validate prompt placeholders" step.

## Root Cause

Line 311 of the workflow markdown contains the literal text:

```
`{{#if ...}}` blocks are left in output
```

During the "Interpolate variables and render templates" step, the `{{#if ...}}` pattern is processed by the template engine. The `...` is converted to an unreplaced placeholder (`__GH_AW______`), which then fails the placeholder validation step with:

```
❌ Error: Found unreplaced placeholders in prompt file:
434:- **Conditional blocks not handled**: \`{{#if __GH_AW______ }}\` blocks are left in output
```

## Fix

Reword the text to avoid the `{{#if` pattern entirely:

```diff
- - **Conditional blocks not handled**: \`{{#if ...}}\` blocks are left in output → fix template processing
+ - **Conditional blocks not handled**: Handlebars if-blocks are left in output → fix template processing
```

Fixes #22168