### PR TITLE
fix: detect default branch from git remote when gh repo view fails

### DIFF
--- a/pkg/cli/add_interactive_git.go
+++ b/pkg/cli/add_interactive_git.go
@@ -197,9 +197,33 @@ func (c *AddInteractiveConfig) updateLocalBranch() error {
 
 	// Get the default branch name using gh
 	output, err := workflow.RunGHCombined("Getting default branch...", "repo", "view", "--repo", c.RepoOverride, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")
-	defaultBranch := "main"
+	defaultBranch := ""
 	if err == nil {
 		defaultBranch = strings.TrimSpace(string(output))
+	}
+
+	// Fallback: query the local origin remote directly (works even when gh repo
+	// view fails, e.g. forks without a default remote set).
+	if defaultBranch == "" {
+		addInteractiveLog.Print("gh repo view failed, trying git ls-remote to detect default branch")
+		lsCmd := exec.Command("git", "ls-remote", "--symref", "origin", "HEAD")
+		lsOutput, lsErr := lsCmd.CombinedOutput()
+		if lsErr == nil {
+			// Output looks like: "ref: refs/heads/master\tHEAD\n..."
+			for _, line := range strings.Split(string(lsOutput), "\n") {
+				if strings.HasPrefix(line, "ref: refs/heads/") {
+					parts := strings.Fields(line)
+					if len(parts) >= 2 {
+						defaultBranch = strings.TrimPrefix(parts[0], "ref: refs/heads/")
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if defaultBranch == "" {
+		defaultBranch = "main"
 	}
 	addInteractiveLog.Printf("Default branch: %s", defaultBranch)
 

--- a/pkg/cli/add_interactive_git.go
+++ b/pkg/cli/add_interactive_git.go
@@ -214,7 +214,7 @@ func (c *AddInteractiveConfig) updateLocalBranch() error {
 				if strings.HasPrefix(line, "ref: refs/heads/") {
 					parts := strings.Fields(line)
 					if len(parts) >= 2 {
-						defaultBranch = strings.TrimPrefix(parts[0], "ref: refs/heads/")
+						defaultBranch = strings.TrimPrefix(parts[1], "refs/heads/")
 						break
 					}
 				}

--- a/pkg/cli/add_interactive_git.go
+++ b/pkg/cli/add_interactive_git.go
@@ -210,11 +210,11 @@ func (c *AddInteractiveConfig) updateLocalBranch() error {
 		lsOutput, lsErr := lsCmd.CombinedOutput()
 		if lsErr == nil {
 			// Output looks like: "ref: refs/heads/master\tHEAD\n..."
-			for _, line := range strings.Split(string(lsOutput), "\n") {
+			for line := range strings.SplitSeq(string(lsOutput), "\n") {
 				if strings.HasPrefix(line, "ref: refs/heads/") {
 					parts := strings.Fields(line)
 					if len(parts) >= 2 {
-						defaultBranch = strings.TrimPrefix(parts[1], "refs/heads/")
+						defaultBranch = strings.TrimPrefix(parts[0], "ref: refs/heads/")
 						break
 					}
 				}


### PR DESCRIPTION
## Problem

When running `gh aw add-wizard` on a fork without a default remote set (`gh repo set-default` not configured), `gh repo view` fails to determine the default branch. The code silently falls back to hardcoded `"main"`, causing `git fetch origin main` to fail on repos that use `master` (or another branch name) as their default.

This manifests as:
```
⚠ Could not update local branch: git fetch failed: exit status 128 (output: fatal: couldn't find remote ref main)
✗ Failed to run workflow: workflow file not found: .github/workflows/lean-squad.md
```

## Fix

Add a fallback in `updateLocalBranch()` that uses `git ls-remote --symref origin HEAD` to detect the actual default branch directly from the git remote. This works regardless of `gh repo set-default` configuration.

The detection chain is now:
1. `gh repo view` (GitHub API via CLI) — works when default remote is set
2. `git ls-remote --symref origin HEAD` (git protocol) — works for any clone with an origin remote
3. Fall back to `"main"` only if both methods fail