### PR TITLE
fix: replace broken gh-aw install step in token audit workflow

### DIFF
--- a/.github/workflows/copilot-token-audit.lock.yml
+++ b/.github/workflows/copilot-token-audit.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f311a20415e36036f9cb4a46ad40f0ce6270c3f606e291211c14216838fa2d48","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4993afcb4a3c4deba55338531bccb1f2368e81e959816495af1ce71b96edac94","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -27,6 +27,7 @@
 #   Imports:
 #     - copilot-setup-steps.yml
 #     - shared/daily-audit-discussion.md
+#     - shared/mcp/gh-aw.md
 #     - shared/python-dataviz.md
 #     - shared/repo-memory-standard.md
 #     - shared/reporting.md
@@ -153,9 +154,9 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_6125d20035c39a13_EOF'
+          cat << 'GH_AW_PROMPT_054db1186592fa8a_EOF'
           <system>
-          GH_AW_PROMPT_6125d20035c39a13_EOF
+          GH_AW_PROMPT_054db1186592fa8a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
@@ -163,7 +164,7 @@ jobs:
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6125d20035c39a13_EOF'
+          cat << 'GH_AW_PROMPT_054db1186592fa8a_EOF'
           <safe-output-tools>
           Tools: create_discussion, upload_asset, missing_tool, missing_data, noop
           
@@ -197,14 +198,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6125d20035c39a13_EOF
+          GH_AW_PROMPT_054db1186592fa8a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6125d20035c39a13_EOF'
+          cat << 'GH_AW_PROMPT_054db1186592fa8a_EOF'
           </system>
