### PR TITLE
fix: install gh-aw CLI in shared token-logs-24h before fallback download

### DIFF
--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2a7790adba369fc83490d325942fc39011abb292a91c841ce1d15f1bbc7778f1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9c0f38dc7951aacaacb90927014bab04b8fb22e44620fd00a079633ed9005e5b","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -145,14 +145,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_865f8c029ab0cc8c_EOF'
+          cat << 'GH_AW_PROMPT_abae0e996ddcf902_EOF'
           <system>
-          GH_AW_PROMPT_865f8c029ab0cc8c_EOF
+          GH_AW_PROMPT_abae0e996ddcf902_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_865f8c029ab0cc8c_EOF'
+          cat << 'GH_AW_PROMPT_abae0e996ddcf902_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -184,14 +184,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_865f8c029ab0cc8c_EOF
+          GH_AW_PROMPT_abae0e996ddcf902_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_865f8c029ab0cc8c_EOF'
+          cat << 'GH_AW_PROMPT_abae0e996ddcf902_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_865f8c029ab0cc8c_EOF
+          GH_AW_PROMPT_abae0e996ddcf902_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -319,7 +319,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -384,12 +384,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c87dffd3914cbb66_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_3ef3f47183d7cd4f_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c87dffd3914cbb66_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3ef3f47183d7cd4f_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7e0bf6c0f540876a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2beb82f5c6ab2993_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -397,8 +397,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_7e0bf6c0f540876a_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_fcef64af71a26bce_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_2beb82f5c6ab2993_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f6dd23bc4ac29cde_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -491,7 +491,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_fcef64af71a26bce_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f6dd23bc4ac29cde_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -561,7 +561,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_4538ff007a3cbeed_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_66b8331665784ad3_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -602,7 +602,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4538ff007a3cbeed_EOF
+          GH_AW_MCP_CONFIG_66b8331665784ad3_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-optimizer.lock.yml
+++ b/.github/workflows/claude-token-optimizer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9c0f38dc7951aacaacb90927014bab04b8fb22e44620fd00a079633ed9005e5b","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"167533721e16dde1234c350423e0e0b74845e7b0b26eeda4b44d04c8183601d6","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Optimizer"
 "on":
@@ -145,14 +145,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_abae0e996ddcf902_EOF'
+          cat << 'GH_AW_PROMPT_0af54c7bc0c8b9d9_EOF'
           <system>
-          GH_AW_PROMPT_abae0e996ddcf902_EOF
+          GH_AW_PROMPT_0af54c7bc0c8b9d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_abae0e996ddcf902_EOF'
+          cat << 'GH_AW_PROMPT_0af54c7bc0c8b9d9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -184,14 +184,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_abae0e996ddcf902_EOF
+          GH_AW_PROMPT_0af54c7bc0c8b9d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_abae0e996ddcf902_EOF'
+          cat << 'GH_AW_PROMPT_0af54c7bc0c8b9d9_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-optimizer.md}}
-          GH_AW_PROMPT_abae0e996ddcf902_EOF
+          GH_AW_PROMPT_0af54c7bc0c8b9d9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -319,7 +319,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps.\n  # Install failure is non-fatal to match the fallback-safe behavior of gh aw logs below.\n  GH_AW_AVAILABLE=false\n  if gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    GH_AW_AVAILABLE=true\n  else\n    echo \"📦 Installing gh-aw CLI extension...\"\n    if gh extension install github/gh-aw 2>/dev/null; then\n      GH_AW_AVAILABLE=true\n    else\n      echo \"⚠️ Failed to install gh-aw CLI extension; continuing with empty token logs.\"\n    fi\n  fi\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine copilot \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine claude \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -384,12 +384,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_3ef3f47183d7cd4f_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_7f487b90f8ae2763_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","claude","cost-reduction"],"max":1,"title_prefix":"⚡ Claude Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3ef3f47183d7cd4f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7f487b90f8ae2763_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2beb82f5c6ab2993_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_61dc28601419cbc5_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Claude Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"claude\" \"cost-reduction\"] will be automatically added."
@@ -397,8 +397,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_2beb82f5c6ab2993_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f6dd23bc4ac29cde_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_61dc28601419cbc5_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_4a4b250c5eba2238_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -491,7 +491,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_f6dd23bc4ac29cde_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_4a4b250c5eba2238_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -561,7 +561,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_66b8331665784ad3_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_ab73ed868d340c5a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -602,7 +602,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_66b8331665784ad3_EOF
+          GH_AW_MCP_CONFIG_ab73ed868d340c5a_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-usage-analyzer.lock.yml
+++ b/.github/workflows/claude-token-usage-analyzer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ba2302c3769bbb8b94c2ff85e0afd230984875af3d57059fbe1ac4afe6b7f8e7","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0d78d6fd6eb34c611967976b884fff2c4d782c65f3fc33885954d205a81838de","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Usage Analyzer"
 "on":
