### PR TITLE
fix: replace broken gh-aw install step in token optimizer workflow

### DIFF
--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"df149e8a0d356495e4f1213c7fe481ce9b401cfeaff5e78bb1d923ed640ef863","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"711f32a7552facdfd64cd7b87379b0761180f36ccec3654c8b6e1b15fc4c0d7d","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -27,6 +27,7 @@
 #   Imports:
 #     - copilot-setup-steps.yml
 #     - shared/daily-audit-discussion.md
+#     - shared/mcp/gh-aw.md
 #     - shared/repo-memory-standard.md
 #     - shared/reporting.md
 #
@@ -149,16 +150,16 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_f30321c9bbe77c01_EOF'
+          cat << 'GH_AW_PROMPT_70b3610d51da5d44_EOF'
           <system>
-          GH_AW_PROMPT_f30321c9bbe77c01_EOF
+          GH_AW_PROMPT_70b3610d51da5d44_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/agentic_workflows_guide.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f30321c9bbe77c01_EOF'
+          cat << 'GH_AW_PROMPT_70b3610d51da5d44_EOF'
           <safe-output-tools>
           Tools: create_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -190,13 +191,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f30321c9bbe77c01_EOF
+          GH_AW_PROMPT_70b3610d51da5d44_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f30321c9bbe77c01_EOF'
+          cat << 'GH_AW_PROMPT_70b3610d51da5d44_EOF'
           </system>
+          {{#runtime-import .github/workflows/shared/mcp/gh-aw.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_f30321c9bbe77c01_EOF
+          GH_AW_PROMPT_70b3610d51da5d44_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -358,13 +360,9 @@ jobs:
       - name: Install TypeScript language server
         run: npm install -g typescript-language-server typescript
       - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Install gh-aw CLI
-        run: |-
-          if ! gh aw --version >/dev/null 2>&1; then
-            gh extension install github/gh-aw
-          fi
-          gh aw --version
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        name: Install gh-aw extension
+        run: "# Install gh-aw if not already available\nif ! gh aw --version >/dev/null 2>&1; then\n  echo \"Installing gh-aw extension...\"\n  curl -fsSL https://raw.githubusercontent.com/github/gh-aw/refs/heads/main/install-gh-aw.sh | bash\nfi\ngh aw --version\n# Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization\nmkdir -p ${RUNNER_TEMP}/gh-aw\nGH_AW_BIN=$(which gh-aw 2>/dev/null || find ~/.local/share/gh/extensions/gh-aw -name 'gh-aw' -type f 2>/dev/null | head -1)\nif [ -n \"$GH_AW_BIN\" ] && [ -f \"$GH_AW_BIN\" ]; then\n  cp \"$GH_AW_BIN\" ${RUNNER_TEMP}/gh-aw/gh-aw\n  chmod +x ${RUNNER_TEMP}/gh-aw/gh-aw\n  echo \"Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw\"\nelse\n  echo \"::error::Failed to find gh-aw binary for MCP server\"\n  exit 1\nfi"
 
       # Repo memory git-based storage configuration from frontmatter processed below
       - name: Clone repo-memory branch (default)
@@ -420,41 +418,17 @@ jobs:
             await determineAutomaticLockdown(github, context, core);
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.13 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.13 ghcr.io/github/gh-aw-firewall/squid:0.25.13 ghcr.io/github/gh-aw-mcpg:v0.2.12 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
-      - name: Install gh-aw extension
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if gh-aw extension is already installed
-          if gh extension list | grep -q "github/gh-aw"; then
-            echo "gh-aw extension already installed, upgrading..."
-            gh extension upgrade gh-aw || true
-          else
-            echo "Installing gh-aw extension..."
-            gh extension install github/gh-aw
-          fi
-          gh aw --version
-          # Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization
-          mkdir -p ${RUNNER_TEMP}/gh-aw
-          GH_AW_BIN=$(which gh-aw 2>/dev/null || find ~/.local/share/gh/extensions/gh-aw -name 'gh-aw' -type f 2>/dev/null | head -1)
-          if [ -n "$GH_AW_BIN" ] && [ -f "$GH_AW_BIN" ]; then
-            cp "$GH_AW_BIN" ${RUNNER_TEMP}/gh-aw/gh-aw
-            chmod +x ${RUNNER_TEMP}/gh-aw/gh-aw
-            echo "Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw"
-          else
-            echo "::error::Failed to find gh-aw binary for MCP server"
-            exit 1
-          fi
       - name: Write Safe Outputs Config
         run: |
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_220be8ce38eefb5c_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e3270863d960a7f7_EOF'
           {"create_discussion":{"category":"audits","close_older_discussions":true,"expires":168,"fallback_to_issue":true,"max":1,"title_prefix":"[copilot-token-optimizer] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_220be8ce38eefb5c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e3270863d960a7f7_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_90c5cb010da3c64f_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a39a8061be3ab911_EOF'
           {
             "description_suffixes": {
               "create_discussion": " CONSTRAINTS: Maximum 1 discussion(s) can be created. Title will be prefixed with \"[copilot-token-optimizer] \". Discussions will be created in category \"audits\"."
@@ -462,8 +436,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_90c5cb010da3c64f_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2ee7f7db0c484671_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_a39a8061be3ab911_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ec2de261c878b880_EOF'
           {
             "create_discussion": {
               "defaultMax": 1,
@@ -549,7 +523,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_2ee7f7db0c484671_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_ec2de261c878b880_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -620,7 +594,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_95f7eb5cfb62269a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_88101803d64e3d6f_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -680,7 +654,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_95f7eb5cfb62269a_EOF
+          GH_AW_MCP_CONFIG_88101803d64e3d6f_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -17,15 +17,6 @@ tools:
     toolsets: [default]
   bash:
     - "*"
-steps:
-  - name: Install gh-aw CLI
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    run: |
-      if ! gh aw --version >/dev/null 2>&1; then
-        gh extension install github/gh-aw
-      fi
-      gh aw --version
 timeout-minutes: 30
 imports:
   - uses: shared/daily-audit-discussion.md
@@ -37,6 +28,7 @@ imports:
       branch-name: "memory/token-audit"
       description: "Historical daily Copilot token usage snapshots (shared with copilot-token-audit)"
   - copilot-setup-steps.yml
+  - uses: shared/mcp/gh-aw.md
   - shared/reporting.md
 features:
   copilot-requests: true


### PR DESCRIPTION
Same fix as PR #24590 for the token audit workflow.

## Problem

The compiler generates an `Install gh-aw extension` step that uses `gh extension list | grep` to detect gh-aw. This fails when gh-aw was already installed via `curl | bash` (from `copilot-setup-steps.yml`), causing the step to try `gh extension install` which also fails.

## Fix

- Import `shared/mcp/gh-aw.md` so the compiler skips its broken step
- Remove redundant `Install gh-aw CLI` step (shared component handles it)

Depends on: #24590 (introduces `shared/mcp/gh-aw.md`)