### PR TITLE
fix: eliminate piped while loops in token optimizer workflows

### DIFF
--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c83cbc1cff24dbfa71c9758e4780a18e718794d2c3a21faef06342d049bf88d9","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e548ad0bac042ffe9ee9929d5ca90115d0d981f73c87902a8178b17947616869","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a17ce043f710c3ae_EOF'
+          cat << 'GH_AW_PROMPT_e5e6cd140cb03f4e_EOF'
           <system>
-          GH_AW_PROMPT_a17ce043f710c3ae_EOF
+          GH_AW_PROMPT_e5e6cd140cb03f4e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a17ce043f710c3ae_EOF'
+          cat << 'GH_AW_PROMPT_e5e6cd140cb03f4e_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a17ce043f710c3ae_EOF
+          GH_AW_PROMPT_e5e6cd140cb03f4e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a17ce043f710c3ae_EOF'
+          cat << 'GH_AW_PROMPT_e5e6cd140cb03f4e_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_a17ce043f710c3ae_EOF
+          GH_AW_PROMPT_e5e6cd140cb03f4e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Claude workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflowName) |\n  map({\n    workflow: .[0].workflowName,\n    total_tokens: (map(.tokenUsage) | add),\n    total_cost: (map(.estimatedCost) | add),\n    run_count: length,\n    avg_tokens: ((map(.tokenUsage) | add) / length),\n    run_ids: map(.databaseId),\n    latest_run_id: (sort_by(.createdAt) | last | .databaseId),\n    latest_run_url: (sort_by(.createdAt) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 | while read -r f; do\n    echo \"Found: $f\"\n    cp \"$f\" /tmp/token-optimizer-claude/workflow-source.md\n  done\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflowName) |\n  map({\n    workflow: .[0].workflowName,\n    total_tokens: (map(.tokenUsage) | add),\n    total_cost: (map(.estimatedCost) | add),\n    run_count: length,\n    avg_tokens: ((map(.tokenUsage) | add) / length),\n    run_ids: map(.databaseId),\n    latest_run_id: (sort_by(.createdAt) | last | .databaseId),\n    latest_run_url: (sort_by(.createdAt) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c4cf3ee925b78e9_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_99f3c82673c40c75_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4c4cf3ee925b78e9_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_99f3c82673c40c75_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_23157a90a325d224_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_016c509bb887d8a7_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_23157a90a325d224_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_33654cf1e6094598_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_016c509bb887d8a7_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8bdfec3203e0fed8_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_33654cf1e6094598_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8bdfec3203e0fed8_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_aa127544f74137f8_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_7859ed28542ae487_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_aa127544f74137f8_EOF
+          GH_AW_MCP_CONFIG_7859ed28542ae487_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -163,10 +163,11 @@ steps:
         echo "Found workflow source: $WORKFLOW_MD"
         cp "$WORKFLOW_MD" /tmp/token-optimizer-claude/workflow-source.md
       else
-        find .github/workflows -name "*.md" -exec grep -l "^name: $WORKFLOW_NAME" {} \; 2>/dev/null | head -1 | while read -r f; do
-          echo "Found: $f"
-          cp "$f" /tmp/token-optimizer-claude/workflow-source.md
-        done
+        FOUND_MD=$(find .github/workflows -name "*.md" -exec grep -l "^name: $WORKFLOW_NAME" {} \; 2>/dev/null | head -1 || true)
+        if [ -n "$FOUND_MD" ]; then
+          echo "Found: $FOUND_MD"
+          cp "$FOUND_MD" /tmp/token-optimizer-claude/workflow-source.md
+        fi
       fi
 
       # Extract declared tools from workflow source

--- a/.github/workflows/claude-token-usage-analyzer.lock.yml
+++ b/.github/workflows/claude-token-usage-analyzer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5c042e9e442b822988d57ea30644cddb18c6992ee6beb461b84ac594f80f47e6","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e69b0617753455baec21652278430e9c3520a4d1be3eb97cd0032ddd5d6857c1","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Usage Analyzer"
 "on":
@@ -132,14 +132,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_0ecfe1847da03198_EOF'
+          cat << 'GH_AW_PROMPT_8006b394fe911ee1_EOF'
           <system>
-          GH_AW_PROMPT_0ecfe1847da03198_EOF
+          GH_AW_PROMPT_8006b394fe911ee1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0ecfe1847da03198_EOF'
+          cat << 'GH_AW_PROMPT_8006b394fe911ee1_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -171,13 +171,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0ecfe1847da03198_EOF
+          GH_AW_PROMPT_8006b394fe911ee1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0ecfe1847da03198_EOF'
+          cat << 'GH_AW_PROMPT_8006b394fe911ee1_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-usage-analyzer.md}}
-          GH_AW_PROMPT_0ecfe1847da03198_EOF
+          GH_AW_PROMPT_8006b394fe911ee1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -310,7 +310,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Claude workflow runs (last 24h)
-        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer-claude\n\necho \"📥 Downloading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer-claude/claude-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Claude workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\nARTIFACT_DIR=\"/tmp/token-analyzer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50] | .[].databaseId' /tmp/token-analyzer-claude/claude-runs.json > /tmp/token-analyzer-claude/run-ids.txt\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer-claude/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer-claude/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer-claude/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer-claude/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer-claude\n\necho \"📥 Downloading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer-claude/claude-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Claude workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\nARTIFACT_DIR=\"/tmp/token-analyzer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.databaseId' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer-claude/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer-claude/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer-claude/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer-claude/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
 
       - name: Configure Git credentials
         env:
@@ -361,12 +361,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c33e76cf19082c1c_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_6145119542beae75_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","claude"],"max":1,"title_prefix":"📊 Claude Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c33e76cf19082c1c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6145119542beae75_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_71ab35b782bdd9cc_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_eaa180fbfdb4f218_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Claude Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"claude\"] will be automatically added."
@@ -374,8 +374,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_71ab35b782bdd9cc_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2c61931508ce5446_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_eaa180fbfdb4f218_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8bb554f7bb6db76c_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -468,7 +468,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_2c61931508ce5446_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8bb554f7bb6db76c_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -538,7 +538,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_62f3de0818863ac6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_b511e335517d7f14_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -579,7 +579,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_62f3de0818863ac6_EOF
+          GH_AW_MCP_CONFIG_b511e335517d7f14_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-usage-analyzer.md
+++ b/.github/workflows/claude-token-usage-analyzer.md
@@ -69,7 +69,7 @@ steps:
       mkdir -p "$ARTIFACT_DIR"
 
       echo "📥 Downloading token-usage.jsonl artifacts..."
-      jq -r '.[0:50] | .[].databaseId' /tmp/token-analyzer-claude/claude-runs.json > /tmp/token-analyzer-claude/run-ids.txt
+      jq -r '.[0:50][]?.databaseId' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true
       while read -r run_id; do
         run_dir="$ARTIFACT_DIR/$run_id"
         mkdir -p "$run_dir"

--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"32da6f54a544abc78649fa29cb833a2e9c73ae28431e2a0384d7c8b74696653b","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8f59f14c06aff09cf7fdc31208a784b762c3c12b7d12fa5d1bb3a2dbfe6567c","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_2c9b7bbaa51e30c1_EOF'
+          cat << 'GH_AW_PROMPT_9c06ceb9fc3e8446_EOF'
           <system>
-          GH_AW_PROMPT_2c9b7bbaa51e30c1_EOF
+          GH_AW_PROMPT_9c06ceb9fc3e8446_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2c9b7bbaa51e30c1_EOF'
+          cat << 'GH_AW_PROMPT_9c06ceb9fc3e8446_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2c9b7bbaa51e30c1_EOF
+          GH_AW_PROMPT_9c06ceb9fc3e8446_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2c9b7bbaa51e30c1_EOF'
+          cat << 'GH_AW_PROMPT_9c06ceb9fc3e8446_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_2c9b7bbaa51e30c1_EOF
+          GH_AW_PROMPT_9c06ceb9fc3e8446_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Copilot workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\necho \"📥 Loading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflowName) |\n  map({\n    workflow: .[0].workflowName,\n    total_tokens: (map(.tokenUsage) | add),\n    total_cost: (map(.estimatedCost) | add),\n    run_count: length,\n    avg_tokens: ((map(.tokenUsage) | add) / length),\n    run_ids: map(.databaseId),\n    latest_run_id: (sort_by(.createdAt) | last | .databaseId),\n    latest_run_url: (sort_by(.createdAt) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 | while read -r f; do\n    echo \"Found: $f\"\n    cp \"$f\" /tmp/token-optimizer/workflow-source.md\n  done\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\necho \"📥 Loading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflowName) |\n  map({\n    workflow: .[0].workflowName,\n    total_tokens: (map(.tokenUsage) | add),\n    total_cost: (map(.estimatedCost) | add),\n    run_count: length,\n    avg_tokens: ((map(.tokenUsage) | add) / length),\n    run_ids: map(.databaseId),\n    latest_run_id: (sort_by(.createdAt) | last | .databaseId),\n    latest_run_url: (sort_by(.createdAt) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e7194fc724a1e551_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_bdb51c7b3aee79ae_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e7194fc724a1e551_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_bdb51c7b3aee79ae_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_39bb3f93a4eeb96c_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5f6440cb818356b0_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_39bb3f93a4eeb96c_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b3c4cfffbfd1bf0b_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_5f6440cb818356b0_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_685e42b2b99de53a_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_b3c4cfffbfd1bf0b_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_685e42b2b99de53a_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_4cdbc74765fcc5fe_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_ce5a4d1c93479cfc_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4cdbc74765fcc5fe_EOF
+          GH_AW_MCP_CONFIG_ce5a4d1c93479cfc_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -137,10 +137,11 @@ steps:
         cp "$WORKFLOW_MD" /tmp/token-optimizer/workflow-source.md
       else
         echo "Workflow source not found at $WORKFLOW_MD, searching..."
-        find .github/workflows -name "*.md" -exec grep -l "^name: $WORKFLOW_NAME" {} \; 2>/dev/null | head -1 | while read -r f; do
-          echo "Found: $f"
-          cp "$f" /tmp/token-optimizer/workflow-source.md
-        done
+        FOUND_MD=$(find .github/workflows -name "*.md" -exec grep -l "^name: $WORKFLOW_NAME" {} \; 2>/dev/null | head -1 || true)
+        if [ -n "$FOUND_MD" ]; then
+          echo "Found: $FOUND_MD"
+          cp "$FOUND_MD" /tmp/token-optimizer/workflow-source.md
+        fi
       fi
 
       # Extract declared tools from workflow source (if available)


### PR DESCRIPTION
Follow-up to PR #24350 — applies the same pipefail-safe patterns to the remaining token workflows.

## Changes

### Optimizer workflows (copilot + claude)
Replace `find | head -1 | while read` piped pattern with command substitution:
```bash
# Before (SIGPIPE risk under pipefail)
find ... | head -1 | while read -r f; do cp "$f" ...; done

# After (safe)
FOUND_MD=$(find ... | head -1 || true)
if [ -n "$FOUND_MD" ]; then cp "$FOUND_MD" ...; fi
```

### Claude analyzer consistency fix
Align `jq` invocation with copilot variant:
- Use `[]?.databaseId` (optional object access) instead of `.[].databaseId`
- Add `2>/dev/null || true` error handling

## Affected workflows
- `copilot-token-optimizer.md`
- `claude-token-optimizer.md`
- `claude-token-usage-analyzer.md` (jq consistency fix only)