### PR TITLE
🛠️ Improve error messaging for branch sync failure

### DIFF
--- a/actions/setup/js/extra_empty_commit.cjs
+++ b/actions/setup/js/extra_empty_commit.cjs
@@ -147,11 +147,12 @@ async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMes
     try {
       await exec.exec("git", ["fetch", "ci-trigger", branchName]);
       await exec.exec("git", ["reset", "--hard", `ci-trigger/${branchName}`]);
-    } catch {
+    } catch (error) {      // Non-fatal: if fetch/reset fails (e.g. branch not yet on remote), continue
+      // with the local HEAD and attempt the push anyway.
       // Non-fatal: if fetch/reset fails (e.g. branch not yet on remote), continue
       // with the local HEAD and attempt the push anyway.
-      core.info(`Could not sync local branch with remote ${branchName} - will attempt push with local HEAD`);
-    }
+      const syncErrorMessage = error instanceof Error ? error.message : String(error);
+      core.warning(`Could not sync local branch with remote ${branchName} - will attempt push with local HEAD. Underlying error: ${syncErrorMessage}`);    }
 
     // Create and push an empty commit
     const message = commitMessage || "ci: trigger checks";

--- a/actions/setup/js/extra_empty_commit.cjs
+++ b/actions/setup/js/extra_empty_commit.cjs
@@ -149,8 +149,6 @@ async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMes
       await exec.exec("git", ["reset", "--hard", `ci-trigger/${branchName}`]);
     } catch (error) {      // Non-fatal: if fetch/reset fails (e.g. branch not yet on remote), continue
       // with the local HEAD and attempt the push anyway.
-      // Non-fatal: if fetch/reset fails (e.g. branch not yet on remote), continue
-      // with the local HEAD and attempt the push anyway.
       const syncErrorMessage = error instanceof Error ? error.message : String(error);
       core.warning(`Could not sync local branch with remote ${branchName} - will attempt push with local HEAD. Underlying error: ${syncErrorMessage}`);    }
 

--- a/actions/setup/js/extra_empty_commit.cjs
+++ b/actions/setup/js/extra_empty_commit.cjs
@@ -147,10 +147,12 @@ async function pushExtraEmptyCommit({ branchName, repoOwner, repoName, commitMes
     try {
       await exec.exec("git", ["fetch", "ci-trigger", branchName]);
       await exec.exec("git", ["reset", "--hard", `ci-trigger/${branchName}`]);
-    } catch (error) {      // Non-fatal: if fetch/reset fails (e.g. branch not yet on remote), continue
+    } catch (error) {
+      // Non-fatal: if fetch/reset fails (e.g. branch not yet on remote), continue
       // with the local HEAD and attempt the push anyway.
       const syncErrorMessage = error instanceof Error ? error.message : String(error);
-      core.warning(`Could not sync local branch with remote ${branchName} - will attempt push with local HEAD. Underlying error: ${syncErrorMessage}`);    }
+      core.warning(`Could not sync local branch with remote ${branchName} - will attempt push with local HEAD. Underlying error: ${syncErrorMessage}`);
+    }
 
     // Create and push an empty commit
     const message = commitMessage || "ci: trigger checks";

--- a/actions/setup/js/extra_empty_commit.test.cjs
+++ b/actions/setup/js/extra_empty_commit.test.cjs
@@ -222,7 +222,7 @@ describe("extra_empty_commit.cjs", () => {
 
       // Push should still be attempted and succeed (mock returns 0 for push)
       expect(result).toEqual({ success: true });
-      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("Could not sync local branch"));
+      expect(mockCore.warning).toHaveBeenCalledWith(expect.stringContaining("Could not sync local branch"));
 
       // commit and push should still have been called
       const commitCall = mockExec.exec.mock.calls.find(c => c[0] === "git" && c[1] && c[1][0] === "commit");


### PR DESCRIPTION
## Summary

- Captures the caught `error` object in the `catch` block for branch sync failures
- Upgrades the log level from `core.info` to `core.warning` to better reflect the non-fatal issue
- Includes the underlying error message in the warning output for easier debugging