### PR TITLE
fix: align token workflows with gh-aw logs --json schema and add shared log caching

### DIFF
--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d28ca01966ea04e0f3dbad739cdce71c88eef80ccc8091c3cbff3401dac2e05c","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"13c7cfc5295aa61b7c28a922b22cd0b487ba6300261433bc1162560a4ccf53dc","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
+          cat << 'GH_AW_PROMPT_589ef83e3bd3cda7_EOF'
           <system>
-          GH_AW_PROMPT_b4eb75949c6211e2_EOF
+          GH_AW_PROMPT_589ef83e3bd3cda7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
+          cat << 'GH_AW_PROMPT_589ef83e3bd3cda7_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b4eb75949c6211e2_EOF
+          GH_AW_PROMPT_589ef83e3bd3cda7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
+          cat << 'GH_AW_PROMPT_589ef83e3bd3cda7_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_b4eb75949c6211e2_EOF
+          GH_AW_PROMPT_589ef83e3bd3cda7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Claude workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0fb88f09872c1369_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_3e75008c6ba33aa9_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0fb88f09872c1369_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3e75008c6ba33aa9_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_971214b094014a4d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_38b3fd6c6344de36_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_971214b094014a4d_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ad5d398c6bc28877_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_38b3fd6c6344de36_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9ad1a16787d3f182_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ad5d398c6bc28877_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_9ad1a16787d3f182_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_c6bfa07f5408b430_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_725b2de35e77c40e_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c6bfa07f5408b430_EOF
+          GH_AW_MCP_CONFIG_725b2de35e77c40e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d28ca01966ea04e0f3dbad739cdce71c88eef80ccc8091c3cbff3401dac2e05c","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"dbff5ee16cfc21a95e26ce60664927bc565c0ad0b4ea980493be8dfb278f7302","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
+          cat << 'GH_AW_PROMPT_39ebff004f890f10_EOF'
           <system>
-          GH_AW_PROMPT_b4eb75949c6211e2_EOF
+          GH_AW_PROMPT_39ebff004f890f10_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
+          cat << 'GH_AW_PROMPT_39ebff004f890f10_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b4eb75949c6211e2_EOF
+          GH_AW_PROMPT_39ebff004f890f10_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
+          cat << 'GH_AW_PROMPT_39ebff004f890f10_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_b4eb75949c6211e2_EOF
+          GH_AW_PROMPT_39ebff004f890f10_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Claude workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-claude-optimizer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" /tmp/token-optimizer-claude/claude-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Loading Claude workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0fb88f09872c1369_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_12e7e3b2b944d6ca_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0fb88f09872c1369_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_12e7e3b2b944d6ca_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_971214b094014a4d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_163d89fa6c431e34_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_971214b094014a4d_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ad5d398c6bc28877_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_163d89fa6c431e34_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_1f62702e2eb2fc94_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ad5d398c6bc28877_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_1f62702e2eb2fc94_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_c6bfa07f5408b430_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_38aabebdf2375b48_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c6bfa07f5408b430_EOF
+          GH_AW_MCP_CONFIG_38aabebdf2375b48_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e548ad0bac042ffe9ee9929d5ca90115d0d981f73c87902a8178b17947616869","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d28ca01966ea04e0f3dbad739cdce71c88eef80ccc8091c3cbff3401dac2e05c","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_e5e6cd140cb03f4e_EOF'
+          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
           <system>