@@ -133,14 +133,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_1c39250609cdc01f_EOF'
+          cat << 'GH_AW_PROMPT_40e5ac33abb2ee11_EOF'
           <system>
-          GH_AW_PROMPT_1c39250609cdc01f_EOF
+          GH_AW_PROMPT_40e5ac33abb2ee11_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1c39250609cdc01f_EOF'
+          cat << 'GH_AW_PROMPT_40e5ac33abb2ee11_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -172,14 +172,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_1c39250609cdc01f_EOF
+          GH_AW_PROMPT_40e5ac33abb2ee11_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1c39250609cdc01f_EOF'
+          cat << 'GH_AW_PROMPT_40e5ac33abb2ee11_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-usage-analyzer.md}}
-          GH_AW_PROMPT_1c39250609cdc01f_EOF
+          GH_AW_PROMPT_40e5ac33abb2ee11_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -302,7 +302,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -367,12 +367,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_83c9165ffb98981e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_92686edf6a500f3d_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","claude"],"max":1,"title_prefix":"📊 Claude Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_83c9165ffb98981e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_92686edf6a500f3d_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_8f3d91b453b7cc58_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5e52dab987c477c2_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Claude Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"claude\"] will be automatically added."
@@ -380,8 +380,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_8f3d91b453b7cc58_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_0962d2ff7c09dfd3_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_5e52dab987c477c2_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f020df3e1e6758ca_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -474,7 +474,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_0962d2ff7c09dfd3_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f020df3e1e6758ca_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -544,7 +544,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_27a93d3048856bb5_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_5397c440a4d20f14_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -585,7 +585,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_27a93d3048856bb5_EOF
+          GH_AW_MCP_CONFIG_5397c440a4d20f14_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/claude-token-usage-analyzer.lock.yml
+++ b/.github/workflows/claude-token-usage-analyzer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0d78d6fd6eb34c611967976b884fff2c4d782c65f3fc33885954d205a81838de","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6a5392393f2e878d3aa326b33cffd33706a5dfcc5550b0c05371b4375d1b1dc0","strict":true,"agent_id":"copilot"}
 
 name: "Claude Token Usage Analyzer"
 "on":
@@ -133,14 +133,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_40e5ac33abb2ee11_EOF'
+          cat << 'GH_AW_PROMPT_81d57ddba232508d_EOF'
           <system>
