### PR TITLE
fix: handle null token_usage in optimizer jq aggregations

### DIFF
--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"dbff5ee16cfc21a95e26ce60664927bc565c0ad0b4ea980493be8dfb278f7302","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"873711dd834e166434441f8b1701c7f20a1b798dccd3db750146478147cd85f4","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_39ebff004f890f10_EOF'
+          cat << 'GH_AW_PROMPT_40acb8f9e0ed0e7f_EOF'
           <system>
-          GH_AW_PROMPT_39ebff004f890f10_EOF
+          GH_AW_PROMPT_40acb8f9e0ed0e7f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_39ebff004f890f10_EOF'
+          cat << 'GH_AW_PROMPT_40acb8f9e0ed0e7f_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_39ebff004f890f10_EOF
+          GH_AW_PROMPT_40acb8f9e0ed0e7f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_39ebff004f890f10_EOF'
+          cat << 'GH_AW_PROMPT_40acb8f9e0ed0e7f_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_39ebff004f890f10_EOF
+          GH_AW_PROMPT_40acb8f9e0ed0e7f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Claude workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-claude-optimizer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" /tmp/token-optimizer-claude/claude-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Loading Claude workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer-claude\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-claude-optimizer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" /tmp/token-optimizer-claude/claude-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Loading Claude workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-optimizer-claude/claude-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer-claude/claude-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-optimizer-claude/claude-runs-raw.json > /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer-claude/claude-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer-claude/claude-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Claude runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Claude runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\n# Schema: gh aw logs --json → LogsData.runs[] (RunData from pkg/cli/logs_report.go)\n#   .workflow_name (string), .token_usage (int, omitempty → null when 0),\n#   .estimated_cost (float, omitempty), .database_id (int64), .created_at (time), .url (string)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage // 0) | add),\n    total_cost: (map(.estimated_cost // 0) | add),\n    run_count: length,\n    avg_tokens: ((map(.token_usage // 0) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer-claude/claude-runs.json > /tmp/token-optimizer-claude/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer-claude/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer-claude/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run\nARTIFACT_DIR=\"/tmp/token-optimizer-claude/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer-claude/token-usage.jsonl\n  echo \"Records: $(wc -l < /tmp/token-optimizer-claude/token-usage.jsonl)\"\n\n  # Pre-compute Anthropic-specific metrics\n  echo \"📊 Computing Anthropic cache efficiency metrics...\"\n  awk '\n  BEGIN { ti=0; to=0; cr=0; cw=0; tr=0 }\n  {\n    if (match($0, /\"input_tokens\" *: *([0-9]+)/, m)) ti += m[1]+0\n    if (match($0, /\"output_tokens\" *: *([0-9]+)/, m)) to += m[1]+0\n    if (match($0, /\"cache_read_tokens\" *: *([0-9]+)/, m)) cr += m[1]+0\n    if (match($0, /\"cache_write_tokens\" *: *([0-9]+)/, m)) cw += m[1]+0\n    tr += 1\n  }\n  END {\n    total = ti + to + cr + cw\n    if (tr == 0) exit\n    printf \"Requests: %d\\n\", tr\n    printf \"Input tokens: %d\\n\", ti\n    printf \"Output tokens: %d\\n\", to\n    printf \"Cache read tokens: %d\\n\", cr\n    printf \"Cache write tokens: %d\\n\", cw\n    printf \"Total tokens: %d\\n\", total\n    if (ti + cr > 0) printf \"Cache hit rate: %.1f%%\\n\", (cr / (ti + cr)) * 100\n    if (ti + cw > 0) printf \"Cache write rate: %.1f%%\\n\", (cw / (ti + cw)) * 100\n    if (cw > 0) printf \"Cache read/write ratio: %.2f\\n\", (cr / cw)\n  }' /tmp/token-optimizer-claude/token-usage.jsonl > /tmp/token-optimizer-claude/cache-metrics.txt\n  cat /tmp/token-optimizer-claude/cache-metrics.txt\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer-claude/token-usage.jsonl\n  touch /tmp/token-optimizer-claude/cache-metrics.txt\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer-claude/workflow-source.md\nelse\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer-claude/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source\nif [ -f /tmp/token-optimizer-claude/workflow-source.md ]; then\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer-claude/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer-claude/declared-tools.txt || true\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_12e7e3b2b944d6ca_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_08493f5af1bbfa21_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_12e7e3b2b944d6ca_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_08493f5af1bbfa21_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_163d89fa6c431e34_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a19354edfe956ae7_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_163d89fa6c431e34_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_1f62702e2eb2fc94_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_a19354edfe956ae7_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8482fe857e9d432f_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_1f62702e2eb2fc94_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8482fe857e9d432f_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_38aabebdf2375b48_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_cb6903a338018680_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_38aabebdf2375b48_EOF
+          GH_AW_MCP_CONFIG_cb6903a338018680_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-optimizer.md
+++ b/.github/workflows/claude-token-optimizer.md
@@ -110,16 +110,19 @@ steps:
       fi
 
       # Find the most expensive workflow (by total tokens across all its runs)
