### PR TITLE
fix: events.jsonl not collected — copy step uses flat glob, misses session subdirectories

### DIFF
--- a/.github/workflows/ace-editor.lock.yml
+++ b/.github/workflows/ace-editor.lock.yml
@@ -456,23 +456,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/ace-editor.lock.yml
+++ b/.github/workflows/ace-editor.lock.yml
@@ -464,7 +464,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/ace-editor.lock.yml
+++ b/.github/workflows/ace-editor.lock.yml
@@ -455,20 +455,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/agent-performance-analyzer.lock.yml
+++ b/.github/workflows/agent-performance-analyzer.lock.yml
@@ -778,7 +778,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/agent-performance-analyzer.lock.yml
+++ b/.github/workflows/agent-performance-analyzer.lock.yml
@@ -770,23 +770,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/agent-performance-analyzer.lock.yml
+++ b/.github/workflows/agent-performance-analyzer.lock.yml
@@ -769,20 +769,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/agent-persona-explorer.lock.yml
+++ b/.github/workflows/agent-persona-explorer.lock.yml
@@ -727,7 +727,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/agent-persona-explorer.lock.yml
+++ b/.github/workflows/agent-persona-explorer.lock.yml
@@ -718,20 +718,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/agent-persona-explorer.lock.yml
+++ b/.github/workflows/agent-persona-explorer.lock.yml
@@ -719,23 +719,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/agentic-observability-kit.lock.yml
+++ b/.github/workflows/agentic-observability-kit.lock.yml
@@ -727,23 +727,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/agentic-observability-kit.lock.yml
+++ b/.github/workflows/agentic-observability-kit.lock.yml
@@ -735,7 +735,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/agentic-observability-kit.lock.yml
+++ b/.github/workflows/agentic-observability-kit.lock.yml
@@ -726,20 +726,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/archie.lock.yml
+++ b/.github/workflows/archie.lock.yml
@@ -742,7 +742,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/archie.lock.yml
+++ b/.github/workflows/archie.lock.yml
@@ -734,23 +734,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/archie.lock.yml
+++ b/.github/workflows/archie.lock.yml
@@ -733,20 +733,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -614,23 +614,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -613,20 +613,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/artifacts-summary.lock.yml
+++ b/.github/workflows/artifacts-summary.lock.yml
@@ -622,7 +622,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/auto-triage-issues.lock.yml
+++ b/.github/workflows/auto-triage-issues.lock.yml
@@ -665,23 +665,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/auto-triage-issues.lock.yml
+++ b/.github/workflows/auto-triage-issues.lock.yml
@@ -664,20 +664,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/auto-triage-issues.lock.yml
+++ b/.github/workflows/auto-triage-issues.lock.yml
@@ -673,7 +673,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/bot-detection.lock.yml
+++ b/.github/workflows/bot-detection.lock.yml
@@ -695,23 +695,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/bot-detection.lock.yml
+++ b/.github/workflows/bot-detection.lock.yml
@@ -694,20 +694,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/bot-detection.lock.yml
+++ b/.github/workflows/bot-detection.lock.yml
@@ -703,7 +703,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -678,20 +678,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -687,7 +687,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/brave.lock.yml
+++ b/.github/workflows/brave.lock.yml
@@ -679,23 +679,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/breaking-change-checker.lock.yml
+++ b/.github/workflows/breaking-change-checker.lock.yml
@@ -655,7 +655,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/breaking-change-checker.lock.yml
+++ b/.github/workflows/breaking-change-checker.lock.yml
@@ -646,20 +646,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/breaking-change-checker.lock.yml
+++ b/.github/workflows/breaking-change-checker.lock.yml
@@ -647,23 +647,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/ci-coach.lock.yml
+++ b/.github/workflows/ci-coach.lock.yml
@@ -697,23 +697,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/ci-coach.lock.yml
+++ b/.github/workflows/ci-coach.lock.yml
@@ -705,7 +705,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/ci-coach.lock.yml
+++ b/.github/workflows/ci-coach.lock.yml
@@ -696,20 +696,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/cli-consistency-checker.lock.yml
+++ b/.github/workflows/cli-consistency-checker.lock.yml
@@ -624,7 +624,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/cli-consistency-checker.lock.yml
+++ b/.github/workflows/cli-consistency-checker.lock.yml
@@ -615,20 +615,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/cli-consistency-checker.lock.yml
+++ b/.github/workflows/cli-consistency-checker.lock.yml
@@ -616,23 +616,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/code-scanning-fixer.lock.yml
+++ b/.github/workflows/code-scanning-fixer.lock.yml
@@ -681,20 +681,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/code-scanning-fixer.lock.yml
+++ b/.github/workflows/code-scanning-fixer.lock.yml
@@ -690,7 +690,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/code-scanning-fixer.lock.yml
+++ b/.github/workflows/code-scanning-fixer.lock.yml
@@ -682,23 +682,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -637,20 +637,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -646,7 +646,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -638,23 +638,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/constraint-solving-potd.lock.yml
+++ b/.github/workflows/constraint-solving-potd.lock.yml
@@ -624,7 +624,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/constraint-solving-potd.lock.yml
+++ b/.github/workflows/constraint-solving-potd.lock.yml
@@ -615,20 +615,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/constraint-solving-potd.lock.yml
+++ b/.github/workflows/constraint-solving-potd.lock.yml
@@ -616,23 +616,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/contribution-check.lock.yml
+++ b/.github/workflows/contribution-check.lock.yml
@@ -661,20 +661,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/contribution-check.lock.yml
+++ b/.github/workflows/contribution-check.lock.yml
@@ -662,23 +662,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/contribution-check.lock.yml
+++ b/.github/workflows/contribution-check.lock.yml
@@ -670,7 +670,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/copilot-cli-deep-research.lock.yml
+++ b/.github/workflows/copilot-cli-deep-research.lock.yml
@@ -671,7 +671,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/copilot-cli-deep-research.lock.yml
+++ b/.github/workflows/copilot-cli-deep-research.lock.yml
@@ -663,23 +663,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/copilot-cli-deep-research.lock.yml
+++ b/.github/workflows/copilot-cli-deep-research.lock.yml
@@ -662,20 +662,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/copilot-pr-merged-report.lock.yml
+++ b/.github/workflows/copilot-pr-merged-report.lock.yml
@@ -784,7 +784,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/copilot-pr-merged-report.lock.yml
+++ b/.github/workflows/copilot-pr-merged-report.lock.yml
@@ -776,23 +776,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/copilot-pr-merged-report.lock.yml
+++ b/.github/workflows/copilot-pr-merged-report.lock.yml
@@ -775,20 +775,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/copilot-pr-nlp-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-nlp-analysis.lock.yml
@@ -728,23 +728,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/copilot-pr-nlp-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-nlp-analysis.lock.yml
@@ -736,7 +736,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/copilot-pr-nlp-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-nlp-analysis.lock.yml
@@ -727,20 +727,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/copilot-pr-prompt-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-prompt-analysis.lock.yml
@@ -677,20 +677,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/copilot-pr-prompt-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-prompt-analysis.lock.yml
@@ -678,23 +678,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/copilot-pr-prompt-analysis.lock.yml
+++ b/.github/workflows/copilot-pr-prompt-analysis.lock.yml
@@ -686,7 +686,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/craft.lock.yml
+++ b/.github/workflows/craft.lock.yml
@@ -681,23 +681,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/craft.lock.yml
+++ b/.github/workflows/craft.lock.yml
@@ -680,20 +680,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/craft.lock.yml
+++ b/.github/workflows/craft.lock.yml
@@ -689,7 +689,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-architecture-diagram.lock.yml
+++ b/.github/workflows/daily-architecture-diagram.lock.yml
@@ -681,23 +681,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-architecture-diagram.lock.yml
+++ b/.github/workflows/daily-architecture-diagram.lock.yml
@@ -680,20 +680,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-architecture-diagram.lock.yml
+++ b/.github/workflows/daily-architecture-diagram.lock.yml
@@ -689,7 +689,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-assign-issue-to-user.lock.yml
+++ b/.github/workflows/daily-assign-issue-to-user.lock.yml
@@ -620,23 +620,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-assign-issue-to-user.lock.yml
+++ b/.github/workflows/daily-assign-issue-to-user.lock.yml
@@ -619,20 +619,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-assign-issue-to-user.lock.yml
+++ b/.github/workflows/daily-assign-issue-to-user.lock.yml
@@ -628,7 +628,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-cli-performance.lock.yml
+++ b/.github/workflows/daily-cli-performance.lock.yml
@@ -840,23 +840,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-cli-performance.lock.yml
+++ b/.github/workflows/daily-cli-performance.lock.yml
@@ -839,20 +839,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-cli-performance.lock.yml
+++ b/.github/workflows/daily-cli-performance.lock.yml
@@ -848,7 +848,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-cli-tools-tester.lock.yml
+++ b/.github/workflows/daily-cli-tools-tester.lock.yml
@@ -709,7 +709,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-cli-tools-tester.lock.yml
+++ b/.github/workflows/daily-cli-tools-tester.lock.yml
@@ -700,20 +700,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-cli-tools-tester.lock.yml
+++ b/.github/workflows/daily-cli-tools-tester.lock.yml
@@ -701,23 +701,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-community-attribution.lock.yml
+++ b/.github/workflows/daily-community-attribution.lock.yml
@@ -694,23 +694,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-community-attribution.lock.yml
+++ b/.github/workflows/daily-community-attribution.lock.yml
@@ -693,20 +693,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-community-attribution.lock.yml
+++ b/.github/workflows/daily-community-attribution.lock.yml
@@ -702,7 +702,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-compiler-quality.lock.yml
+++ b/.github/workflows/daily-compiler-quality.lock.yml
@@ -728,7 +728,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-compiler-quality.lock.yml
+++ b/.github/workflows/daily-compiler-quality.lock.yml
@@ -719,20 +719,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-compiler-quality.lock.yml
+++ b/.github/workflows/daily-compiler-quality.lock.yml
@@ -720,23 +720,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-copilot-token-report.lock.yml
+++ b/.github/workflows/daily-copilot-token-report.lock.yml
@@ -736,20 +736,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-copilot-token-report.lock.yml
+++ b/.github/workflows/daily-copilot-token-report.lock.yml
@@ -745,7 +745,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-copilot-token-report.lock.yml
+++ b/.github/workflows/daily-copilot-token-report.lock.yml
@@ -737,23 +737,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-file-diet.lock.yml
+++ b/.github/workflows/daily-file-diet.lock.yml
@@ -714,23 +714,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-file-diet.lock.yml
+++ b/.github/workflows/daily-file-diet.lock.yml
@@ -722,7 +722,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-file-diet.lock.yml
+++ b/.github/workflows/daily-file-diet.lock.yml
@@ -713,20 +713,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-firewall-report.lock.yml
+++ b/.github/workflows/daily-firewall-report.lock.yml
@@ -758,20 +758,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-firewall-report.lock.yml
+++ b/.github/workflows/daily-firewall-report.lock.yml
@@ -759,23 +759,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-firewall-report.lock.yml
+++ b/.github/workflows/daily-firewall-report.lock.yml
@@ -767,7 +767,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-integrity-analysis.lock.yml
+++ b/.github/workflows/daily-integrity-analysis.lock.yml
@@ -764,23 +764,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-integrity-analysis.lock.yml
+++ b/.github/workflows/daily-integrity-analysis.lock.yml
@@ -772,7 +772,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-integrity-analysis.lock.yml
+++ b/.github/workflows/daily-integrity-analysis.lock.yml
@@ -763,20 +763,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-malicious-code-scan.lock.yml
+++ b/.github/workflows/daily-malicious-code-scan.lock.yml
@@ -625,20 +625,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-malicious-code-scan.lock.yml
+++ b/.github/workflows/daily-malicious-code-scan.lock.yml
@@ -634,7 +634,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-malicious-code-scan.lock.yml
+++ b/.github/workflows/daily-malicious-code-scan.lock.yml
@@ -626,23 +626,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-mcp-concurrency-analysis.lock.yml
+++ b/.github/workflows/daily-mcp-concurrency-analysis.lock.yml
@@ -745,20 +745,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-mcp-concurrency-analysis.lock.yml
+++ b/.github/workflows/daily-mcp-concurrency-analysis.lock.yml
@@ -746,23 +746,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-mcp-concurrency-analysis.lock.yml
+++ b/.github/workflows/daily-mcp-concurrency-analysis.lock.yml
@@ -754,7 +754,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-news.lock.yml
+++ b/.github/workflows/daily-news.lock.yml
@@ -809,7 +809,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-news.lock.yml
+++ b/.github/workflows/daily-news.lock.yml
@@ -800,20 +800,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-news.lock.yml
+++ b/.github/workflows/daily-news.lock.yml
@@ -801,23 +801,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-performance-summary.lock.yml
+++ b/.github/workflows/daily-performance-summary.lock.yml
@@ -1188,20 +1188,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-performance-summary.lock.yml
+++ b/.github/workflows/daily-performance-summary.lock.yml
@@ -1197,7 +1197,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-performance-summary.lock.yml
+++ b/.github/workflows/daily-performance-summary.lock.yml
@@ -1189,23 +1189,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-regulatory.lock.yml
+++ b/.github/workflows/daily-regulatory.lock.yml
@@ -1124,23 +1124,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-regulatory.lock.yml
+++ b/.github/workflows/daily-regulatory.lock.yml
@@ -1123,20 +1123,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-regulatory.lock.yml
+++ b/.github/workflows/daily-regulatory.lock.yml
@@ -1132,7 +1132,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-repo-chronicle.lock.yml
+++ b/.github/workflows/daily-repo-chronicle.lock.yml
@@ -680,23 +680,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-repo-chronicle.lock.yml
+++ b/.github/workflows/daily-repo-chronicle.lock.yml
@@ -688,7 +688,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-repo-chronicle.lock.yml
+++ b/.github/workflows/daily-repo-chronicle.lock.yml
@@ -679,20 +679,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-safe-output-integrator.lock.yml
+++ b/.github/workflows/daily-safe-output-integrator.lock.yml
@@ -660,20 +660,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-safe-output-integrator.lock.yml
+++ b/.github/workflows/daily-safe-output-integrator.lock.yml
@@ -669,7 +669,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-safe-output-integrator.lock.yml
+++ b/.github/workflows/daily-safe-output-integrator.lock.yml
@@ -661,23 +661,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-secrets-analysis.lock.yml
+++ b/.github/workflows/daily-secrets-analysis.lock.yml
@@ -643,23 +643,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-secrets-analysis.lock.yml
+++ b/.github/workflows/daily-secrets-analysis.lock.yml
@@ -651,7 +651,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-secrets-analysis.lock.yml
+++ b/.github/workflows/daily-secrets-analysis.lock.yml
@@ -642,20 +642,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-semgrep-scan.lock.yml
+++ b/.github/workflows/daily-semgrep-scan.lock.yml
@@ -649,20 +649,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-semgrep-scan.lock.yml
+++ b/.github/workflows/daily-semgrep-scan.lock.yml
@@ -658,7 +658,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-semgrep-scan.lock.yml
+++ b/.github/workflows/daily-semgrep-scan.lock.yml
@@ -650,23 +650,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-syntax-error-quality.lock.yml
+++ b/.github/workflows/daily-syntax-error-quality.lock.yml
@@ -655,23 +655,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-syntax-error-quality.lock.yml
+++ b/.github/workflows/daily-syntax-error-quality.lock.yml
@@ -663,7 +663,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-syntax-error-quality.lock.yml
+++ b/.github/workflows/daily-syntax-error-quality.lock.yml
@@ -654,20 +654,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-team-status.lock.yml
+++ b/.github/workflows/daily-team-status.lock.yml
@@ -633,20 +633,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-team-status.lock.yml
+++ b/.github/workflows/daily-team-status.lock.yml
@@ -642,7 +642,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-team-status.lock.yml
+++ b/.github/workflows/daily-team-status.lock.yml
@@ -634,23 +634,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-testify-uber-super-expert.lock.yml
+++ b/.github/workflows/daily-testify-uber-super-expert.lock.yml
@@ -738,23 +738,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-testify-uber-super-expert.lock.yml
+++ b/.github/workflows/daily-testify-uber-super-expert.lock.yml
@@ -737,20 +737,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-testify-uber-super-expert.lock.yml
+++ b/.github/workflows/daily-testify-uber-super-expert.lock.yml
@@ -746,7 +746,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/daily-workflow-updater.lock.yml
+++ b/.github/workflows/daily-workflow-updater.lock.yml
@@ -620,23 +620,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/daily-workflow-updater.lock.yml
+++ b/.github/workflows/daily-workflow-updater.lock.yml
@@ -619,20 +619,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/daily-workflow-updater.lock.yml
+++ b/.github/workflows/daily-workflow-updater.lock.yml
@@ -628,7 +628,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dead-code-remover.lock.yml
+++ b/.github/workflows/dead-code-remover.lock.yml
@@ -668,23 +668,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/dead-code-remover.lock.yml
+++ b/.github/workflows/dead-code-remover.lock.yml
@@ -676,7 +676,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dead-code-remover.lock.yml
+++ b/.github/workflows/dead-code-remover.lock.yml
@@ -667,20 +667,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/delight.lock.yml
+++ b/.github/workflows/delight.lock.yml
@@ -709,7 +709,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/delight.lock.yml
+++ b/.github/workflows/delight.lock.yml
@@ -700,20 +700,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/delight.lock.yml
+++ b/.github/workflows/delight.lock.yml
@@ -701,23 +701,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -625,20 +625,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -634,7 +634,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dependabot-burner.lock.yml
+++ b/.github/workflows/dependabot-burner.lock.yml
@@ -626,23 +626,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/dependabot-go-checker.lock.yml
+++ b/.github/workflows/dependabot-go-checker.lock.yml
@@ -644,23 +644,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/dependabot-go-checker.lock.yml
+++ b/.github/workflows/dependabot-go-checker.lock.yml
@@ -652,7 +652,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dependabot-go-checker.lock.yml
+++ b/.github/workflows/dependabot-go-checker.lock.yml
@@ -643,20 +643,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/dev-hawk.lock.yml
+++ b/.github/workflows/dev-hawk.lock.yml
@@ -720,20 +720,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/dev-hawk.lock.yml
+++ b/.github/workflows/dev-hawk.lock.yml
@@ -729,7 +729,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dev-hawk.lock.yml
+++ b/.github/workflows/dev-hawk.lock.yml
@@ -721,23 +721,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -751,23 +751,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -750,20 +750,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/dev.lock.yml
+++ b/.github/workflows/dev.lock.yml
@@ -759,7 +759,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dictation-prompt.lock.yml
+++ b/.github/workflows/dictation-prompt.lock.yml
@@ -698,20 +698,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/dictation-prompt.lock.yml
+++ b/.github/workflows/dictation-prompt.lock.yml
@@ -707,7 +707,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/dictation-prompt.lock.yml
+++ b/.github/workflows/dictation-prompt.lock.yml
@@ -699,23 +699,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/discussion-task-miner.lock.yml
+++ b/.github/workflows/discussion-task-miner.lock.yml
@@ -696,7 +696,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/discussion-task-miner.lock.yml
+++ b/.github/workflows/discussion-task-miner.lock.yml
@@ -688,23 +688,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/discussion-task-miner.lock.yml
+++ b/.github/workflows/discussion-task-miner.lock.yml
@@ -687,20 +687,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/docs-noob-tester.lock.yml
+++ b/.github/workflows/docs-noob-tester.lock.yml
@@ -657,20 +657,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/docs-noob-tester.lock.yml
+++ b/.github/workflows/docs-noob-tester.lock.yml
@@ -666,7 +666,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/docs-noob-tester.lock.yml
+++ b/.github/workflows/docs-noob-tester.lock.yml
@@ -658,23 +658,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/draft-pr-cleanup.lock.yml
+++ b/.github/workflows/draft-pr-cleanup.lock.yml
@@ -655,23 +655,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/draft-pr-cleanup.lock.yml
+++ b/.github/workflows/draft-pr-cleanup.lock.yml
@@ -663,7 +663,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/draft-pr-cleanup.lock.yml
+++ b/.github/workflows/draft-pr-cleanup.lock.yml
@@ -654,20 +654,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/example-permissions-warning.lock.yml
+++ b/.github/workflows/example-permissions-warning.lock.yml
@@ -432,7 +432,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/example-permissions-warning.lock.yml
+++ b/.github/workflows/example-permissions-warning.lock.yml
@@ -423,20 +423,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/example-permissions-warning.lock.yml
+++ b/.github/workflows/example-permissions-warning.lock.yml
@@ -424,23 +424,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/firewall-escape.lock.yml
+++ b/.github/workflows/firewall-escape.lock.yml
@@ -677,20 +677,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/firewall-escape.lock.yml
+++ b/.github/workflows/firewall-escape.lock.yml
@@ -678,23 +678,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/firewall-escape.lock.yml
+++ b/.github/workflows/firewall-escape.lock.yml
@@ -686,7 +686,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/firewall.lock.yml
+++ b/.github/workflows/firewall.lock.yml
@@ -434,7 +434,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/firewall.lock.yml
+++ b/.github/workflows/firewall.lock.yml
@@ -426,23 +426,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/firewall.lock.yml
+++ b/.github/workflows/firewall.lock.yml
@@ -425,20 +425,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/functional-pragmatist.lock.yml
+++ b/.github/workflows/functional-pragmatist.lock.yml
@@ -638,7 +638,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/functional-pragmatist.lock.yml
+++ b/.github/workflows/functional-pragmatist.lock.yml
@@ -630,23 +630,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/functional-pragmatist.lock.yml
+++ b/.github/workflows/functional-pragmatist.lock.yml
@@ -629,20 +629,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/github-remote-mcp-auth-test.lock.yml
+++ b/.github/workflows/github-remote-mcp-auth-test.lock.yml
@@ -625,20 +625,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/github-remote-mcp-auth-test.lock.yml
+++ b/.github/workflows/github-remote-mcp-auth-test.lock.yml
@@ -634,7 +634,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/github-remote-mcp-auth-test.lock.yml
+++ b/.github/workflows/github-remote-mcp-auth-test.lock.yml
@@ -626,23 +626,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/glossary-maintainer.lock.yml
+++ b/.github/workflows/glossary-maintainer.lock.yml
@@ -833,7 +833,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/glossary-maintainer.lock.yml
+++ b/.github/workflows/glossary-maintainer.lock.yml
@@ -825,23 +825,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/glossary-maintainer.lock.yml
+++ b/.github/workflows/glossary-maintainer.lock.yml
@@ -824,20 +824,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/gpclean.lock.yml
+++ b/.github/workflows/gpclean.lock.yml
@@ -651,20 +651,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/gpclean.lock.yml
+++ b/.github/workflows/gpclean.lock.yml
@@ -652,23 +652,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/gpclean.lock.yml
+++ b/.github/workflows/gpclean.lock.yml
@@ -660,7 +660,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/hourly-ci-cleaner.lock.yml
+++ b/.github/workflows/hourly-ci-cleaner.lock.yml
@@ -680,23 +680,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/hourly-ci-cleaner.lock.yml
+++ b/.github/workflows/hourly-ci-cleaner.lock.yml
@@ -688,7 +688,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/hourly-ci-cleaner.lock.yml
+++ b/.github/workflows/hourly-ci-cleaner.lock.yml
@@ -679,20 +679,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -1018,7 +1018,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -1009,20 +1009,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -1010,23 +1010,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -610,23 +610,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -609,20 +609,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -618,7 +618,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/jsweep.lock.yml
+++ b/.github/workflows/jsweep.lock.yml
@@ -731,7 +731,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/jsweep.lock.yml
+++ b/.github/workflows/jsweep.lock.yml
@@ -722,20 +722,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/jsweep.lock.yml
+++ b/.github/workflows/jsweep.lock.yml
@@ -723,23 +723,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/layout-spec-maintainer.lock.yml
+++ b/.github/workflows/layout-spec-maintainer.lock.yml
@@ -660,20 +660,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/layout-spec-maintainer.lock.yml
+++ b/.github/workflows/layout-spec-maintainer.lock.yml
@@ -669,7 +669,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/layout-spec-maintainer.lock.yml
+++ b/.github/workflows/layout-spec-maintainer.lock.yml
@@ -661,23 +661,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -1138,20 +1138,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -1139,23 +1139,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -1147,7 +1147,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/mergefest.lock.yml
+++ b/.github/workflows/mergefest.lock.yml
@@ -697,23 +697,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/mergefest.lock.yml
+++ b/.github/workflows/mergefest.lock.yml
@@ -705,7 +705,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/mergefest.lock.yml
+++ b/.github/workflows/mergefest.lock.yml
@@ -696,20 +696,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/metrics-collector.lock.yml
+++ b/.github/workflows/metrics-collector.lock.yml
@@ -535,23 +535,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/metrics-collector.lock.yml
+++ b/.github/workflows/metrics-collector.lock.yml
@@ -534,20 +534,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/metrics-collector.lock.yml
+++ b/.github/workflows/metrics-collector.lock.yml
@@ -543,7 +543,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/notion-issue-summary.lock.yml
+++ b/.github/workflows/notion-issue-summary.lock.yml
@@ -638,7 +638,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/notion-issue-summary.lock.yml
+++ b/.github/workflows/notion-issue-summary.lock.yml
@@ -630,23 +630,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/notion-issue-summary.lock.yml
+++ b/.github/workflows/notion-issue-summary.lock.yml
@@ -629,20 +629,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/org-health-report.lock.yml
+++ b/.github/workflows/org-health-report.lock.yml
@@ -685,20 +685,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/org-health-report.lock.yml
+++ b/.github/workflows/org-health-report.lock.yml
@@ -694,7 +694,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/org-health-report.lock.yml
+++ b/.github/workflows/org-health-report.lock.yml
@@ -686,23 +686,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -757,20 +757,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -758,23 +758,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/pdf-summary.lock.yml
+++ b/.github/workflows/pdf-summary.lock.yml
@@ -766,7 +766,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -710,7 +710,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -701,20 +701,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -702,23 +702,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -1042,7 +1042,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -1033,20 +1033,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/poem-bot.lock.yml
+++ b/.github/workflows/poem-bot.lock.yml
@@ -1034,23 +1034,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/portfolio-analyst.lock.yml
+++ b/.github/workflows/portfolio-analyst.lock.yml
@@ -767,20 +767,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/portfolio-analyst.lock.yml
+++ b/.github/workflows/portfolio-analyst.lock.yml
@@ -768,23 +768,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/portfolio-analyst.lock.yml
+++ b/.github/workflows/portfolio-analyst.lock.yml
@@ -776,7 +776,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/pr-nitpick-reviewer.lock.yml
+++ b/.github/workflows/pr-nitpick-reviewer.lock.yml
@@ -755,23 +755,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/pr-nitpick-reviewer.lock.yml
+++ b/.github/workflows/pr-nitpick-reviewer.lock.yml
@@ -754,20 +754,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/pr-nitpick-reviewer.lock.yml
+++ b/.github/workflows/pr-nitpick-reviewer.lock.yml
@@ -763,7 +763,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/pr-triage-agent.lock.yml
+++ b/.github/workflows/pr-triage-agent.lock.yml
@@ -681,23 +681,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/pr-triage-agent.lock.yml
+++ b/.github/workflows/pr-triage-agent.lock.yml
@@ -680,20 +680,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/pr-triage-agent.lock.yml
+++ b/.github/workflows/pr-triage-agent.lock.yml
@@ -689,7 +689,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/python-data-charts.lock.yml
+++ b/.github/workflows/python-data-charts.lock.yml
@@ -756,23 +756,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/python-data-charts.lock.yml
+++ b/.github/workflows/python-data-charts.lock.yml
@@ -764,7 +764,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/python-data-charts.lock.yml
+++ b/.github/workflows/python-data-charts.lock.yml
@@ -755,20 +755,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/q.lock.yml
+++ b/.github/workflows/q.lock.yml
@@ -921,7 +921,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/q.lock.yml
+++ b/.github/workflows/q.lock.yml
@@ -912,20 +912,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/q.lock.yml
+++ b/.github/workflows/q.lock.yml
@@ -913,23 +913,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/refiner.lock.yml
+++ b/.github/workflows/refiner.lock.yml
@@ -672,20 +672,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/refiner.lock.yml
+++ b/.github/workflows/refiner.lock.yml
@@ -673,23 +673,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/refiner.lock.yml
+++ b/.github/workflows/refiner.lock.yml
@@ -681,7 +681,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -661,20 +661,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -662,23 +662,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -670,7 +670,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/repo-audit-analyzer.lock.yml
+++ b/.github/workflows/repo-audit-analyzer.lock.yml
@@ -644,23 +644,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/repo-audit-analyzer.lock.yml
+++ b/.github/workflows/repo-audit-analyzer.lock.yml
@@ -652,7 +652,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/repo-audit-analyzer.lock.yml
+++ b/.github/workflows/repo-audit-analyzer.lock.yml
@@ -643,20 +643,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/repo-tree-map.lock.yml
+++ b/.github/workflows/repo-tree-map.lock.yml
@@ -624,7 +624,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/repo-tree-map.lock.yml
+++ b/.github/workflows/repo-tree-map.lock.yml
@@ -615,20 +615,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/repo-tree-map.lock.yml
+++ b/.github/workflows/repo-tree-map.lock.yml
@@ -616,23 +616,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/repository-quality-improver.lock.yml
+++ b/.github/workflows/repository-quality-improver.lock.yml
@@ -703,20 +703,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/repository-quality-improver.lock.yml
+++ b/.github/workflows/repository-quality-improver.lock.yml
@@ -704,23 +704,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/repository-quality-improver.lock.yml
+++ b/.github/workflows/repository-quality-improver.lock.yml
@@ -712,7 +712,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/research.lock.yml
+++ b/.github/workflows/research.lock.yml
@@ -644,20 +644,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/research.lock.yml
+++ b/.github/workflows/research.lock.yml
@@ -645,23 +645,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/research.lock.yml
+++ b/.github/workflows/research.lock.yml
@@ -653,7 +653,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/security-compliance.lock.yml
+++ b/.github/workflows/security-compliance.lock.yml
@@ -660,23 +660,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/security-compliance.lock.yml
+++ b/.github/workflows/security-compliance.lock.yml
@@ -668,7 +668,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/security-compliance.lock.yml
+++ b/.github/workflows/security-compliance.lock.yml
@@ -659,20 +659,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/security-review.lock.yml
+++ b/.github/workflows/security-review.lock.yml
@@ -811,7 +811,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/security-review.lock.yml
+++ b/.github/workflows/security-review.lock.yml
@@ -803,23 +803,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/security-review.lock.yml
+++ b/.github/workflows/security-review.lock.yml
@@ -802,20 +802,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/slide-deck-maintainer.lock.yml
+++ b/.github/workflows/slide-deck-maintainer.lock.yml
@@ -736,20 +736,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/slide-deck-maintainer.lock.yml
+++ b/.github/workflows/slide-deck-maintainer.lock.yml
@@ -745,7 +745,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/slide-deck-maintainer.lock.yml
+++ b/.github/workflows/slide-deck-maintainer.lock.yml
@@ -737,23 +737,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-copilot-arm.lock.yml
+++ b/.github/workflows/smoke-copilot-arm.lock.yml
@@ -1577,7 +1577,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-copilot-arm.lock.yml
+++ b/.github/workflows/smoke-copilot-arm.lock.yml
@@ -1568,20 +1568,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-copilot-arm.lock.yml
+++ b/.github/workflows/smoke-copilot-arm.lock.yml
@@ -1569,23 +1569,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -1625,7 +1625,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -1616,20 +1616,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -1617,23 +1617,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-create-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-create-cross-repo-pr.lock.yml
@@ -725,20 +725,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-create-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-create-cross-repo-pr.lock.yml
@@ -734,7 +734,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-create-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-create-cross-repo-pr.lock.yml
@@ -726,23 +726,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-multi-pr.lock.yml
+++ b/.github/workflows/smoke-multi-pr.lock.yml
@@ -727,7 +727,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-multi-pr.lock.yml
+++ b/.github/workflows/smoke-multi-pr.lock.yml
@@ -718,20 +718,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-multi-pr.lock.yml
+++ b/.github/workflows/smoke-multi-pr.lock.yml
@@ -719,23 +719,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-project.lock.yml
+++ b/.github/workflows/smoke-project.lock.yml
@@ -859,7 +859,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-project.lock.yml
+++ b/.github/workflows/smoke-project.lock.yml
@@ -851,23 +851,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-project.lock.yml
+++ b/.github/workflows/smoke-project.lock.yml
@@ -850,20 +850,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-service-ports.lock.yml
+++ b/.github/workflows/smoke-service-ports.lock.yml
@@ -637,7 +637,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-service-ports.lock.yml
+++ b/.github/workflows/smoke-service-ports.lock.yml
@@ -629,23 +629,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-service-ports.lock.yml
+++ b/.github/workflows/smoke-service-ports.lock.yml
@@ -628,20 +628,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-temporary-id.lock.yml
+++ b/.github/workflows/smoke-temporary-id.lock.yml
@@ -705,23 +705,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-temporary-id.lock.yml
+++ b/.github/workflows/smoke-temporary-id.lock.yml
@@ -704,20 +704,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-temporary-id.lock.yml
+++ b/.github/workflows/smoke-temporary-id.lock.yml
@@ -713,7 +713,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-test-tools.lock.yml
+++ b/.github/workflows/smoke-test-tools.lock.yml
@@ -674,7 +674,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-test-tools.lock.yml
+++ b/.github/workflows/smoke-test-tools.lock.yml
@@ -666,23 +666,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-test-tools.lock.yml
+++ b/.github/workflows/smoke-test-tools.lock.yml
@@ -665,20 +665,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-update-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-update-cross-repo-pr.lock.yml
@@ -738,23 +738,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-update-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-update-cross-repo-pr.lock.yml
@@ -737,20 +737,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-update-cross-repo-pr.lock.yml
+++ b/.github/workflows/smoke-update-cross-repo-pr.lock.yml
@@ -746,7 +746,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
+++ b/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
@@ -687,23 +687,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
+++ b/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
@@ -686,20 +686,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
+++ b/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
@@ -695,7 +695,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-workflow-call.lock.yml
+++ b/.github/workflows/smoke-workflow-call.lock.yml
@@ -674,20 +674,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/smoke-workflow-call.lock.yml
+++ b/.github/workflows/smoke-workflow-call.lock.yml
@@ -683,7 +683,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/smoke-workflow-call.lock.yml
+++ b/.github/workflows/smoke-workflow-call.lock.yml
@@ -675,23 +675,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/stale-repo-identifier.lock.yml
+++ b/.github/workflows/stale-repo-identifier.lock.yml
@@ -750,7 +750,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/stale-repo-identifier.lock.yml
+++ b/.github/workflows/stale-repo-identifier.lock.yml
@@ -741,20 +741,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/stale-repo-identifier.lock.yml
+++ b/.github/workflows/stale-repo-identifier.lock.yml
@@ -742,23 +742,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/sub-issue-closer.lock.yml
+++ b/.github/workflows/sub-issue-closer.lock.yml
@@ -657,20 +657,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/sub-issue-closer.lock.yml
+++ b/.github/workflows/sub-issue-closer.lock.yml
@@ -666,7 +666,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/sub-issue-closer.lock.yml
+++ b/.github/workflows/sub-issue-closer.lock.yml
@@ -658,23 +658,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/super-linter.lock.yml
+++ b/.github/workflows/super-linter.lock.yml
@@ -660,23 +660,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/super-linter.lock.yml
+++ b/.github/workflows/super-linter.lock.yml
@@ -668,7 +668,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/super-linter.lock.yml
+++ b/.github/workflows/super-linter.lock.yml
@@ -659,20 +659,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -818,20 +818,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -819,23 +819,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/technical-doc-writer.lock.yml
+++ b/.github/workflows/technical-doc-writer.lock.yml
@@ -827,7 +827,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/terminal-stylist.lock.yml
+++ b/.github/workflows/terminal-stylist.lock.yml
@@ -678,20 +678,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/terminal-stylist.lock.yml
+++ b/.github/workflows/terminal-stylist.lock.yml
@@ -687,7 +687,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/terminal-stylist.lock.yml
+++ b/.github/workflows/terminal-stylist.lock.yml
@@ -679,23 +679,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/test-dispatcher.lock.yml
+++ b/.github/workflows/test-dispatcher.lock.yml
@@ -600,23 +600,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/test-dispatcher.lock.yml
+++ b/.github/workflows/test-dispatcher.lock.yml
@@ -608,7 +608,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/test-dispatcher.lock.yml
+++ b/.github/workflows/test-dispatcher.lock.yml
@@ -599,20 +599,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/test-project-url-default.lock.yml
+++ b/.github/workflows/test-project-url-default.lock.yml
@@ -660,23 +660,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/test-project-url-default.lock.yml
+++ b/.github/workflows/test-project-url-default.lock.yml
@@ -668,7 +668,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/test-project-url-default.lock.yml
+++ b/.github/workflows/test-project-url-default.lock.yml
@@ -659,20 +659,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/test-workflow.lock.yml
+++ b/.github/workflows/test-workflow.lock.yml
@@ -424,20 +424,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/test-workflow.lock.yml
+++ b/.github/workflows/test-workflow.lock.yml
@@ -433,7 +433,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/test-workflow.lock.yml
+++ b/.github/workflows/test-workflow.lock.yml
@@ -425,23 +425,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -756,7 +756,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -747,20 +747,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/tidy.lock.yml
+++ b/.github/workflows/tidy.lock.yml
@@ -748,23 +748,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/ubuntu-image-analyzer.lock.yml
+++ b/.github/workflows/ubuntu-image-analyzer.lock.yml
@@ -661,20 +661,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/ubuntu-image-analyzer.lock.yml
+++ b/.github/workflows/ubuntu-image-analyzer.lock.yml
@@ -662,23 +662,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/ubuntu-image-analyzer.lock.yml
+++ b/.github/workflows/ubuntu-image-analyzer.lock.yml
@@ -670,7 +670,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/update-astro.lock.yml
+++ b/.github/workflows/update-astro.lock.yml
@@ -643,23 +643,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/update-astro.lock.yml
+++ b/.github/workflows/update-astro.lock.yml
@@ -651,7 +651,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/update-astro.lock.yml
+++ b/.github/workflows/update-astro.lock.yml
@@ -642,20 +642,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/video-analyzer.lock.yml
+++ b/.github/workflows/video-analyzer.lock.yml
@@ -653,23 +653,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/video-analyzer.lock.yml
+++ b/.github/workflows/video-analyzer.lock.yml
@@ -661,7 +661,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/video-analyzer.lock.yml
+++ b/.github/workflows/video-analyzer.lock.yml
@@ -652,20 +652,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/weekly-blog-post-writer.lock.yml
+++ b/.github/workflows/weekly-blog-post-writer.lock.yml
@@ -815,7 +815,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/weekly-blog-post-writer.lock.yml
+++ b/.github/workflows/weekly-blog-post-writer.lock.yml
@@ -806,20 +806,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/weekly-blog-post-writer.lock.yml
+++ b/.github/workflows/weekly-blog-post-writer.lock.yml
@@ -807,23 +807,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/weekly-editors-health-check.lock.yml
+++ b/.github/workflows/weekly-editors-health-check.lock.yml
@@ -693,7 +693,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/weekly-editors-health-check.lock.yml
+++ b/.github/workflows/weekly-editors-health-check.lock.yml
@@ -685,23 +685,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/weekly-editors-health-check.lock.yml
+++ b/.github/workflows/weekly-editors-health-check.lock.yml
@@ -684,20 +684,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/weekly-issue-summary.lock.yml
+++ b/.github/workflows/weekly-issue-summary.lock.yml
@@ -674,7 +674,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/weekly-issue-summary.lock.yml
+++ b/.github/workflows/weekly-issue-summary.lock.yml
@@ -666,23 +666,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/weekly-issue-summary.lock.yml
+++ b/.github/workflows/weekly-issue-summary.lock.yml
@@ -665,20 +665,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/weekly-safe-outputs-spec-review.lock.yml
+++ b/.github/workflows/weekly-safe-outputs-spec-review.lock.yml
@@ -630,7 +630,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/weekly-safe-outputs-spec-review.lock.yml
+++ b/.github/workflows/weekly-safe-outputs-spec-review.lock.yml
@@ -622,23 +622,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/weekly-safe-outputs-spec-review.lock.yml
+++ b/.github/workflows/weekly-safe-outputs-spec-review.lock.yml
@@ -621,20 +621,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/workflow-generator.lock.yml
+++ b/.github/workflows/workflow-generator.lock.yml
@@ -698,20 +698,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/workflow-generator.lock.yml
+++ b/.github/workflows/workflow-generator.lock.yml
@@ -707,7 +707,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/workflow-generator.lock.yml
+++ b/.github/workflows/workflow-generator.lock.yml
@@ -699,23 +699,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/workflow-health-manager.lock.yml
+++ b/.github/workflows/workflow-health-manager.lock.yml
@@ -725,20 +725,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/workflow-health-manager.lock.yml
+++ b/.github/workflows/workflow-health-manager.lock.yml
@@ -734,7 +734,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/workflow-health-manager.lock.yml
+++ b/.github/workflows/workflow-health-manager.lock.yml
@@ -726,23 +726,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/workflow-normalizer.lock.yml
+++ b/.github/workflows/workflow-normalizer.lock.yml
@@ -700,23 +700,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/workflow-normalizer.lock.yml
+++ b/.github/workflows/workflow-normalizer.lock.yml
@@ -699,20 +699,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/.github/workflows/workflow-normalizer.lock.yml
+++ b/.github/workflows/workflow-normalizer.lock.yml
@@ -708,7 +708,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/workflow-skill-extractor.lock.yml
+++ b/.github/workflows/workflow-skill-extractor.lock.yml
@@ -671,23 +671,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/.github/workflows/workflow-skill-extractor.lock.yml
+++ b/.github/workflows/workflow-skill-extractor.lock.yml
@@ -679,7 +679,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/.github/workflows/workflow-skill-extractor.lock.yml
+++ b/.github/workflows/workflow-skill-extractor.lock.yml
@@ -670,20 +670,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/actions/setup/sh/copy_copilot_session_state.sh
+++ b/actions/setup/sh/copy_copilot_session_state.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copy the entire Copilot session-state directory to the agent logs folder
+# for artifact collection. This ensures all session files (events.jsonl,
+# session.db, plan.md, checkpoints, etc.) are in /tmp/gh-aw/ where secret
+# redaction can scan them and they get uploaded as artifacts.
+#
+# Copilot CLI writes session data inside UUID-named subdirectories:
+#   ~/.copilot/session-state/<session-uuid>/events.jsonl
+#   ~/.copilot/session-state/<session-uuid>/session.db
+#   ~/.copilot/session-state/<session-uuid>/plan.md
+#   ~/.copilot/session-state/<session-uuid>/checkpoints/
+#   ~/.copilot/session-state/<session-uuid>/files/
+
+set -euo pipefail
+
+SESSION_STATE_DIR="$HOME/.copilot/session-state"
+LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
+
+if [ -d "$SESSION_STATE_DIR" ]; then
+  echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
+  mkdir -p "$LOGS_DIR"
+  cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+  echo "Session state directory copied successfully"
+else
+  echo "No session-state directory found at $SESSION_STATE_DIR"
+fi

