### PR TITLE
fix: reduce token audit scope to last 24 hours

### DIFF
--- a/.github/workflows/copilot-token-audit.lock.yml
+++ b/.github/workflows/copilot-token-audit.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f0b2ee01cf90f700233643d7c6ffa4db69067c18ed3516d0604f9b865b60187e","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5e5bbba744e3b4fddbb22ab5feadff35619a7a73a646769cfb1cb977e6bfb05e","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -153,9 +153,9 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_b5b1365a3df339bf_EOF'
+          cat << 'GH_AW_PROMPT_66bee06f519be27f_EOF'
           <system>
-          GH_AW_PROMPT_b5b1365a3df339bf_EOF
+          GH_AW_PROMPT_66bee06f519be27f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
@@ -163,7 +163,7 @@ jobs:
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5b1365a3df339bf_EOF'
+          cat << 'GH_AW_PROMPT_66bee06f519be27f_EOF'
           <safe-output-tools>
           Tools: create_discussion, upload_asset, missing_tool, missing_data, noop
           
@@ -197,14 +197,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b5b1365a3df339bf_EOF
+          GH_AW_PROMPT_66bee06f519be27f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5b1365a3df339bf_EOF'
+          cat << 'GH_AW_PROMPT_66bee06f519be27f_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/shared/python-dataviz.md}}
           {{#runtime-import .github/workflows/copilot-token-audit.md}}
-          GH_AW_PROMPT_b5b1365a3df339bf_EOF
+          GH_AW_PROMPT_66bee06f519be27f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -408,7 +408,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Copilot workflow logs
-        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\n# Download last 30 days of Copilot logs as JSON\ngh aw logs \\\n  --engine copilot \\\n  --start-date -30d \\\n  --json \\\n  -c 500 \\\n  > /tmp/gh-aw/token-audit/copilot-logs.json\n\nTOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/copilot-logs.json)\necho \"✅ Downloaded $TOTAL Copilot workflow runs (last 30 days)\"\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\n# Download last 24 hours of Copilot logs as JSON\ngh aw logs \\\n  --engine copilot \\\n  --start-date -1d \\\n  --json \\\n  -c 100 \\\n  > /tmp/gh-aw/token-audit/copilot-logs.json\n\nTOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/copilot-logs.json)\necho \"✅ Downloaded $TOTAL Copilot workflow runs (last 24 hours)\"\n"
 
       # Cache memory file share configuration from frontmatter processed below
       - name: Create cache-memory directory
@@ -508,12 +508,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_109add83f69b1874_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_8b80532612753551_EOF'
           {"create_discussion":{"category":"audits","close_older_discussions":true,"expires":72,"fallback_to_issue":true,"max":1,"title_prefix":"[copilot-token-audit] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/${{ github.workflow }}","max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_109add83f69b1874_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8b80532612753551_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e68a2dc7ddff8a0f_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_1cb33b140f1ad090_EOF'
           {
             "description_suffixes": {
               "create_discussion": " CONSTRAINTS: Maximum 1 discussion(s) can be created. Title will be prefixed with \"[copilot-token-audit] \". Discussions will be created in category \"audits\".",
@@ -522,8 +522,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_e68a2dc7ddff8a0f_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_77c243e10a3bbdb7_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_1cb33b140f1ad090_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ba0302e44a1c3d1e_EOF'
           {
             "create_discussion": {
               "defaultMax": 1,
@@ -618,7 +618,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_77c243e10a3bbdb7_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_ba0302e44a1c3d1e_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -692,7 +692,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_78a0259eb6778c7e_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_759d72ab9f994189_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -752,7 +752,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_78a0259eb6778c7e_EOF
+          GH_AW_MCP_CONFIG_759d72ab9f994189_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-audit.md
+++ b/.github/workflows/copilot-token-audit.md
@@ -31,16 +31,16 @@ steps:
       set -euo pipefail
       mkdir -p /tmp/gh-aw/token-audit
 
-      # Download last 30 days of Copilot logs as JSON
+      # Download last 24 hours of Copilot logs as JSON
       gh aw logs \
         --engine copilot \
-        --start-date -30d \
+        --start-date -1d \
         --json \
-        -c 500 \
+        -c 100 \
         > /tmp/gh-aw/token-audit/copilot-logs.json
 
       TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/copilot-logs.json)
-      echo "✅ Downloaded $TOTAL Copilot workflow runs (last 30 days)"
+      echo "✅ Downloaded $TOTAL Copilot workflow runs (last 24 hours)"
 timeout-minutes: 25
 imports:
   - uses: shared/daily-audit-discussion.md
@@ -178,7 +178,7 @@ Create a discussion with these sections:
 ```
 ### 📊 Executive Summary
 
-- **Period**: last 30 days (YYYY-MM-DD to YYYY-MM-DD)
+- **Period**: last 24 hours (YYYY-MM-DD to YYYY-MM-DD)
 - **Total runs**: N
 - **Total tokens**: N (formatted with commas)
 - **Total cost**: $X.XX


### PR DESCRIPTION
## Problem

The Daily Copilot Token Usage Audit workflow ([run #23984075650](https://github.com/github/gh-aw/actions/runs/23984075650)) fails at the "Download Copilot workflow logs" step with **HTTP 403: API rate limit exceeded**.

The workflow downloads 30 days / 500 runs of log data (`--start-date -30d -c 500`), which exhausts the GitHub API rate limit for the installation token — 99 artifact downloads failed before the final listing request was also rate-limited.

## Fix

Since this workflow runs **daily** and persists snapshots to repo-memory, it only needs the **last 24 hours** of data each run. Changed:

- `--start-date -30d` → `--start-date -1d`
- `-c 500` → `-c 100`
- Updated prompt text to reference "last 24 hours" instead of "last 30 days"