+      # Schema: gh aw logs --json → LogsData.runs[] (RunData from pkg/cli/logs_report.go)
+      #   .workflow_name (string), .token_usage (int, omitempty → null when 0),
+      #   .estimated_cost (float, omitempty), .database_id (int64), .created_at (time), .url (string)
       echo "🔍 Identifying most expensive workflow..."
       jq -r '
         sort_by(.workflow_name) |
         group_by(.workflow_name) |
         map({
           workflow: .[0].workflow_name,
-          total_tokens: (map(.token_usage) | add),
-          total_cost: 0,
+          total_tokens: (map(.token_usage // 0) | add),
+          total_cost: (map(.estimated_cost // 0) | add),
           run_count: length,
-          avg_tokens: ((map(.token_usage) | add) / length),
+          avg_tokens: ((map(.token_usage // 0) | add) / length),
           run_ids: map(.database_id),
           latest_run_id: (sort_by(.created_at) | last | .database_id),
           latest_run_url: (sort_by(.created_at) | last | .url)

--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6eadad6bbe15632de5d8067a8b7daa0eb6baeb44a942e2e0d55ec41d846d5b63","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cf29a921a12e201dc7a4b01cc2501dc89c83bbb630f62fba54244c2383fba665","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Optimizer"
 "on":
@@ -144,14 +144,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_5ce9c5eb83669cda_EOF'
+          cat << 'GH_AW_PROMPT_bccc4116b26a58e2_EOF'
           <system>
-          GH_AW_PROMPT_5ce9c5eb83669cda_EOF
+          GH_AW_PROMPT_bccc4116b26a58e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5ce9c5eb83669cda_EOF'
+          cat << 'GH_AW_PROMPT_bccc4116b26a58e2_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -183,13 +183,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5ce9c5eb83669cda_EOF
+          GH_AW_PROMPT_bccc4116b26a58e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5ce9c5eb83669cda_EOF'
+          cat << 'GH_AW_PROMPT_bccc4116b26a58e2_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_5ce9c5eb83669cda_EOF
+          GH_AW_PROMPT_bccc4116b26a58e2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,7 +327,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Find and download artifacts from the most expensive Copilot workflow
-        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-optimizer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" /tmp/token-optimizer/copilot-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Loading Copilot workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer/copilot-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage) | add),\n    total_cost: 0,\n    run_count: length,\n    avg_tokens: ((map(.token_usage) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/token-optimizer\n\n# Try to use pre-fetched logs from the Token Logs Fetch workflow to avoid redundant API calls\nTODAY=$(date -u +%Y-%m-%d)\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/token-logs-cache-optimizer\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" /tmp/token-optimizer/copilot-runs.json\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Loading Copilot workflow runs from last 24 hours...\"\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-optimizer/copilot-runs-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-optimizer/copilot-runs-raw.json\n\n  # Extract runs array from the JSON output\n  jq '.runs // []' /tmp/token-optimizer/copilot-runs-raw.json > /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo \"[]\" > /tmp/token-optimizer/copilot-runs.json\nfi\n\nRUN_COUNT=$(jq 'length' /tmp/token-optimizer/copilot-runs.json 2>/dev/null || echo 0)\necho \"Found ${RUN_COUNT} Copilot runs\"\n\nif [ \"$RUN_COUNT\" -eq 0 ]; then\n  echo \"No Copilot runs found, nothing to optimize\"\n  exit 0\nfi\n\n# Find the most expensive workflow (by total tokens across all its runs)\n# Schema: gh aw logs --json → LogsData.runs[] (RunData from pkg/cli/logs_report.go)\n#   .workflow_name (string), .token_usage (int, omitempty → null when 0),\n#   .estimated_cost (float, omitempty), .database_id (int64), .created_at (time), .url (string)\necho \"🔍 Identifying most expensive workflow...\"\njq -r '\n  sort_by(.workflow_name) |\n  group_by(.workflow_name) |\n  map({\n    workflow: .[0].workflow_name,\n    total_tokens: (map(.token_usage // 0) | add),\n    total_cost: (map(.estimated_cost // 0) | add),\n    run_count: length,\n    avg_tokens: ((map(.token_usage // 0) | add) / length),\n    run_ids: map(.database_id),\n    latest_run_id: (sort_by(.created_at) | last | .database_id),\n    latest_run_url: (sort_by(.created_at) | last | .url)\n  }) |\n  sort_by(.total_tokens) | reverse | .[0]\n' /tmp/token-optimizer/copilot-runs.json > /tmp/token-optimizer/top-workflow.json\n\nWORKFLOW_NAME=$(jq -r '.workflow' /tmp/token-optimizer/top-workflow.json)\nLATEST_RUN_ID=$(jq -r '.latest_run_id' /tmp/token-optimizer/top-workflow.json)\necho \"Most expensive workflow: $WORKFLOW_NAME (run: $LATEST_RUN_ID)\"\necho \"WORKFLOW_NAME=$WORKFLOW_NAME\" >> \"$GITHUB_ENV\"\n\n# Download the firewall-audit-logs artifact from the latest run of that workflow\nARTIFACT_DIR=\"/tmp/token-optimizer/artifacts\"\nmkdir -p \"$ARTIFACT_DIR\"\n\necho \"📥 Downloading firewall-audit-logs from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"firewall-audit-logs\" \\\n  --dir \"$ARTIFACT_DIR\" \\\n  2>/dev/null || true\n\n# Also download agent artifacts (contains prompt and tool usage logs)\necho \"📥 Downloading agent artifacts from run $LATEST_RUN_ID...\"\ngh run download \"$LATEST_RUN_ID\" \\\n  --repo \"$GITHUB_REPOSITORY\" \\\n  --name \"agent\" \\\n  --dir \"$ARTIFACT_DIR/agent\" \\\n  2>/dev/null || true\n\n# Find token-usage.jsonl\nUSAGE_FILE=$(find \"$ARTIFACT_DIR\" -name \"token-usage.jsonl\" 2>/dev/null | head -1)\nif [ -n \"$USAGE_FILE\" ]; then\n  echo \"Found token-usage.jsonl: $USAGE_FILE\"\n  cp \"$USAGE_FILE\" /tmp/token-optimizer/token-usage.jsonl\n  wc -l < /tmp/token-optimizer/token-usage.jsonl\nelse\n  echo \"No token-usage.jsonl found in artifacts\"\n  touch /tmp/token-optimizer/token-usage.jsonl\nfi\n\n# Find the workflow markdown source\nWORKFLOW_MD_NAME=$(echo \"$WORKFLOW_NAME\" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')\nWORKFLOW_MD=\".github/workflows/${WORKFLOW_MD_NAME}.md\"\nif [ -f \"$WORKFLOW_MD\" ]; then\n  echo \"Found workflow source: $WORKFLOW_MD\"\n  cp \"$WORKFLOW_MD\" /tmp/token-optimizer/workflow-source.md\nelse\n  echo \"Workflow source not found at $WORKFLOW_MD, searching...\"\n  FOUND_MD=$(find .github/workflows -name \"*.md\" -exec grep -l \"^name: $WORKFLOW_NAME\" {} \\; 2>/dev/null | head -1 || true)\n  if [ -n \"$FOUND_MD\" ]; then\n    echo \"Found: $FOUND_MD\"\n    cp \"$FOUND_MD\" /tmp/token-optimizer/workflow-source.md\n  fi\nfi\n\n# Extract declared tools from workflow source (if available)\nif [ -f /tmp/token-optimizer/workflow-source.md ]; then\n  echo \"📋 Extracting declared tools from workflow source...\"\n  # Extract tools section from frontmatter\n  sed -n '/^---$/,/^---$/p' /tmp/token-optimizer/workflow-source.md | \\\n    grep -A20 \"^tools:\" | head -30 > /tmp/token-optimizer/declared-tools.txt || true\n  cat /tmp/token-optimizer/declared-tools.txt\nfi\n"
 
       - name: Configure Git credentials
         env:
@@ -378,12 +378,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_948280de2275be42_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_9b9a172a6869b596_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_948280de2275be42_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9b9a172a6869b596_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_743d8b22383899ed_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_3700905b94f54529_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
@@ -391,8 +391,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_743d8b22383899ed_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9d0d6fbaccddcacf_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_3700905b94f54529_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8187f794fe362003_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -485,7 +485,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_9d0d6fbaccddcacf_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8187f794fe362003_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -555,7 +555,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_dd0e368aa164a954_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_766fb6333e2be087_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -596,7 +596,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dd0e368aa164a954_EOF
+          GH_AW_MCP_CONFIG_766fb6333e2be087_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -110,16 +110,19 @@ steps:
       fi
 
       # Find the most expensive workflow (by total tokens across all its runs)
+      # Schema: gh aw logs --json → LogsData.runs[] (RunData from pkg/cli/logs_report.go)
+      #   .workflow_name (string), .token_usage (int, omitempty → null when 0),
+      #   .estimated_cost (float, omitempty), .database_id (int64), .created_at (time), .url (string)
       echo "🔍 Identifying most expensive workflow..."
       jq -r '
         sort_by(.workflow_name) |
         group_by(.workflow_name) |
         map({
           workflow: .[0].workflow_name,
-          total_tokens: (map(.token_usage) | add),
-          total_cost: 0,
+          total_tokens: (map(.token_usage // 0) | add),
+          total_cost: (map(.estimated_cost // 0) | add),
           run_count: length,
-          avg_tokens: ((map(.token_usage) | add) / length),
+          avg_tokens: ((map(.token_usage // 0) | add) / length),
           run_ids: map(.database_id),
           latest_run_id: (sort_by(.created_at) | last | .database_id),
           latest_run_url: (sort_by(.created_at) | last | .url)


### PR DESCRIPTION
## Problem

The Copilot Token Optimizer failed in [run 23965804699](https://github.com/github/gh-aw/actions/runs/23965804699) with:

```
jq: error: null (null) and number (1) cannot be divided
```

The `token_usage` field in `RunData` uses `omitempty`, so when a run has zero token usage the field is omitted from JSON. In jq, accessing an omitted field yields `null`. When **all** runs in a workflow group have null token usage:
- `map(.token_usage) | add` → `null`
- `null / length` → division error

## Fix

- Add `// 0` null coalescing: `map(.token_usage // 0) | add`
- Replace hardcoded `total_cost: 0` with actual field: `map(.estimated_cost // 0) | add`
- Add inline schema comments in the workflow jq blocks documenting the `RunData` fields and their nullability (source of truth: `pkg/cli/logs_report.go`)

## Files Changed

- `.github/workflows/copilot-token-optimizer.md` — null-safe jq, schema comments, estimated_cost field
- `.github/workflows/claude-token-optimizer.md` — same changes
- Corresponding `.lock.yml` files (recompiled)

No changes to `pkg/cli/logs_report.go` — the Go struct is unchanged; comments in the workflows reference it as the schema source.

## Testing

- Both workflows compile successfully
- Hash consistency test passes (184/184 workflows)