-          GH_AW_PROMPT_40e5ac33abb2ee11_EOF
+          GH_AW_PROMPT_81d57ddba232508d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_40e5ac33abb2ee11_EOF'
+          cat << 'GH_AW_PROMPT_81d57ddba232508d_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -172,14 +172,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_40e5ac33abb2ee11_EOF
+          GH_AW_PROMPT_81d57ddba232508d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_40e5ac33abb2ee11_EOF'
+          cat << 'GH_AW_PROMPT_81d57ddba232508d_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/claude-token-usage-analyzer.md}}
-          GH_AW_PROMPT_40e5ac33abb2ee11_EOF
+          GH_AW_PROMPT_81d57ddba232508d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -302,7 +302,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps.\n  # Install failure is non-fatal to match the fallback-safe behavior of gh aw logs below.\n  GH_AW_AVAILABLE=false\n  if gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    GH_AW_AVAILABLE=true\n  else\n    echo \"📦 Installing gh-aw CLI extension...\"\n    if gh extension install github/gh-aw 2>/dev/null; then\n      GH_AW_AVAILABLE=true\n    else\n      echo \"⚠️ Failed to install gh-aw CLI extension; continuing with empty token logs.\"\n    fi\n  fi\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine copilot \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine claude \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -367,12 +367,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_92686edf6a500f3d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_82de6ae2dadd7c2e_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","claude"],"max":1,"title_prefix":"📊 Claude Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_92686edf6a500f3d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_82de6ae2dadd7c2e_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5e52dab987c477c2_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_39ed3d7b845edb78_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Claude Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"claude\"] will be automatically added."
@@ -380,8 +380,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_5e52dab987c477c2_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f020df3e1e6758ca_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_39ed3d7b845edb78_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9c8c2c76d601c1b7_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -474,7 +474,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_f020df3e1e6758ca_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_9c8c2c76d601c1b7_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -544,7 +544,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_5397c440a4d20f14_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_d7b7aa695410e4dd_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -585,7 +585,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5397c440a4d20f14_EOF
+          GH_AW_MCP_CONFIG_d7b7aa695410e4dd_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"22b5f7da1cb1e6b3efc2727b7cedff5a440d13bd02bbff7e63163b02d1f49538","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a24c1ae4883581d6e6fd93548c4f5f51dabb7a191410c2643b603956e5e613e9","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Optimizer"
 "on":
@@ -145,14 +145,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_82f4d61527eb7ee5_EOF'
+          cat << 'GH_AW_PROMPT_7b0bea533deb5342_EOF'
           <system>
-          GH_AW_PROMPT_82f4d61527eb7ee5_EOF
+          GH_AW_PROMPT_7b0bea533deb5342_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_82f4d61527eb7ee5_EOF'
+          cat << 'GH_AW_PROMPT_7b0bea533deb5342_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -184,14 +184,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_82f4d61527eb7ee5_EOF
+          GH_AW_PROMPT_7b0bea533deb5342_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_82f4d61527eb7ee5_EOF'
+          cat << 'GH_AW_PROMPT_7b0bea533deb5342_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_82f4d61527eb7ee5_EOF
+          GH_AW_PROMPT_7b0bea533deb5342_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -319,7 +319,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps.\n  # Install failure is non-fatal to match the fallback-safe behavior of gh aw logs below.\n  GH_AW_AVAILABLE=false\n  if gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    GH_AW_AVAILABLE=true\n  else\n    echo \"📦 Installing gh-aw CLI extension...\"\n    if gh extension install github/gh-aw 2>/dev/null; then\n      GH_AW_AVAILABLE=true\n    else\n      echo \"⚠️ Failed to install gh-aw CLI extension; continuing with empty token logs.\"\n    fi\n  fi\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine copilot \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine claude \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -384,12 +384,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_3e706430018f86c1_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_cd0120f4aba03592_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3e706430018f86c1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_cd0120f4aba03592_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_3803329a2ff10815_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7104d9148cbc1b80_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
@@ -397,8 +397,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_3803329a2ff10815_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f38468ec9362afd8_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_7104d9148cbc1b80_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_eac739de4be6980d_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -491,7 +491,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_f38468ec9362afd8_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_eac739de4be6980d_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -561,7 +561,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_df21c71978d5f984_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_1715673cd075ccbd_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -602,7 +602,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_df21c71978d5f984_EOF
+          GH_AW_MCP_CONFIG_1715673cd075ccbd_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc01976ea054f024daf4349524f6d822528849946e652f50121bd709cfb1c8af","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"22b5f7da1cb1e6b3efc2727b7cedff5a440d13bd02bbff7e63163b02d1f49538","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Optimizer"
 "on":
@@ -145,14 +145,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_8266933d40461ccb_EOF'
+          cat << 'GH_AW_PROMPT_82f4d61527eb7ee5_EOF'
           <system>
