### PR TITLE
fix: pull merged workflow files after GitHub confirms workflow is ready

### DIFF
--- a/pkg/cli/add_interactive_git.go
+++ b/pkg/cli/add_interactive_git.go
@@ -186,17 +186,6 @@ func (c *AddInteractiveConfig) createWorkflowPRAndConfigureSecret(ctx context.Co
 		fmt.Fprintln(os.Stderr, console.FormatSuccessMessage(fmt.Sprintf("Secret '%s' added", secretName)))
 	}
 
-	// Step 8d: Update local branch with merged changes from GitHub.
-	// Switch to the default branch and pull so that workflow files are available
-	// locally for the subsequent "run workflow" step.
-	if err := c.updateLocalBranch(); err != nil {
-		// Non-fatal - warn the user and continue; the workflow exists on GitHub
-		// even if we can't update the local branch.
-		addInteractiveLog.Printf("Failed to update local branch: %v", err)
-		fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Could not update local branch: %v", err)))
-		fmt.Fprintln(os.Stderr, "You may need to switch to your repository's default branch (for example 'main') and run 'git pull' manually before running the workflow.")
-	}
-
 	return nil
 }
 

--- a/pkg/cli/add_interactive_workflow.go
+++ b/pkg/cli/add_interactive_workflow.go
@@ -127,6 +127,16 @@ func (c *AddInteractiveConfig) checkStatusAndOfferRun(ctx context.Context) error
 		if parsed != nil {
 			fmt.Fprintln(os.Stderr, "")
 
+			// Pull the merged workflow files now that we know GitHub has processed the
+			// merge (workflowFound is true). Doing this here—rather than immediately
+			// after the PR merge—avoids a race where git fetch runs before GitHub's git
+			// objects have been updated, which caused "workflow file not found" errors.
+			if err := c.updateLocalBranch(); err != nil {
+				addInteractiveLog.Printf("Failed to update local branch: %v", err)
+				fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Could not update local branch: %v", err)))
+				fmt.Fprintln(os.Stderr, "You may need to switch to your repository's default branch (for example 'main') and run 'git pull' manually before running the workflow.")
+			}
+
 			if err := RunSpecificWorkflowInteractively(ctx, parsed.WorkflowName, c.Verbose, c.EngineOverride, c.RepoOverride, "", false, false, false); err != nil {
 				fmt.Fprintln(os.Stderr, console.FormatErrorMessage(fmt.Sprintf("Failed to run workflow: %v", err)))
 				c.showFinalInstructions()

--- a/pkg/cli/add_interactive_workflow.go
+++ b/pkg/cli/add_interactive_workflow.go
@@ -131,10 +131,16 @@ func (c *AddInteractiveConfig) checkStatusAndOfferRun(ctx context.Context) error
 			// merge (workflowFound is true). Doing this here—rather than immediately
 			// after the PR merge—avoids a race where git fetch runs before GitHub's git
 			// objects have been updated, which caused "workflow file not found" errors.
+			if !c.Verbose {
+				fmt.Fprintln(os.Stderr, "Updating local branch (this may take a few seconds)...")
+			}
 			if err := c.updateLocalBranch(); err != nil {
 				addInteractiveLog.Printf("Failed to update local branch: %v", err)
 				fmt.Fprintln(os.Stderr, console.FormatWarningMessage(fmt.Sprintf("Could not update local branch: %v", err)))
 				fmt.Fprintln(os.Stderr, "You may need to switch to your repository's default branch (for example 'main') and run 'git pull' manually before running the workflow.")
+			}
+			if !c.Verbose {
+				fmt.Fprintln(os.Stderr, "Finished updating local branch.")
 			}
 
 			if err := RunSpecificWorkflowInteractively(ctx, parsed.WorkflowName, c.Verbose, c.EngineOverride, c.RepoOverride, "", false, false, false); err != nil {


### PR DESCRIPTION
## Problem

After `gh aw add-wizard` merges the PR, the wizard immediately runs `git fetch` + `git pull`. At that instant GitHub's git objects may not yet reflect the merged commit, so the pull retrieves stale refs and the workflow `.md` file is missing from the working tree. This caused:

```
✗ Failed to run workflow: workflow file not found: .github/workflows/repo-assist.md
```

## Fix

Move `updateLocalBranch()` from `createWorkflowPRAndConfigureSecret` (immediately after PR merge) to `checkStatusAndOfferRun` (just before `RunSpecificWorkflowInteractively` is called).

By that point `checkStatusAndOfferRun` has already polled the GitHub Actions API and received `workflowFound=true`, which proves the merge is fully propagated to GitHub's git layer. The subsequent `git pull` therefore reliably retrieves the merged workflow files.