--- a/pkg/workflow/copilot_engine_execution.go
+++ b/pkg/workflow/copilot_engine_execution.go
@@ -434,11 +434,10 @@ func extractAddDirPaths(args []string) []string {
 	return dirs
 }
 
-// generateCopilotSessionFileCopyStep generates a step to copy Copilot session state files
-// from ~/.copilot/session-state/<session-uuid>/ to /tmp/gh-aw/sandbox/agent/logs/
-// This ensures session files are in /tmp/gh-aw/ where secret redaction can scan them.
-// Copilot CLI writes events.jsonl inside session subdirectories, so we use find
-// to recursively locate them and preserve the session ID in the filename.
+// generateCopilotSessionFileCopyStep generates a step to copy the entire Copilot
+// session-state directory from ~/.copilot/session-state/ to /tmp/gh-aw/sandbox/agent/logs/
+// This ensures all session files (events.jsonl, session.db, plan.md, checkpoints, etc.)
+// are in /tmp/gh-aw/ where secret redaction can scan them and they get uploaded as artifacts.
 func generateCopilotSessionFileCopyStep() GitHubActionStep {
 	var step []string
 
@@ -446,23 +445,16 @@ func generateCopilotSessionFileCopyStep() GitHubActionStep {
 	step = append(step, "        if: always()")
 	step = append(step, "        continue-on-error: true")
 	step = append(step, "        run: |")
-	step = append(step, "          # Copy Copilot session state files to logs folder for artifact collection")
+	step = append(step, "          # Copy entire Copilot session-state directory to logs for artifact collection")
 	step = append(step, "          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them")
 	step = append(step, "          SESSION_STATE_DIR=\"$HOME/.copilot/session-state\"")
-	step = append(step, "          LOGS_DIR=\"/tmp/gh-aw/sandbox/agent/logs\"")
+	step = append(step, "          LOGS_DIR=\"/tmp/gh-aw/sandbox/agent/logs/copilot-session-state\"")
 	step = append(step, "          ")
 	step = append(step, "          if [ -d \"$SESSION_STATE_DIR\" ]; then")
-	step = append(step, "            echo \"Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR\"")
+	step = append(step, "            echo \"Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR\"")
 	step = append(step, "            mkdir -p \"$LOGS_DIR\"")
-	step = append(step, "            # Copilot CLI writes events.jsonl inside session subdirectories:")
-	step = append(step, "            #   ~/.copilot/session-state/<session-uuid>/events.jsonl")
-	step = append(step, "            # Use find to recursively locate .jsonl files and preserve session ID in filename")
-	step = append(step, "            find \"$SESSION_STATE_DIR\" -name '*.jsonl' -type f | while read -r f; do")
-	step = append(step, "              session_id=$(basename \"$(dirname \"$f\")\")")
-	step = append(step, "              filename=$(basename \"$f\" .jsonl)")
-	step = append(step, "              cp -v \"$f\" \"$LOGS_DIR/${filename}-${session_id}.jsonl\"")
-	step = append(step, "            done")
-	step = append(step, "            echo \"Session state files copied successfully\"")
+	step = append(step, "            cp -rv \"$SESSION_STATE_DIR\"/. \"$LOGS_DIR/\" 2>/dev/null || true")
+	step = append(step, "            echo \"Session state directory copied successfully\"")
 	step = append(step, "          else")
 	step = append(step, "            echo \"No session-state directory found at $SESSION_STATE_DIR\"")
 	step = append(step, "          fi")

--- a/pkg/workflow/copilot_engine_execution.go
+++ b/pkg/workflow/copilot_engine_execution.go
@@ -438,26 +438,14 @@ func extractAddDirPaths(args []string) []string {
 // session-state directory from ~/.copilot/session-state/ to /tmp/gh-aw/sandbox/agent/logs/
 // This ensures all session files (events.jsonl, session.db, plan.md, checkpoints, etc.)
 // are in /tmp/gh-aw/ where secret redaction can scan them and they get uploaded as artifacts.
+// The logic is in actions/setup/sh/copy_copilot_session_state.sh.
 func generateCopilotSessionFileCopyStep() GitHubActionStep {
 	var step []string
 
 	step = append(step, "      - name: Copy Copilot session state files to logs")
 	step = append(step, "        if: always()")
 	step = append(step, "        continue-on-error: true")
-	step = append(step, "        run: |")
-	step = append(step, "          # Copy entire Copilot session-state directory to logs for artifact collection")
-	step = append(step, "          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them")
-	step = append(step, "          SESSION_STATE_DIR=\"$HOME/.copilot/session-state\"")
-	step = append(step, "          LOGS_DIR=\"/tmp/gh-aw/sandbox/agent/logs/copilot-session-state\"")
-	step = append(step, "          ")
-	step = append(step, "          if [ -d \"$SESSION_STATE_DIR\" ]; then")
-	step = append(step, "            echo \"Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR\"")
-	step = append(step, "            mkdir -p \"$LOGS_DIR\"")
-	step = append(step, "            cp -rv \"$SESSION_STATE_DIR\"/. \"$LOGS_DIR/\" 2>/dev/null || true")
-	step = append(step, "            echo \"Session state directory copied successfully\"")
-	step = append(step, "          else")
-	step = append(step, "            echo \"No session-state directory found at $SESSION_STATE_DIR\"")
-	step = append(step, "          fi")
+	step = append(step, "        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh")
 
 	return GitHubActionStep(step)
 }

--- a/pkg/workflow/copilot_engine_execution.go
+++ b/pkg/workflow/copilot_engine_execution.go
@@ -435,8 +435,10 @@ func extractAddDirPaths(args []string) []string {
 }
 
 // generateCopilotSessionFileCopyStep generates a step to copy Copilot session state files
-// from ~/.copilot/session-state/ to /tmp/gh-aw/sandbox/agent/logs/
-// This ensures session files are in /tmp/gh-aw/ where secret redaction can scan them
+// from ~/.copilot/session-state/<session-uuid>/ to /tmp/gh-aw/sandbox/agent/logs/
+// This ensures session files are in /tmp/gh-aw/ where secret redaction can scan them.
+// Copilot CLI writes events.jsonl inside session subdirectories, so we use find
+// to recursively locate them and preserve the session ID in the filename.
 func generateCopilotSessionFileCopyStep() GitHubActionStep {
 	var step []string
 
@@ -452,7 +454,14 @@ func generateCopilotSessionFileCopyStep() GitHubActionStep {
 	step = append(step, "          if [ -d \"$SESSION_STATE_DIR\" ]; then")
 	step = append(step, "            echo \"Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR\"")
 	step = append(step, "            mkdir -p \"$LOGS_DIR\"")
-	step = append(step, "            cp -v \"$SESSION_STATE_DIR\"/*.jsonl \"$LOGS_DIR/\" 2>/dev/null || true")
+	step = append(step, "            # Copilot CLI writes events.jsonl inside session subdirectories:")
+	step = append(step, "            #   ~/.copilot/session-state/<session-uuid>/events.jsonl")
+	step = append(step, "            # Use find to recursively locate .jsonl files and preserve session ID in filename")
+	step = append(step, "            find \"$SESSION_STATE_DIR\" -name '*.jsonl' -type f | while read -r f; do")
+	step = append(step, "              session_id=$(basename \"$(dirname \"$f\")\")")
+	step = append(step, "              filename=$(basename \"$f\" .jsonl)")
+	step = append(step, "              cp -v \"$f\" \"$LOGS_DIR/${filename}-${session_id}.jsonl\"")
+	step = append(step, "            done")
 	step = append(step, "            echo \"Session state files copied successfully\"")
 	step = append(step, "          else")
 	step = append(step, "            echo \"No session-state directory found at $SESSION_STATE_DIR\"")

--- a/pkg/workflow/copilot_engine_test.go
+++ b/pkg/workflow/copilot_engine_test.go
@@ -1418,14 +1418,14 @@ func TestGenerateCopilotSessionFileCopyStep(t *testing.T) {
 	if !strings.Contains(content, "always()") {
 		t.Error("Step should run always()")
 	}
-	if !strings.Contains(content, ".copilot/session-state") {
-		t.Error("Step should reference the Copilot session-state directory")
-	}
-	if !strings.Contains(content, "/tmp/gh-aw/sandbox/agent/logs") {
-		t.Error("Step should copy files into the gh-aw logs directory")
-	}
 	if !strings.Contains(content, "continue-on-error: true") {
 		t.Error("Step should be marked continue-on-error")
+	}
+	if !strings.Contains(content, "copy_copilot_session_state.sh") {
+		t.Error("Step should invoke copy_copilot_session_state.sh")
+	}
+	if !strings.Contains(content, "${RUNNER_TEMP}/gh-aw/actions/") {
+		t.Error("Step should reference script via ${RUNNER_TEMP}/gh-aw/actions/")
 	}
 }
 

--- a/pkg/workflow/copilot_session_copy_test.go
+++ b/pkg/workflow/copilot_session_copy_test.go
@@ -49,9 +49,20 @@ func TestCopilotSessionFileCopyStep(t *testing.T) {
 		t.Error("Expected step to reference '/tmp/gh-aw/sandbox/agent/logs' directory")
 	}
 
-	// Verify .jsonl file copy
+	// Verify recursive find for .jsonl files in session subdirectories
+	if !strings.Contains(stepContent, "find") {
+		t.Error("Expected step to use 'find' for recursive .jsonl file discovery")
+	}
 	if !strings.Contains(stepContent, "*.jsonl") {
-		t.Error("Expected step to copy *.jsonl files")
+		t.Error("Expected step to search for *.jsonl files")
+	}
+
+	// Verify session ID is preserved in the output filename
+	if !strings.Contains(stepContent, "session_id=$(basename") {
+		t.Error("Expected step to extract session_id from parent directory")
+	}
+	if !strings.Contains(stepContent, "${filename}-${session_id}.jsonl") {
+		t.Error("Expected step to include session_id in output filename to avoid collisions")
 	}
 
 	// Verify cp command

--- a/pkg/workflow/copilot_session_copy_test.go
+++ b/pkg/workflow/copilot_session_copy_test.go
@@ -39,18 +39,13 @@ func TestCopilotSessionFileCopyStep(t *testing.T) {
 		t.Error("Expected step to have 'continue-on-error: true'")
 	}
 
-	// Verify source directory reference
-	if !strings.Contains(stepContent, "$HOME/.copilot/session-state") {
-		t.Error("Expected step to reference '$HOME/.copilot/session-state' directory")
+	// Verify it delegates to the external shell script
+	if !strings.Contains(stepContent, "copy_copilot_session_state.sh") {
+		t.Error("Expected step to invoke copy_copilot_session_state.sh")
 	}
 
-	// Verify target is a dedicated subdirectory under logs
-	if !strings.Contains(stepContent, "/tmp/gh-aw/sandbox/agent/logs/copilot-session-state") {
-		t.Error("Expected step to copy to '/tmp/gh-aw/sandbox/agent/logs/copilot-session-state'")
-	}
-
-	// Verify recursive copy of entire directory tree
-	if !strings.Contains(stepContent, "cp -rv") {
-		t.Error("Expected step to use 'cp -rv' for recursive directory copy")
+	// Verify it uses the RUNNER_TEMP-based actions path
+	if !strings.Contains(stepContent, "${RUNNER_TEMP}/gh-aw/actions/") {
+		t.Error("Expected step to reference script via ${RUNNER_TEMP}/gh-aw/actions/")
 	}
 }

--- a/pkg/workflow/copilot_session_copy_test.go
+++ b/pkg/workflow/copilot_session_copy_test.go
@@ -44,29 +44,13 @@ func TestCopilotSessionFileCopyStep(t *testing.T) {
 		t.Error("Expected step to reference '$HOME/.copilot/session-state' directory")
 	}
 
-	// Verify target directory reference
-	if !strings.Contains(stepContent, "/tmp/gh-aw/sandbox/agent/logs") {
-		t.Error("Expected step to reference '/tmp/gh-aw/sandbox/agent/logs' directory")
+	// Verify target is a dedicated subdirectory under logs
+	if !strings.Contains(stepContent, "/tmp/gh-aw/sandbox/agent/logs/copilot-session-state") {
+		t.Error("Expected step to copy to '/tmp/gh-aw/sandbox/agent/logs/copilot-session-state'")
 	}
 
-	// Verify recursive find for .jsonl files in session subdirectories
-	if !strings.Contains(stepContent, "find") {
-		t.Error("Expected step to use 'find' for recursive .jsonl file discovery")
-	}
-	if !strings.Contains(stepContent, "*.jsonl") {
-		t.Error("Expected step to search for *.jsonl files")
-	}
-
-	// Verify session ID is preserved in the output filename
-	if !strings.Contains(stepContent, "session_id=$(basename") {
-		t.Error("Expected step to extract session_id from parent directory")
-	}
-	if !strings.Contains(stepContent, "${filename}-${session_id}.jsonl") {
-		t.Error("Expected step to include session_id in output filename to avoid collisions")
-	}
-
-	// Verify cp command
-	if !strings.Contains(stepContent, "cp -v") {
-		t.Error("Expected step to use 'cp -v' command")
+	// Verify recursive copy of entire directory tree
+	if !strings.Contains(stepContent, "cp -rv") {
+		t.Error("Expected step to use 'cp -rv' for recursive directory copy")
 	}
 }

--- a/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/basic-copilot.golden
+++ b/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/basic-copilot.golden
@@ -403,23 +403,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/basic-copilot.golden
+++ b/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/basic-copilot.golden
@@ -402,20 +402,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/basic-copilot.golden
+++ b/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/basic-copilot.golden
@@ -411,7 +411,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"

--- a/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/with-imports.golden
+++ b/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/with-imports.golden
@@ -403,20 +403,7 @@ jobs:
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
-        run: |
-          # Copy entire Copilot session-state directory to logs for artifact collection
-          # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
-          SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
-          
-          if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
-            mkdir -p "$LOGS_DIR"
-            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
-            echo "Session state directory copied successfully"
-          else
-            echo "No session-state directory found at $SESSION_STATE_DIR"
-          fi
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/copy_copilot_session_state.sh
       - name: Stop MCP Gateway
         if: always()
         continue-on-error: true

--- a/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/with-imports.golden
+++ b/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/with-imports.golden
@@ -404,23 +404,16 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          # Copy Copilot session state files to logs folder for artifact collection
+          # Copy entire Copilot session-state directory to logs for artifact collection
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
-          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
+          LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs/copilot-session-state"
           
           if [ -d "$SESSION_STATE_DIR" ]; then
-            echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
+            echo "Copying Copilot session state from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            # Copilot CLI writes events.jsonl inside session subdirectories:
-            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
-            # Use find to recursively locate .jsonl files and preserve session ID in filename
-            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
-              session_id=$(basename "$(dirname "$f")")
-              filename=$(basename "$f" .jsonl)
-              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
-            done
-            echo "Session state files copied successfully"
+            cp -rv "$SESSION_STATE_DIR"/. "$LOGS_DIR/" 2>/dev/null || true
+            echo "Session state directory copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"
           fi

--- a/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/with-imports.golden
+++ b/pkg/workflow/testdata/wasm_golden/TestWasmGolden_CompileFixtures/with-imports.golden
@@ -412,7 +412,14 @@ jobs:
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
-            cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true
+            # Copilot CLI writes events.jsonl inside session subdirectories:
+            #   ~/.copilot/session-state/<session-uuid>/events.jsonl
+            # Use find to recursively locate .jsonl files and preserve session ID in filename
+            find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
+              session_id=$(basename "$(dirname "$f")")
+              filename=$(basename "$f" .jsonl)
+              cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
+            done
             echo "Session state files copied successfully"
           else
             echo "No session-state directory found at $SESSION_STATE_DIR"


### PR DESCRIPTION
## Problem

The "Copy Copilot session state files to logs" step used a flat glob pattern (`$SESSION_STATE_DIR/*.jsonl`) that only matched files at the top level of `~/.copilot/session-state/`. However, Copilot CLI writes `events.jsonl` inside session subdirectories:

```
~/.copilot/session-state/
  <session-uuid>/
    events.jsonl    ← never matched by flat glob
    session.db
    plan.md
```

This meant the copy silently succeeded with zero files, and no `events.jsonl` appeared in workflow artifacts.

## Fix

Replaced the flat glob with `find` for recursive discovery:

```bash
# Before (broken)
cp -v "$SESSION_STATE_DIR"/*.jsonl "$LOGS_DIR/" 2>/dev/null || true

# After (fixed)
find "$SESSION_STATE_DIR" -name '*.jsonl' -type f | while read -r f; do
  session_id=$(basename "$(dirname "$f")")
  filename=$(basename "$f" .jsonl)
  cp -v "$f" "$LOGS_DIR/${filename}-${session_id}.jsonl"
done
```

The session ID is preserved in the output filename (`events-<session-uuid>.jsonl`) to avoid collisions if multiple sessions ran in the same workflow.

## Files changed

| File | Change |
|------|--------|
| `pkg/workflow/copilot_engine_execution.go` | Replace flat glob with recursive find |
| `pkg/workflow/copilot_session_copy_test.go` | Update test assertions for new logic |
| 121 `.lock.yml` files + wasm golden files | Recompiled |

Closes #23990

---

---
✨ PR Review Safe Output Test - Run 23882603888

> 💥 *[THE END] — Illustrated by [Smoke Claude](https://github.com/github/gh-aw/actions/runs/23882603888)* · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fsmoke-claude%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Smoke Claude, engine: claude, model: auto, id: 23882603888, workflow_id: smoke-claude, run: https://github.com/github/gh-aw/actions/runs/23882603888 -->