+          {{#runtime-import .github/workflows/shared/mcp/gh-aw.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/shared/python-dataviz.md}}
           {{#runtime-import .github/workflows/copilot-token-audit.md}}
-          GH_AW_PROMPT_6125d20035c39a13_EOF
+          GH_AW_PROMPT_054db1186592fa8a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -375,6 +377,10 @@ jobs:
         run: go install golang.org/x/tools/gopls@latest
       - name: Install TypeScript language server
         run: npm install -g typescript-language-server typescript
+      - env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        name: Install gh-aw extension
+        run: "# Install gh-aw if not already available\nif ! gh aw --version >/dev/null 2>&1; then\n  echo \"Installing gh-aw extension...\"\n  curl -fsSL https://raw.githubusercontent.com/github/gh-aw/refs/heads/main/install-gh-aw.sh | bash\nfi\ngh aw --version\n# Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization\nmkdir -p ${RUNNER_TEMP}/gh-aw\nGH_AW_BIN=$(which gh-aw 2>/dev/null || find ~/.local/share/gh/extensions/gh-aw -name 'gh-aw' -type f 2>/dev/null | head -1)\nif [ -n \"$GH_AW_BIN\" ] && [ -f \"$GH_AW_BIN\" ]; then\n  cp \"$GH_AW_BIN\" ${RUNNER_TEMP}/gh-aw/gh-aw\n  chmod +x ${RUNNER_TEMP}/gh-aw/gh-aw\n  echo \"Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw\"\nelse\n  echo \"::error::Failed to find gh-aw binary for MCP server\"\n  exit 1\nfi"
       - name: Setup Python environment
         run: "# Create working directory for Python scripts\nmkdir -p /tmp/gh-aw/python\nmkdir -p /tmp/gh-aw/python/data\nmkdir -p /tmp/gh-aw/python/charts\nmkdir -p /tmp/gh-aw/python/artifacts\n\necho \"Python environment setup complete\"\necho \"Working directory: /tmp/gh-aw/python\"\necho \"Data directory: /tmp/gh-aw/python/data\"\necho \"Charts directory: /tmp/gh-aw/python/charts\"\necho \"Artifacts directory: /tmp/gh-aw/python/artifacts\"\n"
       - name: Install Python scientific libraries
@@ -397,14 +403,6 @@ jobs:
             /tmp/gh-aw/python/*.py
             /tmp/gh-aw/python/data/*
           retention-days: 30
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Install gh-aw CLI
-        run: |
-          if ! gh aw --version >/dev/null 2>&1; then
-            gh extension install github/gh-aw
-          fi
-          gh aw --version
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download Copilot workflow logs
@@ -479,41 +477,17 @@ jobs:
             await determineAutomaticLockdown(github, context, core);
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.13 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.13 ghcr.io/github/gh-aw-firewall/squid:0.25.13 ghcr.io/github/gh-aw-mcpg:v0.2.12 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
-      - name: Install gh-aw extension
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if gh-aw extension is already installed
-          if gh extension list | grep -q "github/gh-aw"; then
-            echo "gh-aw extension already installed, upgrading..."
-            gh extension upgrade gh-aw || true
-          else
-            echo "Installing gh-aw extension..."
-            gh extension install github/gh-aw
-          fi
-          gh aw --version
-          # Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization
-          mkdir -p ${RUNNER_TEMP}/gh-aw
-          GH_AW_BIN=$(which gh-aw 2>/dev/null || find ~/.local/share/gh/extensions/gh-aw -name 'gh-aw' -type f 2>/dev/null | head -1)
-          if [ -n "$GH_AW_BIN" ] && [ -f "$GH_AW_BIN" ]; then
-            cp "$GH_AW_BIN" ${RUNNER_TEMP}/gh-aw/gh-aw
-            chmod +x ${RUNNER_TEMP}/gh-aw/gh-aw
-            echo "Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw"
-          else
-            echo "::error::Failed to find gh-aw binary for MCP server"
-            exit 1
-          fi
       - name: Write Safe Outputs Config
         run: |
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_75c4ce050a0ea57a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_819e53f76fde48af_EOF'
           {"create_discussion":{"category":"audits","close_older_discussions":true,"expires":72,"fallback_to_issue":true,"max":1,"title_prefix":"[copilot-token-audit] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg"],"branch":"assets/${{ github.workflow }}","max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_75c4ce050a0ea57a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_819e53f76fde48af_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_24ed1afa67f7901e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_288b8994e1fd8d09_EOF'
           {
             "description_suffixes": {
               "create_discussion": " CONSTRAINTS: Maximum 1 discussion(s) can be created. Title will be prefixed with \"[copilot-token-audit] \". Discussions will be created in category \"audits\".",
@@ -522,8 +496,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_24ed1afa67f7901e_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_6879bccfef4859d0_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_288b8994e1fd8d09_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8fca0007804a33a6_EOF'
           {
             "create_discussion": {
               "defaultMax": 1,
@@ -618,7 +592,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_6879bccfef4859d0_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8fca0007804a33a6_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -692,7 +666,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_606521f4ea5282e7_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_d7bab00102f5cd4c_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -752,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_606521f4ea5282e7_EOF
+          GH_AW_MCP_CONFIG_d7bab00102f5cd4c_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-audit.md
+++ b/.github/workflows/copilot-token-audit.md
@@ -16,14 +16,6 @@ tools:
   bash:
     - "*"
 steps:
-  - name: Install gh-aw CLI
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    run: |
-      if ! gh aw --version >/dev/null 2>&1; then
-        gh extension install github/gh-aw
-      fi
-      gh aw --version
   - name: Download Copilot workflow logs
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,6 +55,7 @@ imports:
       branch-name: "memory/token-audit"
       description: "Historical daily Copilot token usage snapshots"
   - copilot-setup-steps.yml
+  - uses: shared/mcp/gh-aw.md
   - shared/reporting.md
   - shared/python-dataviz.md
 features:

--- a/.github/workflows/shared/mcp/gh-aw.md
+++ b/.github/workflows/shared/mcp/gh-aw.md
@@ -1,0 +1,36 @@
+---
+# gh-aw Extension - Shared Component
+# Installs the gh-aw CLI extension and copies the binary
+# for MCP server containerization.
+#
+# This component replaces the compiler-generated "Install gh-aw extension"
+# step with a robust installation that handles pre-installed binaries
+# (e.g., from copilot-setup-steps.yml curl-based installs).
+#
+# Usage:
+#   imports:
+#     - uses: shared/mcp/gh-aw.md
+
+steps:
+  - name: Install gh-aw extension
+    env:
+      GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+    run: |
+      # Install gh-aw if not already available
+      if ! gh aw --version >/dev/null 2>&1; then
+        echo "Installing gh-aw extension..."
+        curl -fsSL https://raw.githubusercontent.com/github/gh-aw/refs/heads/main/install-gh-aw.sh | bash
+      fi
+      gh aw --version
+      # Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization
+      mkdir -p ${RUNNER_TEMP}/gh-aw
+      GH_AW_BIN=$(which gh-aw 2>/dev/null || find ~/.local/share/gh/extensions/gh-aw -name 'gh-aw' -type f 2>/dev/null | head -1)
+      if [ -n "$GH_AW_BIN" ] && [ -f "$GH_AW_BIN" ]; then
+        cp "$GH_AW_BIN" ${RUNNER_TEMP}/gh-aw/gh-aw
+        chmod +x ${RUNNER_TEMP}/gh-aw/gh-aw
+        echo "Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw"
+      else
+        echo "::error::Failed to find gh-aw binary for MCP server"
+        exit 1
+      fi
+---


### PR DESCRIPTION
## Problem

The compiler generates an `Install gh-aw extension` step that uses `gh extension list | grep` to detect whether gh-aw is installed. When gh-aw was already installed via `curl | bash` (from `copilot-setup-steps.yml`), `gh extension list` doesn't detect it, so the step tries `gh extension install github/gh-aw` which fails (directory already exists), and `set -e` kills the script before the binary copy for MCP containerization runs.

**Failed run**: https://github.com/github/gh-aw/actions/runs/23987203365

## Fix

- Create `shared/mcp/gh-aw.md` shared component with correct install logic:
  - Uses `gh aw --version` to detect existing installs (works regardless of install method)
  - Falls back to `curl | bash` install (same as `copilot-setup-steps.yml`)
  - Copies binary to `${RUNNER_TEMP}/gh-aw/gh-aw` for MCP containerization
- Import it in `copilot-token-audit.md` so the compiler skips its broken step
- Remove redundant `Install gh-aw CLI` step (now handled by the shared component)

## Scope

Only the token audit workflow is updated in this PR. Other affected workflows can adopt `shared/mcp/gh-aw.md` separately.