-          GH_AW_PROMPT_e5e6cd140cb03f4e_EOF
+          GH_AW_PROMPT_b4eb75949c6211e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e5e6cd140cb03f4e_EOF'
+          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e5e6cd140cb03f4e_EOF
+          GH_AW_PROMPT_b4eb75949c6211e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e5e6cd140cb03f4e_EOF'
+          cat << 'GH_AW_PROMPT_b4eb75949c6211e2_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_e5e6cd140cb03f4e_EOF
+          GH_AW_PROMPT_b4eb75949c6211e2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Claude workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflowName) |\n  map({\n    workflow: .[0].workflowName,\n    total_tokens: (map(.tokenUsage) | add),\n    total_cost: (map(.estimatedCost) | add),\n    run_count: length,\n    avg_tokens: ((map(.tokenUsage) | add) / length),\n    run_ids: map(.databaseId),\n    latest_run_id: (sort_by(.createdAt) | last | .databaseId),\n    latest_run_url: (sort_by(.createdAt) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\necho \"📥 Loading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_99f3c82673c40c75_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0fb88f09872c1369_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_99f3c82673c40c75_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0fb88f09872c1369_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_016c509bb887d8a7_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_971214b094014a4d_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_016c509bb887d8a7_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8bdfec3203e0fed8_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_971214b094014a4d_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ad5d398c6bc28877_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_8bdfec3203e0fed8_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_ad5d398c6bc28877_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_7859ed28542ae487_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_c6bfa07f5408b430_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7859ed28542ae487_EOF
+          GH_AW_MCP_CONFIG_c6bfa07f5408b430_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -61,16 +61,45 @@ steps:
       set -euo pipefail
       mkdir -p /tmp/token-optimizer-claude
 
-      echo "📥 Loading Claude workflow runs from last 24 hours..."
-      gh aw logs \
-        --engine claude \
-        --start-date -1d \
-        --json \
-        -c 300 \
-        > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json
+      # Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls
+      TODAY=$(date -u +%Y-%m-%d)
+      FETCH_RUN_ID=$(gh run list \
+        --workflow "token-logs-fetch.lock.yml" \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' 2>/dev/null || echo "")
+      USED_CACHE=false
+      if [ -n "$FETCH_RUN_ID" ]; then
+        CACHE_TMP="/tmp/token-logs-cache-claude-optimizer"
+        mkdir -p "$CACHE_TMP"
+        gh run download "$FETCH_RUN_ID" \
+          --repo "$GITHUB_REPOSITORY" \
+          --name "cache-memory" \
+          --dir "$CACHE_TMP" \
+          2>/dev/null || true
+        CACHE_DATE=$(cat "$CACHE_TMP/token-logs/fetch-date.txt" 2>/dev/null || echo "")
+        if [ "$CACHE_DATE" = "$TODAY" ] && [ -s "$CACHE_TMP/token-logs/claude-runs.json" ]; then
+          echo "✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)"
+          cp "$CACHE_TMP/token-logs/claude-runs.json" /tmp/token-optimizer-claude/claude-runs.json
+          USED_CACHE=true
+        else
+          echo "ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)"
+        fi
+      fi
 
-      # Extract runs array from the JSON output
-      jq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer-claude/claude-runs.json
+      if [ "$USED_CACHE" != "true" ]; then
+        echo "📥 Loading Claude workflow runs from last 24 hours..."
+        gh aw logs \
+          --engine claude \
+          --start-date -1d \
+          --json \
+          -c 300 \
+          > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json
+
+        # Extract runs array from the JSON output
+        jq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer-claude/claude-runs.json
+      fi
 
       RUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)
       echo "Found ${RUN_COUNT} Claude runs"

--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -83,6 +83,7 @@ steps:
       # Find the most expensive workflow (by total tokens across all its runs)
       echo "🔍 Identifying most expensive workflow..."
       jq -r '
+        sort_by(.workflow_name) |
         group_by(.workflow_name) |
         map({
           workflow: .[0].workflow_name,

--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -67,9 +67,12 @@ steps:
         --start-date -1d \
         --json \
         -c 300 \
-        > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer-claude/claude-runs.json
+        > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json
 
-      RUN_COUNT=$(jq '. | length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)
+      # Extract runs array from the JSON output
+      jq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer-claude/claude-runs.json
+
+      RUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)
       echo "Found ${RUN_COUNT} Claude runs"
 
       if [ "$RUN_COUNT" -eq 0 ]; then
@@ -80,16 +83,16 @@ steps:
       # Find the most expensive workflow (by total tokens across all its runs)
       echo "🔍 Identifying most expensive workflow..."
       jq -r '
-        group_by(.workflowName) |
+        group_by(.workflow_name) |
         map({
-          workflow: .[0].workflowName,
-          total_tokens: (map(.tokenUsage) | add),
-          total_cost: (map(.estimatedCost) | add),
+          workflow: .[0].workflow_name,
+          total_tokens: (map(.token_usage) | add),
+          total_cost: 0,
           run_count: length,
-          avg_tokens: ((map(.tokenUsage) | add) / length),
-          run_ids: map(.databaseId),
-          latest_run_id: (sort_by(.createdAt) | last | .databaseId),
-          latest_run_url: (sort_by(.createdAt) | last | .url)
+          avg_tokens: ((map(.token_usage) | add) / length),
+          run_ids: map(.database_id),
+          latest_run_id: (sort_by(.created_at) | last | .database_id),
+          latest_run_url: (sort_by(.created_at) | last | .url)
         }) |
         sort_by(.total_tokens) | reverse | .[0]
       ' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json

--- a/.github/workflows/claude-token-usage-analyzer.lock.yml
+++ b/.github/workflows/claude-token-usage-analyzer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e69b0617753455baec21652278430e9c3520a4d1be3eb97cd0032ddd5d6857c1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6d66eade0456e72f7633fe59372e82e86d56afc2d374492975124f67ea898cf1","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Usage Analyzer"
 "on":
@@ -132,14 +132,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_8006b394fe911ee1_EOF'
+          cat << 'GH_AW_PROMPT_e1a5813608bb58e3_EOF'
           <system>
-          GH_AW_PROMPT_8006b394fe911ee1_EOF
+          GH_AW_PROMPT_e1a5813608bb58e3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8006b394fe911ee1_EOF'
+          cat << 'GH_AW_PROMPT_e1a5813608bb58e3_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -171,13 +171,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8006b394fe911ee1_EOF
+          GH_AW_PROMPT_e1a5813608bb58e3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8006b394fe911ee1_EOF'
+          cat << 'GH_AW_PROMPT_e1a5813608bb58e3_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-usage-analyzer.md}}
-          GH_AW_PROMPT_8006b394fe911ee1_EOF
+          GH_AW_PROMPT_e1a5813608bb58e3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -310,7 +310,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Claude workflow runs (last 24h)
-        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer-claude\n\necho \"📥 Downloading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer-claude/claude-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Claude workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\nARTIFACT_DIR=\"/tmp/token-analyzer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.databaseId' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer-claude/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer-claude/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer-claude/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer-claude/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer-claude\n\necho \"📥 Downloading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-analyzer-claude/claude-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-analyzer-claude/claude-runs-raw.json > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer-claude/claude-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Claude workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\nARTIFACT_DIR=\"/tmp/token-analyzer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.database_id' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer-claude/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer-claude/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer-claude/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer-claude/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
 
       - name: Configure Git credentials
         env:
@@ -361,12 +361,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_6145119542beae75_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a4ba8bab8dcca375_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","claude"],"max":1,"title_prefix":"📊 Claude Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6145119542beae75_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a4ba8bab8dcca375_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_eaa180fbfdb4f218_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e2f42f9d919138fa_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Claude Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"claude\"] will be automatically added."
@@ -374,8 +374,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_eaa180fbfdb4f218_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8bb554f7bb6db76c_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_e2f42f9d919138fa_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_89ae148174e0a909_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -468,7 +468,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_8bb554f7bb6db76c_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_89ae148174e0a909_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -538,7 +538,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_b511e335517d7f14_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_d12389cf810a9482_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -579,7 +579,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b511e335517d7f14_EOF
+          GH_AW_MCP_CONFIG_d12389cf810a9482_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-usage-analyzer.lock.yml
+++ b/.github/workflows/claude-token-usage-analyzer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6d66eade0456e72f7633fe59372e82e86d56afc2d374492975124f67ea898cf1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8e6be7e2956872fe478a9ab8396eb583429c408d43b0bd1956735df464e90baf","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Usage Analyzer"
 "on":
@@ -132,14 +132,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_e1a5813608bb58e3_EOF'
+          cat << 'GH_AW_PROMPT_17d5d1cbaeff7d93_EOF'
           <system>
-          GH_AW_PROMPT_e1a5813608bb58e3_EOF
+          GH_AW_PROMPT_17d5d1cbaeff7d93_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e1a5813608bb58e3_EOF'
+          cat << 'GH_AW_PROMPT_17d5d1cbaeff7d93_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -171,13 +171,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e1a5813608bb58e3_EOF
+          GH_AW_PROMPT_17d5d1cbaeff7d93_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e1a5813608bb58e3_EOF'
+          cat << 'GH_AW_PROMPT_17d5d1cbaeff7d93_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-usage-analyzer.md}}
-          GH_AW_PROMPT_e1a5813608bb58e3_EOF
+          GH_AW_PROMPT_17d5d1cbaeff7d93_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -310,7 +310,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Claude workflow runs (last 24h)
-        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer-claude\n\necho \"📥 Downloading Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-analyzer-claude/claude-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-analyzer-claude/claude-runs-raw.json > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer-claude/claude-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Claude workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\nARTIFACT_DIR=\"/tmp/token-analyzer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.database_id' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer-claude/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer-claude/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer-claude/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer-claude/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer-claude\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-claude-analyzer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" /tmp/token-analyzer-claude/claude-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Claude workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-analyzer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-analyzer-claude/claude-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-analyzer-claude/claude-runs-raw.json > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer-claude/claude-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Claude workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\nARTIFACT_DIR=\"/tmp/token-analyzer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.database_id' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer-claude/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer-claude/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer-claude/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer-claude/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
 
       - name: Configure Git credentials
         env:
@@ -361,12 +361,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a4ba8bab8dcca375_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e591f4f8252fc42c_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","claude"],"max":1,"title_prefix":"📊 Claude Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a4ba8bab8dcca375_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e591f4f8252fc42c_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e2f42f9d919138fa_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_ec4b56ef535d93ce_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Claude Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"claude\"] will be automatically added."
@@ -374,8 +374,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_e2f42f9d919138fa_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_89ae148174e0a909_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_ec4b56ef535d93ce_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_3f99af1cbefc5c06_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -468,7 +468,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_89ae148174e0a909_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_3f99af1cbefc5c06_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -538,7 +538,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_d12389cf810a9482_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_959b0238f0b52450_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -579,7 +579,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d12389cf810a9482_EOF
+          GH_AW_MCP_CONFIG_959b0238f0b52450_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-usage-analyzer.md
+++ b/.github/workflows/claude-token-usage-analyzer.md
@@ -59,9 +59,12 @@ steps:
         --start-date -1d \
         --json \
         -c 300 \
-        > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer-claude/claude-runs.json
+        > /tmp/token-analyzer-claude/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-analyzer-claude/claude-runs-raw.json
 
-      RUN_COUNT=$(jq '. | length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)
+      # Extract runs array from the JSON output
+      jq '.runs // []' /tmp/token-analyzer-claude/claude-runs-raw.json > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer-claude/claude-runs.json
+
+      RUN_COUNT=$(jq 'length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)
       echo "✅ Found ${RUN_COUNT} Claude workflow runs"
 
       # Download token-usage.jsonl artifacts for per-model breakdown
@@ -69,7 +72,7 @@ steps:
       mkdir -p "$ARTIFACT_DIR"
 
       echo "📥 Downloading token-usage.jsonl artifacts..."
-      jq -r '.[0:50][]?.databaseId' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true
+      jq -r '.[0:50][]?.database_id' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null > /tmp/token-analyzer-claude/run-ids.txt || true
       while read -r run_id; do
         run_dir="$ARTIFACT_DIR/$run_id"
         mkdir -p "$run_dir"
@@ -119,7 +122,7 @@ You are the Claude Token Usage Analyzer. Your job is to analyze Claude/Anthropic
 
 Pre-downloaded data is available in `/tmp/token-analyzer-claude/`:
 
-- **`/tmp/token-analyzer-claude/claude-runs.json`** — All Claude workflow runs from the last 24 hours (array of run objects with `workflowName`, `databaseId`, `tokenUsage`, `estimatedCost`, `turns`, `url`, `conclusion`, etc.)
+- **`/tmp/token-analyzer-claude/claude-runs.json`** — All Claude workflow runs from the last 24 hours (array of run objects with `workflow_name`, `database_id`, `token_usage`, `turns`, `url`, `conclusion`, etc.)
 - **`/tmp/token-analyzer-claude/token-usage-merged.jsonl`** — Merged per-request token records from `firewall-audit-logs` artifacts, with fields: `model`, `provider`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `duration_ms`, `run_id`
 
 ## Analysis Process
@@ -129,7 +132,7 @@ Pre-downloaded data is available in `/tmp/token-analyzer-claude/`:
 Process `/tmp/token-analyzer-claude/claude-runs.json` to compute per-workflow statistics:
 
 ```bash
-jq -r '.[] | [.workflowName, .tokenUsage, .estimatedCost, .turns, .conclusion, .url, .databaseId] | @tsv' \
+jq -r '.[] | [.workflow_name, .token_usage, .turns, .conclusion, .url, .database_id] | @tsv' \
   /tmp/token-analyzer-claude/claude-runs.json
 ```
 

--- a/.github/workflows/claude-token-usage-analyzer.md
+++ b/.github/workflows/claude-token-usage-analyzer.md
@@ -53,16 +53,45 @@ steps:
       set -euo pipefail
       mkdir -p /tmp/token-analyzer-claude
 
-      echo "📥 Downloading Claude workflow runs from last 24 hours..."
-      gh aw logs \
-        --engine claude \
-        --start-date -1d \
-        --json \
-        -c 300 \
-        > /tmp/token-analyzer-claude/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-analyzer-claude/claude-runs-raw.json
+      # Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls
+      TODAY=$(date -u +%Y-%m-%d)
+      FETCH_RUN_ID=$(gh run list \
+        --workflow "token-logs-fetch.lock.yml" \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' 2>/dev/null || echo "")
+      USED_CACHE=false
+      if [ -n "$FETCH_RUN_ID" ]; then
+        CACHE_TMP="/tmp/token-logs-cache-claude-analyzer"
+        mkdir -p "$CACHE_TMP"
+        gh run download "$FETCH_RUN_ID" \
+          --repo "$GITHUB_REPOSITORY" \
+          --name "cache-memory" \
+          --dir "$CACHE_TMP" \
+          2>/dev/null || true
+        CACHE_DATE=$(cat "$CACHE_TMP/token-logs/fetch-date.txt" 2>/dev/null || echo "")
+        if [ "$CACHE_DATE" = "$TODAY" ] && [ -s "$CACHE_TMP/token-logs/claude-runs.json" ]; then
+          echo "✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)"
+          cp "$CACHE_TMP/token-logs/claude-runs.json" /tmp/token-analyzer-claude/claude-runs.json
+          USED_CACHE=true
+        else
+          echo "ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)"
+        fi
+      fi
 
-      # Extract runs array from the JSON output
-      jq '.runs // []' /tmp/token-analyzer-claude/claude-runs-raw.json > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer-claude/claude-runs.json
+      if [ "$USED_CACHE" != "true" ]; then
+        echo "📥 Downloading Claude workflow runs from last 24 hours..."
+        gh aw logs \
+          --engine claude \
+          --start-date -1d \
+          --json \
+          -c 300 \
+          > /tmp/token-analyzer-claude/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-analyzer-claude/claude-runs-raw.json
+
+        # Extract runs array from the JSON output
+        jq '.runs // []' /tmp/token-analyzer-claude/claude-runs-raw.json > /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer-claude/claude-runs.json
+      fi
 
       RUN_COUNT=$(jq 'length' /tmp/token-analyzer-claude/claude-runs.json 2>/dev/null || echo 0)
       echo "✅ Found ${RUN_COUNT} Claude workflow runs"

--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8f59f14c06aff09cf7fdc31208a784b762c3c12b7d12fa5d1bb3a2dbfe6567c","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fd23e1427b2313e8891e828fe49ebfd23bdc4abc966f587a004d381370a68f13","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_9c06ceb9fc3e8446_EOF'
+          cat << 'GH_AW_PROMPT_68c5831fe1087681_EOF'
           <system>
-          GH_AW_PROMPT_9c06ceb9fc3e8446_EOF
+          GH_AW_PROMPT_68c5831fe1087681_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9c06ceb9fc3e8446_EOF'
+          cat << 'GH_AW_PROMPT_68c5831fe1087681_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9c06ceb9fc3e8446_EOF
+          GH_AW_PROMPT_68c5831fe1087681_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9c06ceb9fc3e8446_EOF'
+          cat << 'GH_AW_PROMPT_68c5831fe1087681_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_9c06ceb9fc3e8446_EOF
+          GH_AW_PROMPT_68c5831fe1087681_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Copilot workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\necho \"📥 Loading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflowName) |\n  map({\n    workflow: .[0].workflowName,\n    total_tokens: (map(.tokenUsage) | add),\n    total_cost: (map(.estimatedCost) | add),\n    run_count: length,\n    avg_tokens: ((map(.tokenUsage) | add) / length),\n    run_ids: map(.databaseId),\n    latest_run_id: (sort_by(.createdAt) | last | .databaseId),\n    latest_run_url: (sort_by(.createdAt) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\necho \"📥 Loading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer/copilot-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_bdb51c7b3aee79ae_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_178afd5b56c5bba7_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bdb51c7b3aee79ae_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_178afd5b56c5bba7_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5f6440cb818356b0_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_cec4f6a3637a6d3b_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_5f6440cb818356b0_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_685e42b2b99de53a_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_cec4f6a3637a6d3b_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2089a1213782993a_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_685e42b2b99de53a_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_2089a1213782993a_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_ce5a4d1c93479cfc_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_27cc3fbbc713df4f_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ce5a4d1c93479cfc_EOF
+          GH_AW_MCP_CONFIG_27cc3fbbc713df4f_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fd23e1427b2313e8891e828fe49ebfd23bdc4abc966f587a004d381370a68f13","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4a77b0829a21910b7fa4fb4e195a1c5381fd9f6529ee7c616e10c45271ca5a6d","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_68c5831fe1087681_EOF'
+          cat << 'GH_AW_PROMPT_ab867cbc4c45e654_EOF'
           <system>
-          GH_AW_PROMPT_68c5831fe1087681_EOF
+          GH_AW_PROMPT_ab867cbc4c45e654_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_68c5831fe1087681_EOF'
+          cat << 'GH_AW_PROMPT_ab867cbc4c45e654_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_68c5831fe1087681_EOF
+          GH_AW_PROMPT_ab867cbc4c45e654_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_68c5831fe1087681_EOF'
+          cat << 'GH_AW_PROMPT_ab867cbc4c45e654_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_68c5831fe1087681_EOF
+          GH_AW_PROMPT_ab867cbc4c45e654_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Copilot workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\necho \"📥 Loading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer/copilot-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\necho \"📥 Loading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer/copilot-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_178afd5b56c5bba7_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_8004a01d2ab0d07a_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_178afd5b56c5bba7_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8004a01d2ab0d07a_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_cec4f6a3637a6d3b_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c400a077d5e74753_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_cec4f6a3637a6d3b_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2089a1213782993a_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_c400a077d5e74753_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_94580559ea46ee78_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_2089a1213782993a_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_94580559ea46ee78_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_27cc3fbbc713df4f_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_d40d7a82d24074ef_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_27cc3fbbc713df4f_EOF
+          GH_AW_MCP_CONFIG_d40d7a82d24074ef_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -67,9 +67,12 @@ steps:
         --start-date -1d \
         --json \
         -c 300 \
-        > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer/copilot-runs.json
+        > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-optimizer/copilot-runs-raw.json
 
-      RUN_COUNT=$(jq '. | length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)
+      # Extract runs array from the JSON output
+      jq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer/copilot-runs.json
+
+      RUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)
       echo "Found ${RUN_COUNT} Copilot runs"
 
       if [ "$RUN_COUNT" -eq 0 ]; then
@@ -80,16 +83,16 @@ steps:
       # Find the most expensive workflow (by total tokens across all its runs)
       echo "🔍 Identifying most expensive workflow..."
       jq -r '
-        group_by(.workflowName) |
+        group_by(.workflow_name) |
         map({
-          workflow: .[0].workflowName,
-          total_tokens: (map(.tokenUsage) | add),
-          total_cost: (map(.estimatedCost) | add),
+          workflow: .[0].workflow_name,
+          total_tokens: (map(.token_usage) | add),
+          total_cost: 0,
           run_count: length,
-          avg_tokens: ((map(.tokenUsage) | add) / length),
-          run_ids: map(.databaseId),
-          latest_run_id: (sort_by(.createdAt) | last | .databaseId),
-          latest_run_url: (sort_by(.createdAt) | last | .url)
+          avg_tokens: ((map(.token_usage) | add) / length),
+          run_ids: map(.database_id),
+          latest_run_id: (sort_by(.created_at) | last | .database_id),
+          latest_run_url: (sort_by(.created_at) | last | .url)
         }) |
         sort_by(.total_tokens) | reverse | .[0]
       ' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -61,16 +61,45 @@ steps:
       set -euo pipefail
       mkdir -p /tmp/token-optimizer
 
-      echo "📥 Loading Copilot workflow runs from last 24 hours..."
-      gh aw logs \
-        --engine copilot \
-        --start-date -1d \
-        --json \
-        -c 300 \
-        > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-optimizer/copilot-runs-raw.json
+      # Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls
+      TODAY=$(date -u +%Y-%m-%d)
+      FETCH_RUN_ID=$(gh run list \
+        --workflow "token-logs-fetch.lock.yml" \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' 2>/dev/null || echo "")
+      USED_CACHE=false
+      if [ -n "$FETCH_RUN_ID" ]; then
+        CACHE_TMP="/tmp/token-logs-cache-optimizer"
+        mkdir -p "$CACHE_TMP"
+        gh run download "$FETCH_RUN_ID" \
+          --repo "$GITHUB_REPOSITORY" \
+          --name "cache-memory" \
+          --dir "$CACHE_TMP" \
+          2>/dev/null || true
+        CACHE_DATE=$(cat "$CACHE_TMP/token-logs/fetch-date.txt" 2>/dev/null || echo "")
+        if [ "$CACHE_DATE" = "$TODAY" ] && [ -s "$CACHE_TMP/token-logs/copilot-runs.json" ]; then
+          echo "✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)"
+          cp "$CACHE_TMP/token-logs/copilot-runs.json" /tmp/token-optimizer/copilot-runs.json
+          USED_CACHE=true
+        else
+          echo "ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)"
+        fi
+      fi
 
-      # Extract runs array from the JSON output
-      jq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer/copilot-runs.json
+      if [ "$USED_CACHE" != "true" ]; then
+        echo "📥 Loading Copilot workflow runs from last 24 hours..."
+        gh aw logs \
+          --engine copilot \
+          --start-date -1d \
+          --json \
+          -c 300 \
+          > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-optimizer/copilot-runs-raw.json
+
+        # Extract runs array from the JSON output
+        jq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-optimizer/copilot-runs.json
+      fi
 
       RUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)
       echo "Found ${RUN_COUNT} Copilot runs"

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -83,6 +83,7 @@ steps:
       # Find the most expensive workflow (by total tokens across all its runs)
       echo "🔍 Identifying most expensive workflow..."
       jq -r '
+        sort_by(.workflow_name) |
         group_by(.workflow_name) |
         map({
           workflow: .[0].workflow_name,

--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b289a6f4ddae47c218302a21a6199546f19abebf8650b1963e2c8699302c4666","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bb3e0ddc54c3b2b84499160d1c1db0297adfa5cf06b0b7b5a771e9d9da4857ff","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Usage Analyzer"
 "on":
@@ -132,14 +132,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_ac218341b6979b04_EOF'
+          cat << 'GH_AW_PROMPT_daf57289ac6aa438_EOF'
           <system>
-          GH_AW_PROMPT_ac218341b6979b04_EOF
+          GH_AW_PROMPT_daf57289ac6aa438_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ac218341b6979b04_EOF'
+          cat << 'GH_AW_PROMPT_daf57289ac6aa438_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -171,13 +171,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ac218341b6979b04_EOF
+          GH_AW_PROMPT_daf57289ac6aa438_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ac218341b6979b04_EOF'
+          cat << 'GH_AW_PROMPT_daf57289ac6aa438_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-usage-analyzer.md}}
-          GH_AW_PROMPT_ac218341b6979b04_EOF
+          GH_AW_PROMPT_daf57289ac6aa438_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -310,7 +310,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Copilot workflow runs (last 24h)
-        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer\n\necho \"📥 Downloading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-analyzer/copilot-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-analyzer/copilot-runs-raw.json > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer/copilot-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Copilot workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\n# We look for the firewall-audit-logs artifact which contains token-usage.jsonl\nARTIFACT_DIR=\"/tmp/token-analyzer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.database_id' /tmp/token-analyzer/copilot-runs.json 2>/dev/null > /tmp/token-analyzer/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files into a single aggregate file annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-analyzer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" /tmp/token-analyzer/copilot-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-analyzer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-analyzer/copilot-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-analyzer/copilot-runs-raw.json > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer/copilot-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Copilot workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\n# We look for the firewall-audit-logs artifact which contains token-usage.jsonl\nARTIFACT_DIR=\"/tmp/token-analyzer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.database_id' /tmp/token-analyzer/copilot-runs.json 2>/dev/null > /tmp/token-analyzer/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files into a single aggregate file annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
 
       - name: Configure Git credentials
         env:
@@ -361,12 +361,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_34f7182c6d0b277b_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5e7995fc41d2308e_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","copilot"],"max":1,"title_prefix":"📊 Copilot Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_34f7182c6d0b277b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5e7995fc41d2308e_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_840971bf025c07cc_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_01fe7c132b6ba579_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Copilot Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"copilot\"] will be automatically added."
@@ -374,8 +374,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_840971bf025c07cc_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b0e902b7f47a2fc6_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_01fe7c132b6ba579_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_73af6f249a088d12_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -468,7 +468,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_b0e902b7f47a2fc6_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_73af6f249a088d12_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -538,7 +538,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_b6b35d61ba8b5d52_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_fa6396237d6c74c6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -579,7 +579,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b6b35d61ba8b5d52_EOF
+          GH_AW_MCP_CONFIG_fa6396237d6c74c6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b1ce75410b09f89b58a1f4df88bc49635b77fb7d802528b5869f504e3085b94b","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b289a6f4ddae47c218302a21a6199546f19abebf8650b1963e2c8699302c4666","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Usage Analyzer"
 "on":
@@ -132,14 +132,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_77b51c2908cd9c50_EOF'
+          cat << 'GH_AW_PROMPT_ac218341b6979b04_EOF'
           <system>
-          GH_AW_PROMPT_77b51c2908cd9c50_EOF
+          GH_AW_PROMPT_ac218341b6979b04_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_77b51c2908cd9c50_EOF'
+          cat << 'GH_AW_PROMPT_ac218341b6979b04_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -171,13 +171,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_77b51c2908cd9c50_EOF
+          GH_AW_PROMPT_ac218341b6979b04_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_77b51c2908cd9c50_EOF'
+          cat << 'GH_AW_PROMPT_ac218341b6979b04_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-usage-analyzer.md}}
-          GH_AW_PROMPT_77b51c2908cd9c50_EOF
+          GH_AW_PROMPT_ac218341b6979b04_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -310,7 +310,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Copilot workflow runs (last 24h)
-        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer\n\necho \"📥 Downloading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer/copilot-runs.json\n\nRUN_COUNT=$(jq '. | length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Copilot workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\n# We look for the firewall-audit-logs artifact which contains token-usage.jsonl\nARTIFACT_DIR=\"/tmp/token-analyzer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.databaseId' /tmp/token-analyzer/copilot-runs.json 2>/dev/null > /tmp/token-analyzer/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files into a single aggregate file annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-analyzer\n\necho \"📥 Downloading Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-analyzer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-analyzer/copilot-runs-raw.json\n\n# Extract runs array from the JSON output\njq '.runs // []' /tmp/token-analyzer/copilot-runs-raw.json > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-analyzer/copilot-runs.json\n\nRUN_COUNT=$(jq 'length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)\necho \"✅ Found ${RUN_COUNT} Copilot workflow runs\"\n\n# Download token-usage.jsonl artifacts for per-model breakdown\n# We look for the firewall-audit-logs artifact which contains token-usage.jsonl\nARTIFACT_DIR=\"/tmp/token-analyzer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading token-usage.jsonl artifacts...\"\njq -r '.[0:50][]?.database_id' /tmp/token-analyzer/copilot-runs.json 2>/dev/null > /tmp/token-analyzer/run-ids.txt || true\nwhile read -r run_id; do\n  run_dir=\"$ARTIFACT_DIR/$run_id\"\n  mkdir -p \"$run_dir\"\n  gh run download \"$run_id\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"firewall-audit-logs\" \\\n    --dir \"$run_dir\" \\\n    2>/dev/null || true\ndone < /tmp/token-analyzer/run-ids.txt\n\n# Count how many token-usage.jsonl files we got\nJSONL_COUNT=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | wc -l)\necho \"✅ Downloaded ${JSONL_COUNT} token-usage.jsonl artifacts\"\n\n# Merge all token-usage.jsonl files into a single aggregate file annotated with run_id\nMERGED_FILE=\"/tmp/token-analyzer/token-usage-merged.jsonl\"\n> \"$MERGED_FILE\"\nfind \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" > /tmp/token-analyzer/jsonl-files.txt 2>/dev/null || true\nwhile read -r f; do\n  run_id=$(echo \"$f\" | grep -oP '(?<=/artifacts/)\\d+(?=/)' || true)\n  while IFS= read -r line; do\n    if [ -n \"$line\" ]; then\n      echo \"${line}\" | jq --arg run_id \"$run_id\" '. + {run_id: $run_id}' >> \"$MERGED_FILE\" 2>/dev/null || true\n    fi\n  done < \"$f\"\ndone < /tmp/token-analyzer/jsonl-files.txt\n\nRECORD_COUNT=$(wc -l < \"$MERGED_FILE\" 2>/dev/null || echo 0)\necho \"✅ Merged ${RECORD_COUNT} token usage records\"\n"
 
       - name: Configure Git credentials
         env:
@@ -361,12 +361,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0237bbe3896dae81_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_34f7182c6d0b277b_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","copilot"],"max":1,"title_prefix":"📊 Copilot Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0237bbe3896dae81_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_34f7182c6d0b277b_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_21502b3c7d44f092_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_840971bf025c07cc_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Copilot Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"copilot\"] will be automatically added."
@@ -374,8 +374,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_21502b3c7d44f092_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_5df732c7ff691456_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_840971bf025c07cc_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b0e902b7f47a2fc6_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -468,7 +468,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_5df732c7ff691456_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b0e902b7f47a2fc6_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -538,7 +538,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_85f5bf5a0a3b4a96_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_b6b35d61ba8b5d52_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -579,7 +579,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_85f5bf5a0a3b4a96_EOF
+          GH_AW_MCP_CONFIG_b6b35d61ba8b5d52_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-usage-analyzer.md
+++ b/.github/workflows/copilot-token-usage-analyzer.md
@@ -53,16 +53,45 @@ steps:
       set -euo pipefail
       mkdir -p /tmp/token-analyzer
 
-      echo "📥 Downloading Copilot workflow runs from last 24 hours..."
-      gh aw logs \
-        --engine copilot \
-        --start-date -1d \
-        --json \
-        -c 300 \
-        > /tmp/token-analyzer/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-analyzer/copilot-runs-raw.json
+      # Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls
+      TODAY=$(date -u +%Y-%m-%d)
+      FETCH_RUN_ID=$(gh run list \
+        --workflow "token-logs-fetch.lock.yml" \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' 2>/dev/null || echo "")
+      USED_CACHE=false
+      if [ -n "$FETCH_RUN_ID" ]; then
+        CACHE_TMP="/tmp/token-logs-cache-analyzer"
+        mkdir -p "$CACHE_TMP"
+        gh run download "$FETCH_RUN_ID" \
+          --repo "$GITHUB_REPOSITORY" \
+          --name "cache-memory" \
+          --dir "$CACHE_TMP" \
+          2>/dev/null || true
+        CACHE_DATE=$(cat "$CACHE_TMP/token-logs/fetch-date.txt" 2>/dev/null || echo "")
+        if [ "$CACHE_DATE" = "$TODAY" ] && [ -s "$CACHE_TMP/token-logs/copilot-runs.json" ]; then
+          echo "✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)"
+          cp "$CACHE_TMP/token-logs/copilot-runs.json" /tmp/token-analyzer/copilot-runs.json
+          USED_CACHE=true
+        else
+          echo "ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)"
+        fi
+      fi
 
-      # Extract runs array from the JSON output
-      jq '.runs // []' /tmp/token-analyzer/copilot-runs-raw.json > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer/copilot-runs.json
+      if [ "$USED_CACHE" != "true" ]; then
+        echo "📥 Downloading Copilot workflow runs from last 24 hours..."
+        gh aw logs \
+          --engine copilot \
+          --start-date -1d \
+          --json \
+          -c 300 \
+          > /tmp/token-analyzer/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-analyzer/copilot-runs-raw.json
+
+        # Extract runs array from the JSON output
+        jq '.runs // []' /tmp/token-analyzer/copilot-runs-raw.json > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer/copilot-runs.json
+      fi
 
       RUN_COUNT=$(jq 'length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)
       echo "✅ Found ${RUN_COUNT} Copilot workflow runs"

--- a/.github/workflows/copilot-token-usage-analyzer.md
+++ b/.github/workflows/copilot-token-usage-analyzer.md
@@ -59,9 +59,12 @@ steps:
         --start-date -1d \
         --json \
         -c 300 \
-        > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer/copilot-runs.json
+        > /tmp/token-analyzer/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-analyzer/copilot-runs-raw.json
 
-      RUN_COUNT=$(jq '. | length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)
+      # Extract runs array from the JSON output
+      jq '.runs // []' /tmp/token-analyzer/copilot-runs-raw.json > /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-analyzer/copilot-runs.json
+
+      RUN_COUNT=$(jq 'length' /tmp/token-analyzer/copilot-runs.json 2>/dev/null || echo 0)
       echo "✅ Found ${RUN_COUNT} Copilot workflow runs"
 
       # Download token-usage.jsonl artifacts for per-model breakdown
@@ -70,7 +73,7 @@ steps:
       mkdir -p "$ARTIFACT_DIR"
 
       echo "📥 Downloading token-usage.jsonl artifacts..."
-      jq -r '.[0:50][]?.databaseId' /tmp/token-analyzer/copilot-runs.json 2>/dev/null > /tmp/token-analyzer/run-ids.txt || true
+      jq -r '.[0:50][]?.database_id' /tmp/token-analyzer/copilot-runs.json 2>/dev/null > /tmp/token-analyzer/run-ids.txt || true
       while read -r run_id; do
         run_dir="$ARTIFACT_DIR/$run_id"
         mkdir -p "$run_dir"
@@ -120,7 +123,7 @@ You are the Copilot Token Usage Analyzer. Your job is to analyze Copilot token c
 
 Pre-downloaded data is available in `/tmp/token-analyzer/`:
 
-- **`/tmp/token-analyzer/copilot-runs.json`** — All Copilot workflow runs from the last 24 hours (array of run objects with `workflowName`, `databaseId`, `tokenUsage`, `estimatedCost`, `turns`, `url`, `conclusion`, etc.)
+- **`/tmp/token-analyzer/copilot-runs.json`** — All Copilot workflow runs from the last 24 hours (array of run objects with `workflow_name`, `database_id`, `token_usage`, `turns`, `url`, `conclusion`, etc.)
 - **`/tmp/token-analyzer/token-usage-merged.jsonl`** — Merged per-request token records from `firewall-audit-logs` artifacts, with fields: `model`, `provider`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `duration_ms`, `run_id`
 
 ## Analysis Process
@@ -130,7 +133,7 @@ Pre-downloaded data is available in `/tmp/token-analyzer/`:
 Process `/tmp/token-analyzer/copilot-runs.json` to compute per-workflow statistics:
 
 ```bash
-jq -r '.[] | [.workflowName, .tokenUsage, .estimatedCost, .turns, .conclusion, .url, .databaseId] | @tsv' \
+jq -r '.[] | [.workflow_name, .token_usage, .turns, .conclusion, .url, .database_id] | @tsv' \
   /tmp/token-analyzer/copilot-runs.json
 ```
 

--- a/.github/workflows/token-logs-fetch.lock.yml
+++ b/.github/workflows/token-logs-fetch.lock.yml
@@ -20,17 +20,15 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Analyzes the most expensive Copilot workflow identified by the token usage analyzer and creates an optimization issue with specific token-saving recommendations
+# Pre-fetches Copilot and Claude workflow run logs daily and stores them in cache-memory to avoid redundant API calls and rate-limiting in downstream token analysis and optimization workflows
 #
-# Resolved workflow manifest:
-#   Imports:
-#     - shared/reporting.md
-#
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6eadad6bbe15632de5d8067a8b7daa0eb6baeb44a942e2e0d55ec41d846d5b63","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"77d36911c8e8f38e7a1eb9aa895af361b0136b7088d2ff848d490476f794c270","strict":true,"agent_id":"copilot"}
 
-name: "Copilot Token Optimizer"
+name: "Token Logs Fetch"
 "on":
-  # skip-if-match: is:issue is:open in:title "⚡ Copilot Token Optimization:" # Skip-if-match processed as search check in pre-activation job
+  schedule:
+  - cron: "54 7 * * 1-5"
+    # Friendly format: daily around 08:45 on weekdays (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -38,29 +36,16 @@ name: "Copilot Token Optimizer"
         description: Agent caller context (used internally by Agentic Workflows).
         required: false
         type: string
-  workflow_run:
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    branches:
-    - main
-    types:
-    - completed
-    workflows:
-    - Copilot Token Usage Analyzer
 
 permissions: {}
 
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Copilot Token Optimizer"
+run-name: "Token Logs Fetch"
 
 jobs:
   activation:
-    needs: pre_activation
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
-      (!(github.event.workflow_run.repository.fork)))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -89,7 +74,7 @@ jobs:
           GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'auto' }}
           GH_AW_INFO_VERSION: "latest"
           GH_AW_INFO_AGENT_VERSION: "latest"
-          GH_AW_INFO_WORKFLOW_NAME: "Copilot Token Optimizer"
+          GH_AW_INFO_WORKFLOW_NAME: "Token Logs Fetch"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -119,7 +104,7 @@ jobs:
       - name: Check workflow lock file
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "copilot-token-optimizer.lock.yml"
+          GH_AW_WORKFLOW_FILE: "token-logs-fetch.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -131,7 +116,6 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
-          GH_AW_ENV_WORKFLOW_NAME: ${{ env.WORKFLOW_NAME }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -144,16 +128,20 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_5ce9c5eb83669cda_EOF'
+          cat << 'GH_AW_PROMPT_564883dfc94bb1c9_EOF'
           <system>
-          GH_AW_PROMPT_5ce9c5eb83669cda_EOF
+          GH_AW_PROMPT_564883dfc94bb1c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
+          cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5ce9c5eb83669cda_EOF'
+          cat << 'GH_AW_PROMPT_564883dfc94bb1c9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
+          GH_AW_PROMPT_564883dfc94bb1c9_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
+          cat << 'GH_AW_PROMPT_564883dfc94bb1c9_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -183,20 +171,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5ce9c5eb83669cda_EOF
+          GH_AW_PROMPT_564883dfc94bb1c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5ce9c5eb83669cda_EOF'
+          cat << 'GH_AW_PROMPT_564883dfc94bb1c9_EOF'
           </system>
-          {{#runtime-import .github/workflows/shared/reporting.md}}
-          {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_5ce9c5eb83669cda_EOF
+          {{#runtime-import .github/workflows/token-logs-fetch.md}}
+          GH_AW_PROMPT_564883dfc94bb1c9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_ENV_WORKFLOW_NAME: ${{ env.WORKFLOW_NAME }}
-          GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -207,7 +192,9 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_ENV_WORKFLOW_NAME: ${{ env.WORKFLOW_NAME }}
+          GH_AW_ALLOWED_EXTENSIONS: ''
+          GH_AW_CACHE_DESCRIPTION: ''
+          GH_AW_CACHE_DIR: '/tmp/gh-aw/cache-memory/'
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -216,7 +203,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -228,7 +214,9 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_ENV_WORKFLOW_NAME: process.env.GH_AW_ENV_WORKFLOW_NAME,
+                GH_AW_ALLOWED_EXTENSIONS: process.env.GH_AW_ALLOWED_EXTENSIONS,
+                GH_AW_CACHE_DESCRIPTION: process.env.GH_AW_CACHE_DESCRIPTION,
+                GH_AW_CACHE_DIR: process.env.GH_AW_CACHE_DIR,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -236,8 +224,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -267,8 +254,6 @@ jobs:
       actions: read
       contents: read
       copilot-requests: write
-      issues: read
-      pull-requests: read
     concurrency:
       group: "gh-aw-copilot-${{ github.workflow }}"
     env:
@@ -277,7 +262,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: copilottokenoptimizer
+      GH_AW_WORKFLOW_ID_SANITIZED: tokenlogsfetch
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       effective_tokens: ${{ steps.parse-mcp-gateway.outputs.effective_tokens }}
@@ -326,9 +311,24 @@ jobs:
           gh aw --version
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Find and download artifacts from the most expensive Copilot workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-optimizer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" /tmp/token-optimizer/copilot-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Loading Copilot workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer/copilot-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
+        name: Fetch Copilot and Claude workflow run logs
+        run: "set -euo pipefail\nmkdir -p /tmp/token-logs\n\necho \"📥 Fetching Copilot workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-logs/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs/copilot-runs-raw.json\n\njq '.runs // []' /tmp/token-logs/copilot-runs-raw.json > /tmp/token-logs/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-logs/copilot-runs.json\necho \"✅ Copilot runs: $(jq 'length' /tmp/token-logs/copilot-runs.json)\"\n\necho \"📥 Fetching Claude workflow runs from last 24 hours...\"\ngh aw logs \\\n  --engine claude \\\n  --start-date -1d \\\n  --json \\\n  -c 300 \\\n  > /tmp/token-logs/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs/claude-runs-raw.json\n\njq '.runs // []' /tmp/token-logs/claude-runs-raw.json > /tmp/token-logs/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-logs/claude-runs.json\necho \"✅ Claude runs: $(jq 'length' /tmp/token-logs/claude-runs.json)\""
 
+      # Cache memory file share configuration from frontmatter processed below
+      - name: Create cache-memory directory
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/create_cache_memory_dir.sh
+      - name: Restore cache-memory file share data
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
+          path: /tmp/gh-aw/cache-memory
+          restore-keys: |
+            memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-
+      - name: Setup cache-memory git repository
+        env:
+          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
+          GH_AW_MIN_INTEGRITY: none
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/setup_cache_memory_git.sh
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -378,21 +378,21 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_948280de2275be42_EOF'
-          {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_948280de2275be42_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_9f109b086ddbc660_EOF'
+          {"create_issue":{"labels":["token-logs-fetch"],"max":1,"title_prefix":"[token-logs-fetch]"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_9f109b086ddbc660_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_743d8b22383899ed_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c4497f70f215a2ea_EOF'
           {
             "description_suffixes": {
-              "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
+              "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[token-logs-fetch]\". Labels [\"token-logs-fetch\"] will be automatically added."
             },
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_743d8b22383899ed_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9d0d6fbaccddcacf_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_c4497f70f215a2ea_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_fa3ea862e417a214_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_9d0d6fbaccddcacf_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_fa3ea862e417a214_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_dd0e368aa164a954_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_23d1a6d7f0f43aca_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -565,7 +565,7 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "context,repos,issues,pull_requests,actions"
+                  "GITHUB_TOOLSETS": "context,repos,issues,pull_requests"
                 },
                 "guard-policies": {
                   "allow-only": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dd0e368aa164a954_EOF
+          GH_AW_MCP_CONFIG_23d1a6d7f0f43aca_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -608,13 +608,13 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 30
+        timeout-minutes: 15
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           # shellcheck disable=SC1003
           sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.13 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --allow-all-tools --add-dir /tmp/gh-aw/cache-memory/ --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
@@ -753,6 +753,17 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
+      - name: Commit cache-memory changes
+        if: always()
+        env:
+          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/commit_cache_memory_git.sh
+      - name: Upload cache-memory data as artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        if: always()
+        with:
+          name: cache-memory
+          path: /tmp/gh-aw/cache-memory
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
@@ -789,13 +800,14 @@ jobs:
       - agent
       - detection
       - safe_outputs
+      - update_cache_memory
     if: always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
       contents: read
       issues: write
     concurrency:
-      group: "gh-aw-conclusion-copilot-token-optimizer"
+      group: "gh-aw-conclusion-token-logs-fetch"
       cancel-in-progress: false
     outputs:
       noop_message: ${{ steps.noop.outputs.noop_message }}
@@ -833,7 +845,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Copilot Token Optimizer"
+          GH_AW_WORKFLOW_NAME: "Token Logs Fetch"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -850,7 +862,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Copilot Token Optimizer"
+          GH_AW_WORKFLOW_NAME: "Token Logs Fetch"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -864,17 +876,17 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Copilot Token Optimizer"
+          GH_AW_WORKFLOW_NAME: "Token Logs Fetch"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "copilot-token-optimizer"
+          GH_AW_WORKFLOW_ID: "token-logs-fetch"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
-          GH_AW_TIMEOUT_MINUTES: "30"
+          GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -966,8 +978,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Copilot Token Optimizer"
-          WORKFLOW_DESCRIPTION: "Analyzes the most expensive Copilot workflow identified by the token usage analyzer and creates an optimization issue with specific token-saving recommendations"
+          WORKFLOW_NAME: "Token Logs Fetch"
+          WORKFLOW_DESCRIPTION: "Pre-fetches Copilot and Claude workflow run logs daily and stores them in cache-memory to avoid redundant API calls and rate-limiting in downstream token analysis and optimization workflows"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1037,51 +1049,6 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
             await main();
 
-  pre_activation:
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_skip_if_match.outputs.skip_check_ok == 'true' }}
-      matched_command: ''
-    steps:
-      - name: Checkout actions folder
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions
-          persist-credentials: false
-      - name: Setup Scripts
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-      - name: Check skip-if-match query
-        id: check_skip_if_match
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_SKIP_QUERY: "is:issue is:open in:title \"⚡ Copilot Token Optimization:\""
-          GH_AW_WORKFLOW_NAME: "Copilot Token Optimizer"
-          GH_AW_SKIP_MAX_MATCHES: "1"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_match.cjs');
-            await main();
-
   safe_outputs:
     needs:
       - agent
@@ -1093,12 +1060,12 @@ jobs:
       issues: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/copilot-token-optimizer"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/token-logs-fetch"
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
-      GH_AW_WORKFLOW_ID: "copilot-token-optimizer"
-      GH_AW_WORKFLOW_NAME: "Copilot Token Optimizer"
+      GH_AW_WORKFLOW_ID: "token-logs-fetch"
+      GH_AW_WORKFLOW_NAME: "Token Logs Fetch"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
@@ -1151,7 +1118,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":true,\"expires\":168,\"labels\":[\"automated-analysis\",\"token-optimization\",\"copilot\",\"cost-reduction\"],\"max\":1,\"title_prefix\":\"⚡ Copilot Token Optimization: \"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"token-logs-fetch\"],\"max\":1,\"title_prefix\":\"[token-logs-fetch]\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1166,4 +1133,51 @@ jobs:
           name: safe-output-items
           path: /tmp/gh-aw/safe-output-items.jsonl
           if-no-files-found: ignore
+
+  update_cache_memory:
+    needs:
+      - agent
+      - detection
+    if: >
+      always() && (needs.detection.result == 'success' || needs.detection.result == 'skipped') &&
+      needs.agent.result == 'success'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    env:
+      GH_AW_WORKFLOW_ID_SANITIZED: tokenlogsfetch
+    steps:
+      - name: Checkout actions folder
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: github/gh-aw
+          sparse-checkout: |
+            actions
+          persist-credentials: false
+      - name: Setup Scripts
+        uses: ./actions/setup
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+      - name: Download cache-memory artifact (default)
+        id: download_cache_default
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: cache-memory
+          path: /tmp/gh-aw/cache-memory
+      - name: Check if cache-memory folder has content (default)
+        id: check_cache_default
+        shell: bash
+        run: |
+          if [ -d "/tmp/gh-aw/cache-memory" ] && [ "$(ls -A /tmp/gh-aw/cache-memory 2>/dev/null)" ]; then
+            echo "has_content=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_content=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Save cache-memory to cache (default)
+        if: steps.check_cache_default.outputs.has_content == 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
+          path: /tmp/gh-aw/cache-memory
 

--- a/.github/workflows/token-logs-fetch.md
+++ b/.github/workflows/token-logs-fetch.md
@@ -1,0 +1,91 @@
+---
+name: Token Logs Fetch
+description: Pre-fetches Copilot and Claude workflow run logs daily and stores them in cache-memory to avoid redundant API calls and rate-limiting in downstream token analysis and optimization workflows
+on:
+  schedule:
+    - cron: "daily around 08:45 on weekdays"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+engine: copilot
+features:
+  copilot-requests: true
+
+tools:
+  bash:
+    - "*"
+  cache-memory: true
+
+safe-outputs:
+  noop:
+
+network: defaults
+
+timeout-minutes: 15
+
+steps:
+  - name: Install gh-aw CLI
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    run: |
+      if gh extension list | grep -q "github/gh-aw"; then
+        gh extension upgrade gh-aw || true
+      else
+        gh extension install github/gh-aw
+      fi
+      gh aw --version
+  - name: Fetch Copilot and Claude workflow run logs
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    run: |
+      set -euo pipefail
+      mkdir -p /tmp/token-logs
+
+      echo "📥 Fetching Copilot workflow runs from last 24 hours..."
+      gh aw logs \
+        --engine copilot \
+        --start-date -1d \
+        --json \
+        -c 300 \
+        > /tmp/token-logs/copilot-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-logs/copilot-runs-raw.json
+
+      jq '.runs // []' /tmp/token-logs/copilot-runs-raw.json > /tmp/token-logs/copilot-runs.json 2>/dev/null || echo "[]" > /tmp/token-logs/copilot-runs.json
+      echo "✅ Copilot runs: $(jq 'length' /tmp/token-logs/copilot-runs.json)"
+
+      echo "📥 Fetching Claude workflow runs from last 24 hours..."
+      gh aw logs \
+        --engine claude \
+        --start-date -1d \
+        --json \
+        -c 300 \
+        > /tmp/token-logs/claude-runs-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-logs/claude-runs-raw.json
+
+      jq '.runs // []' /tmp/token-logs/claude-runs-raw.json > /tmp/token-logs/claude-runs.json 2>/dev/null || echo "[]" > /tmp/token-logs/claude-runs.json
+      echo "✅ Claude runs: $(jq 'length' /tmp/token-logs/claude-runs.json)"
+---
+
+# Token Logs Fetch
+
+Pre-fetched workflow run logs are available at `/tmp/token-logs/`:
+
+- `/tmp/token-logs/copilot-runs.json` — Copilot workflow runs from the last 24 hours
+- `/tmp/token-logs/claude-runs.json` — Claude workflow runs from the last 24 hours
+
+Your task is to cache these files for use by downstream token analysis and optimization workflows:
+
+```bash
+mkdir -p /tmp/gh-aw/cache-memory/token-logs
+cp /tmp/token-logs/copilot-runs.json /tmp/gh-aw/cache-memory/token-logs/
+cp /tmp/token-logs/claude-runs.json /tmp/gh-aw/cache-memory/token-logs/
+date -u +%Y-%m-%d > /tmp/gh-aw/cache-memory/token-logs/fetch-date.txt
+echo "Cached logs for $(cat /tmp/gh-aw/cache-memory/token-logs/fetch-date.txt)"
+```
+
+Once the files are cached, call noop.
+
+```json
+{"noop": {"message": "Token logs fetched and cached for downstream analysis workflows"}}
+```


### PR DESCRIPTION
## Problem

The Copilot Token Optimizer workflow failed in <a href="https://github.com/github/gh-aw/actions/runs/23962678922">run 23962678922</a> with:

```
jq: error: Cannot index array with string "workflowName"
```

All 4 token workflows (copilot/claude analyzers and optimizers) assumed `gh aw logs --json` outputs a **bare JSON array** with **camelCase** field names. In reality, it outputs an **object** with a `.runs` array, and run objects use **snake_case** field names.

Additionally, each workflow independently called `gh aw logs --json`, causing redundant API calls and potential rate-limiting when all 4 workflows run in sequence each day.

## Fix

- Extract `.runs` array from the JSON object before processing
- Replace camelCase field references with snake_case:
  - `workflowName` → `workflow_name`
  - `tokenUsage` → `token_usage`
  - `databaseId` → `database_id`
  - `createdAt` → `created_at`
- Replace non-existent `estimatedCost` with `0` placeholder
- Update documentation sections with correct field names
- Add `sort_by(.workflow_name)` before `group_by(.workflow_name)` in optimizers for deterministic grouping
- Extract a new **`token-logs-fetch.md`** shared agentic workflow that pre-fetches both Copilot and Claude logs once daily (~08:45) and caches them via `cache-memory`
- Update all 4 token workflows to check for and use the pre-fetched cached logs (falling back to direct `gh aw logs --json` if no valid cache exists)

## Files Changed

- `.github/workflows/token-logs-fetch.md` _(new)_
- `.github/workflows/copilot-token-optimizer.md`
- `.github/workflows/claude-token-optimizer.md`
- `.github/workflows/copilot-token-usage-analyzer.md`
- `.github/workflows/claude-token-usage-analyzer.md`
- All corresponding `.lock.yml` files (recompiled)

## Testing

- All 184 workflows compile successfully
- `make fmt && make lint` pass with 0 issues