-          GH_AW_PROMPT_8266933d40461ccb_EOF
+          GH_AW_PROMPT_82f4d61527eb7ee5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8266933d40461ccb_EOF'
+          cat << 'GH_AW_PROMPT_82f4d61527eb7ee5_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -184,14 +184,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8266933d40461ccb_EOF
+          GH_AW_PROMPT_82f4d61527eb7ee5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8266933d40461ccb_EOF'
+          cat << 'GH_AW_PROMPT_82f4d61527eb7ee5_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_8266933d40461ccb_EOF
+          GH_AW_PROMPT_82f4d61527eb7ee5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -319,7 +319,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -384,12 +384,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e856f5ceb5837736_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_3e706430018f86c1_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["automated-analysis","token-optimization","copilot","cost-reduction"],"max":1,"title_prefix":"⚡ Copilot Token Optimization: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e856f5ceb5837736_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3e706430018f86c1_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_dad1e5cf5de0976e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_3803329a2ff10815_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"⚡ Copilot Token Optimization: \". Labels [\"automated-analysis\" \"token-optimization\" \"copilot\" \"cost-reduction\"] will be automatically added."
@@ -397,8 +397,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_dad1e5cf5de0976e_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d9890737c1114701_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_3803329a2ff10815_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f38468ec9362afd8_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -491,7 +491,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_d9890737c1114701_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f38468ec9362afd8_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -561,7 +561,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_343378b042518646_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_df21c71978d5f984_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -602,7 +602,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_343378b042518646_EOF
+          GH_AW_MCP_CONFIG_df21c71978d5f984_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -30,7 +30,7 @@
 #     - shared/trends.md
 #     - shared/charts-with-trending.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"35ef0b0d58c85162088d7176d3579f15c52e6cacf78fbe131b8f45d4771495ad","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"69044543fa20b09bcac56c8da732625fe1c5589ca459212153fc34f42b846090","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Usage Analyzer"
 "on":
@@ -136,15 +136,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_3d565f0b0537ebe6_EOF'
+          cat << 'GH_AW_PROMPT_e093dd99eb9f0be4_EOF'
           <system>
-          GH_AW_PROMPT_3d565f0b0537ebe6_EOF
+          GH_AW_PROMPT_e093dd99eb9f0be4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3d565f0b0537ebe6_EOF'
+          cat << 'GH_AW_PROMPT_e093dd99eb9f0be4_EOF'
           <safe-output-tools>
           Tools: create_issue, upload_asset, missing_tool, missing_data, noop
           
@@ -178,9 +178,9 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_3d565f0b0537ebe6_EOF
+          GH_AW_PROMPT_e093dd99eb9f0be4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3d565f0b0537ebe6_EOF'
+          cat << 'GH_AW_PROMPT_e093dd99eb9f0be4_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
@@ -188,7 +188,7 @@ jobs:
           {{#runtime-import .github/workflows/shared/python-dataviz.md}}
           {{#runtime-import .github/workflows/shared/trends.md}}
           {{#runtime-import .github/workflows/copilot-token-usage-analyzer.md}}
-          GH_AW_PROMPT_3d565f0b0537ebe6_EOF
+          GH_AW_PROMPT_e093dd99eb9f0be4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -321,7 +321,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps.\n  # Install failure is non-fatal to match the fallback-safe behavior of gh aw logs below.\n  GH_AW_AVAILABLE=false\n  if gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    GH_AW_AVAILABLE=true\n  else\n    echo \"📦 Installing gh-aw CLI extension...\"\n    if gh extension install github/gh-aw 2>/dev/null; then\n      GH_AW_AVAILABLE=true\n    else\n      echo \"⚠️ Failed to install gh-aw CLI extension; continuing with empty token logs.\"\n    fi\n  fi\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine copilot \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine claude \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -401,12 +401,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_b5e5215f37587215_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_fcf8ef07873e003f_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","copilot"],"max":1,"title_prefix":"📊 Copilot Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_b5e5215f37587215_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_fcf8ef07873e003f_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_9225a77a9e58b4e8_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_bf52e2ac70bd3012_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Copilot Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"copilot\"] will be automatically added.",
@@ -415,8 +415,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_9225a77a9e58b4e8_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_7be4ee45d99f3a2d_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_bf52e2ac70bd3012_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2a939727edbed576_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -518,7 +518,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_7be4ee45d99f3a2d_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_2a939727edbed576_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -591,7 +591,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_2f06f91299fd0f65_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_117f0830d1197999_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -632,7 +632,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2f06f91299fd0f65_EOF
+          GH_AW_MCP_CONFIG_117f0830d1197999_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/reporting.md
 #     - shared/token-logs-24h.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"77138b4593415a65273b1f64482dcc86c5a2607d54f424897cb55b2369398f75","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"35ef0b0d58c85162088d7176d3579f15c52e6cacf78fbe131b8f45d4771495ad","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Usage Analyzer"
 "on":
@@ -133,14 +133,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_2e452ca050c3e6b7_EOF'
+          cat << 'GH_AW_PROMPT_3d565f0b0537ebe6_EOF'
           <system>
-          GH_AW_PROMPT_2e452ca050c3e6b7_EOF
+          GH_AW_PROMPT_3d565f0b0537ebe6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2e452ca050c3e6b7_EOF'
+          cat << 'GH_AW_PROMPT_3d565f0b0537ebe6_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -172,14 +172,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2e452ca050c3e6b7_EOF
+          GH_AW_PROMPT_3d565f0b0537ebe6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2e452ca050c3e6b7_EOF'
+          cat << 'GH_AW_PROMPT_3d565f0b0537ebe6_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-usage-analyzer.md}}
-          GH_AW_PROMPT_2e452ca050c3e6b7_EOF
+          GH_AW_PROMPT_3d565f0b0537ebe6_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -302,7 +302,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
-        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+        run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps\n  if ! gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    echo \"📦 Installing gh-aw CLI extension...\"\n    gh extension install github/gh-aw\n  fi\n\n  gh aw logs \\\n    --engine copilot \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  gh aw logs \\\n    --engine claude \\\n    --start-date -1d \\\n    --json \\\n    -c 300 \\\n    > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -367,12 +367,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_f7c033eea955b25b_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_b5e5215f37587215_EOF'
           {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","copilot"],"max":1,"title_prefix":"📊 Copilot Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f7c033eea955b25b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b5e5215f37587215_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_df08769c80198a03_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_9225a77a9e58b4e8_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Copilot Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"copilot\"] will be automatically added."
@@ -380,8 +380,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_df08769c80198a03_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d050d42b52b9100c_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_9225a77a9e58b4e8_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_7be4ee45d99f3a2d_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -474,7 +474,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_d050d42b52b9100c_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_7be4ee45d99f3a2d_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -544,7 +544,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_b43eef03b95713ce_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_2f06f91299fd0f65_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -585,7 +585,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b43eef03b95713ce_EOF
+          GH_AW_MCP_CONFIG_2f06f91299fd0f65_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-usage-analyzer.lock.yml
+++ b/.github/workflows/copilot-token-usage-analyzer.lock.yml
@@ -30,7 +30,7 @@
 #     - shared/trends.md
 #     - shared/charts-with-trending.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"69044543fa20b09bcac56c8da732625fe1c5589ca459212153fc34f42b846090","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"49c13aa69c6b78320d9388fb9ec80f1f6c77223d646fbc3eedeb337792f8e425","strict":true,"agent_id":"copilot"}
 
 name: "Copilot Token Usage Analyzer"
 "on":
@@ -136,15 +136,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_e093dd99eb9f0be4_EOF'
+          cat << 'GH_AW_PROMPT_e49e167afc9c643d_EOF'
           <system>
-          GH_AW_PROMPT_e093dd99eb9f0be4_EOF
+          GH_AW_PROMPT_e49e167afc9c643d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e093dd99eb9f0be4_EOF'
+          cat << 'GH_AW_PROMPT_e49e167afc9c643d_EOF'
           <safe-output-tools>
           Tools: create_issue, upload_asset, missing_tool, missing_data, noop
           
@@ -178,9 +178,9 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e093dd99eb9f0be4_EOF
+          GH_AW_PROMPT_e49e167afc9c643d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e093dd99eb9f0be4_EOF'
+          cat << 'GH_AW_PROMPT_e49e167afc9c643d_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/token-logs-24h.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
@@ -188,7 +188,7 @@ jobs:
           {{#runtime-import .github/workflows/shared/python-dataviz.md}}
           {{#runtime-import .github/workflows/shared/trends.md}}
           {{#runtime-import .github/workflows/copilot-token-usage-analyzer.md}}
-          GH_AW_PROMPT_e093dd99eb9f0be4_EOF
+          GH_AW_PROMPT_e49e167afc9c643d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -322,6 +322,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Restore 24h token logs from cache
         run: "set -euo pipefail\nTOKEN_LOGS_DIR=\"/tmp/gh-aw/token-logs\"\nmkdir -p \"$TOKEN_LOGS_DIR\"\nTODAY=$(date -u +%Y-%m-%d)\n\n# Look for today's pre-fetched data from the Token Logs Fetch workflow\nFETCH_RUN_ID=$(gh run list \\\n  --workflow \"token-logs-fetch.lock.yml\" \\\n  --status success \\\n  --limit 1 \\\n  --json databaseId \\\n  --jq '.[0].databaseId' 2>/dev/null || echo \"\")\n\nUSED_CACHE=false\nif [ -n \"$FETCH_RUN_ID\" ]; then\n  CACHE_TMP=\"/tmp/gh-aw/token-logs-fetch-cache\"\n  mkdir -p \"$CACHE_TMP\"\n  gh run download \"$FETCH_RUN_ID\" \\\n    --repo \"$GITHUB_REPOSITORY\" \\\n    --name \"cache-memory\" \\\n    --dir \"$CACHE_TMP\" \\\n    2>/dev/null || true\n  CACHE_DATE=$(cat \"$CACHE_TMP/token-logs/fetch-date.txt\" 2>/dev/null || echo \"\")\n  if [ \"$CACHE_DATE\" = \"$TODAY\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/copilot-runs.json\" ] && \\\n     [ -s \"$CACHE_TMP/token-logs/claude-runs.json\" ]; then\n    echo \"✅ Using pre-fetched logs from Token Logs Fetch run $FETCH_RUN_ID (date: $CACHE_DATE)\"\n    cp \"$CACHE_TMP/token-logs/copilot-runs.json\" \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n    cp \"$CACHE_TMP/token-logs/claude-runs.json\" \"$TOKEN_LOGS_DIR/claude-runs.json\"\n    USED_CACHE=true\n  else\n    echo \"ℹ️ No valid cached logs found (cache date: ${CACHE_DATE:-none}, today: $TODAY)\"\n  fi\nfi\n\nif [ \"$USED_CACHE\" != \"true\" ]; then\n  echo \"📥 Downloading Copilot and Claude workflow runs from last 24 hours...\"\n\n  # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps.\n  # Install failure is non-fatal to match the fallback-safe behavior of gh aw logs below.\n  GH_AW_AVAILABLE=false\n  if gh extension list 2>/dev/null | grep -q \"github/gh-aw\"; then\n    GH_AW_AVAILABLE=true\n  else\n    echo \"📦 Installing gh-aw CLI extension...\"\n    if gh extension install github/gh-aw 2>/dev/null; then\n      GH_AW_AVAILABLE=true\n    else\n      echo \"⚠️ Failed to install gh-aw CLI extension; continuing with empty token logs.\"\n    fi\n  fi\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine copilot \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-copilot-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-copilot-raw.json > \"$TOKEN_LOGS_DIR/copilot-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/copilot-runs.json\"\n\n  if [ \"$GH_AW_AVAILABLE\" = \"true\" ]; then\n    gh aw logs \\\n      --engine claude \\\n      --start-date -1d \\\n      --json \\\n      -c 300 \\\n      > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  else\n    echo '{\"runs\":[]}' > /tmp/token-logs-claude-raw.json\n  fi\n  jq '.runs // []' /tmp/token-logs-claude-raw.json > \"$TOKEN_LOGS_DIR/claude-runs.json\" 2>/dev/null || echo \"[]\" > \"$TOKEN_LOGS_DIR/claude-runs.json\"\nfi\n\necho \"✅ Copilot runs: $(jq 'length' \"$TOKEN_LOGS_DIR/copilot-runs.json\")\"\necho \"✅ Claude runs: $(jq 'length' \"$TOKEN_LOGS_DIR/claude-runs.json\")\""
+      - name: Setup Python environment
+        run: "# Create working directory for Python scripts\nmkdir -p /tmp/gh-aw/python\nmkdir -p /tmp/gh-aw/python/data\nmkdir -p /tmp/gh-aw/python/charts\nmkdir -p /tmp/gh-aw/python/artifacts\n\necho \"Python environment setup complete\"\necho \"Working directory: /tmp/gh-aw/python\"\necho \"Data directory: /tmp/gh-aw/python/data\"\necho \"Charts directory: /tmp/gh-aw/python/charts\"\necho \"Artifacts directory: /tmp/gh-aw/python/artifacts\"\n"
+      - name: Install Python scientific libraries
+        run: "# Create a virtual environment for proper package isolation (avoids --break-system-packages)\nif [ ! -d /tmp/gh-aw/venv ]; then\n  python3 -m venv /tmp/gh-aw/venv\nfi\necho \"/tmp/gh-aw/venv/bin\" >> \"$GITHUB_PATH\"\n/tmp/gh-aw/venv/bin/pip install --quiet numpy pandas matplotlib seaborn scipy\n\n# Verify installations\n/tmp/gh-aw/venv/bin/python3 -c \"import numpy; print(f'NumPy {numpy.__version__} installed')\"\n/tmp/gh-aw/venv/bin/python3 -c \"import pandas; print(f'Pandas {pandas.__version__} installed')\"\n/tmp/gh-aw/venv/bin/python3 -c \"import matplotlib; print(f'Matplotlib {matplotlib.__version__} installed')\"\n/tmp/gh-aw/venv/bin/python3 -c \"import seaborn; print(f'Seaborn {seaborn.__version__} installed')\"\n/tmp/gh-aw/venv/bin/python3 -c \"import scipy; print(f'SciPy {scipy.__version__} installed')\"\n\necho \"All scientific libraries installed successfully\"\n"
+      - if: always()
+        name: Upload charts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          if-no-files-found: warn
+          name: data-charts
+          path: /tmp/gh-aw/python/charts/*.png
+          retention-days: 30
+      - if: always()
+        name: Upload source files and data
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          if-no-files-found: warn
+          name: python-source-and-data
+          path: |
+            /tmp/gh-aw/python/*.py
+            /tmp/gh-aw/python/data/*
+          retention-days: 30
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Install gh-aw CLI
@@ -401,12 +423,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_fcf8ef07873e003f_EOF'
-          {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","copilot"],"max":1,"title_prefix":"📊 Copilot Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fcf8ef07873e003f_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_143eec2040ddc01d_EOF'
+          {"create_issue":{"close_older_issues":true,"expires":48,"labels":["automated-analysis","token-usage","copilot"],"max":1,"title_prefix":"📊 Copilot Token Usage Report: "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/${{ github.workflow }}","max-size":10240}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_143eec2040ddc01d_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_bf52e2ac70bd3012_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5f624a3878ddf334_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📊 Copilot Token Usage Report: \". Labels [\"automated-analysis\" \"token-usage\" \"copilot\"] will be automatically added.",
@@ -415,8 +437,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_bf52e2ac70bd3012_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2a939727edbed576_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_5f624a3878ddf334_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_39b21abdc3e44190_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -518,7 +540,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_2a939727edbed576_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_39b21abdc3e44190_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -591,7 +613,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_117f0830d1197999_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_a4d199634435b1e5_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -632,7 +654,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_117f0830d1197999_EOF
+          GH_AW_MCP_CONFIG_a4d199634435b1e5_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/shared/token-logs-24h.md
+++ b/.github/workflows/shared/token-logs-24h.md
@@ -52,6 +52,12 @@ steps:
       if [ "$USED_CACHE" != "true" ]; then
         echo "📥 Downloading Copilot and Claude workflow runs from last 24 hours..."
 
+        # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps
+        if ! gh extension list 2>/dev/null | grep -q "github/gh-aw"; then
+          echo "📦 Installing gh-aw CLI extension..."
+          gh extension install github/gh-aw
+        fi
+
         gh aw logs \
           --engine copilot \
           --start-date -1d \

--- a/.github/workflows/shared/token-logs-24h.md
+++ b/.github/workflows/shared/token-logs-24h.md
@@ -52,26 +52,42 @@ steps:
       if [ "$USED_CACHE" != "true" ]; then
         echo "📥 Downloading Copilot and Claude workflow runs from last 24 hours..."
 
-        # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps
-        if ! gh extension list 2>/dev/null | grep -q "github/gh-aw"; then
+        # Ensure gh-aw CLI is installed — this shared step runs before user-defined steps.
+        # Install failure is non-fatal to match the fallback-safe behavior of gh aw logs below.
+        GH_AW_AVAILABLE=false
+        if gh extension list 2>/dev/null | grep -q "github/gh-aw"; then
+          GH_AW_AVAILABLE=true
+        else
           echo "📦 Installing gh-aw CLI extension..."
-          gh extension install github/gh-aw
+          if gh extension install github/gh-aw 2>/dev/null; then
+            GH_AW_AVAILABLE=true
+          else
+            echo "⚠️ Failed to install gh-aw CLI extension; continuing with empty token logs."
+          fi
         fi
 
-        gh aw logs \
-          --engine copilot \
-          --start-date -1d \
-          --json \
-          -c 300 \
-          > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-logs-copilot-raw.json
+        if [ "$GH_AW_AVAILABLE" = "true" ]; then
+          gh aw logs \
+            --engine copilot \
+            --start-date -1d \
+            --json \
+            -c 300 \
+            > /tmp/token-logs-copilot-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-logs-copilot-raw.json
+        else
+          echo '{"runs":[]}' > /tmp/token-logs-copilot-raw.json
+        fi
         jq '.runs // []' /tmp/token-logs-copilot-raw.json > "$TOKEN_LOGS_DIR/copilot-runs.json" 2>/dev/null || echo "[]" > "$TOKEN_LOGS_DIR/copilot-runs.json"
 
-        gh aw logs \
-          --engine claude \
-          --start-date -1d \
-          --json \
-          -c 300 \
-          > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-logs-claude-raw.json
+        if [ "$GH_AW_AVAILABLE" = "true" ]; then
+          gh aw logs \
+            --engine claude \
+            --start-date -1d \
+            --json \
+            -c 300 \
+            > /tmp/token-logs-claude-raw.json 2>/dev/null || echo '{"runs":[]}' > /tmp/token-logs-claude-raw.json
+        else
+          echo '{"runs":[]}' > /tmp/token-logs-claude-raw.json
+        fi
         jq '.runs // []' /tmp/token-logs-claude-raw.json > "$TOKEN_LOGS_DIR/claude-runs.json" 2>/dev/null || echo "[]" > "$TOKEN_LOGS_DIR/claude-runs.json"
       fi
 


### PR DESCRIPTION
## Problem

The Copilot Token Usage Analyzer [run 23970804938](https://github.com/github/gh-aw/actions/runs/23970804938) completed successfully but produced **0 runs** — no report was created.

**Root cause**: The `shared/token-logs-24h.md` shared component is injected by the compiler as step 6, **before** the user-defined "Install gh-aw CLI" step (step 7). When the Token Logs Fetch cache is stale or unavailable, the fallback path calls `gh aw logs` — but `gh-aw` isn't installed yet. The command fails silently (`2>/dev/null || echo '{"runs":[]}'`) and writes empty data.

**Execution trace:**
```
Step 6: Restore 24h token logs from cache  ← shared step (runs gh aw logs → fails, 0 runs)
Step 7: Install gh-aw CLI                  ← user-defined step (too late)
Step 8: Download Copilot workflow runs      ← copies empty data from step 6
→ ✅ Found 0 Copilot workflow runs
→ Agent has nothing to analyze, calls noop
```

## Fix

Add an inline `gh-aw` install check in the shared component's fallback path:

```bash
if ! gh extension list 2>/dev/null | grep -q "github/gh-aw"; then
  echo "📦 Installing gh-aw CLI extension..."
  gh extension install github/gh-aw
fi
```

This ensures `gh aw logs` has the CLI available regardless of step ordering.

## Files Changed

- `.github/workflows/shared/token-logs-24h.md` — add gh-aw install before fallback download
- All 4 token workflow `.lock.yml` files (recompiled)

## Testing

- All 4 workflows compile successfully
- Hash consistency test passes (184/184 workflows)