### PR TITLE
fix: token optimizer step ordering — move selection to agent

### DIFF
--- a/.github/workflows/copilot-token-optimizer.lock.yml
+++ b/.github/workflows/copilot-token-optimizer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a6bcd462ec25d00d67e28e2ef703964593a783fd6df6bb344d72a51d4fbea228","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d165c9656088312e3645272964379a361d0b1ae8ec97f0acd7b1cfb18bdd4abe","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -152,15 +152,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_ba2656cdc5f78ee3_EOF'
+          cat << 'GH_AW_PROMPT_e6d2be3d1a38fbb4_EOF'
           <system>
-          GH_AW_PROMPT_ba2656cdc5f78ee3_EOF
+          GH_AW_PROMPT_e6d2be3d1a38fbb4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ba2656cdc5f78ee3_EOF'
+          cat << 'GH_AW_PROMPT_e6d2be3d1a38fbb4_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -192,14 +192,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ba2656cdc5f78ee3_EOF
+          GH_AW_PROMPT_e6d2be3d1a38fbb4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ba2656cdc5f78ee3_EOF'
+          cat << 'GH_AW_PROMPT_e6d2be3d1a38fbb4_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/mcp/gh-aw.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/copilot-token-optimizer.md}}
-          GH_AW_PROMPT_ba2656cdc5f78ee3_EOF
+          GH_AW_PROMPT_e6d2be3d1a38fbb4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -368,12 +368,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         name: Install gh-aw extension
         run: "# Install gh-aw if not already available\nif ! gh aw --version >/dev/null 2>&1; then\n  echo \"Installing gh-aw extension...\"\n  curl -fsSL https://raw.githubusercontent.com/github/gh-aw/refs/heads/main/install-gh-aw.sh | bash\nfi\ngh aw --version\n# Copy the gh-aw binary to ${RUNNER_TEMP}/gh-aw for MCP server containerization\nmkdir -p ${RUNNER_TEMP}/gh-aw\nGH_AW_BIN=$(which gh-aw 2>/dev/null || find ~/.local/share/gh/extensions/gh-aw -name 'gh-aw' -type f 2>/dev/null | head -1)\nif [ -n \"$GH_AW_BIN\" ] && [ -f \"$GH_AW_BIN\" ]; then\n  cp \"$GH_AW_BIN\" ${RUNNER_TEMP}/gh-aw/gh-aw\n  chmod +x ${RUNNER_TEMP}/gh-aw/gh-aw\n  echo \"Copied gh-aw binary to ${RUNNER_TEMP}/gh-aw/gh-aw\"\nelse\n  echo \"::error::Failed to find gh-aw binary for MCP server\"\n  exit 1\nfi"
-      - name: Select target workflow from audit snapshot
-        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\n# Find the most recent audit snapshot\nLATEST=$(ls -1 /tmp/gh-aw/repo-memory/default/*.json 2>/dev/null \\\n  | grep -v rolling \\\n  | grep -v optimization \\\n  | sort -r \\\n  | head -1)\n\nif [ -z \"$LATEST\" ]; then\n  echo \"⚠️ No audit snapshots found — copilot-token-audit may not have run yet.\"\n  echo '{\"selected\":\"\",\"candidates\":[]}' > /tmp/gh-aw/token-audit/selection.json\n  exit 0\nfi\n\necho \"Latest snapshot: $LATEST\"\n\n# Load optimization history (if any)\nOPT_LOG=\"/tmp/gh-aw/repo-memory/default/optimization-log.json\"\nOPT_CUTOFF=$(date -u -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-14d +%Y-%m-%d)\n\n# Select top 5 candidates, excluding recently optimized workflows\npython3 -c \"\nimport json, random, sys\n\nsnap = json.load(open('$LATEST'))\nworkflows = snap.get('workflows', [])\n\n# Load optimization log\ntry:\n    opt_log = json.load(open('$OPT_LOG'))\n    recent = {e['workflow_name'] for e in opt_log if e.get('date','') >= '$OPT_CUTOFF'}\nexcept (FileNotFoundError, json.JSONDecodeError):\n    recent = set()\n\n# Filter: non-zero tokens, not recently optimized, skip self\ncandidates = [\n    w for w in workflows\n    if w['total_tokens'] > 0\n    and w['workflow_name'] not in recent\n    and 'Token' not in w['workflow_name']\n]\n\nif not candidates:\n    # Fall back to all non-zero workflows\n    candidates = [w for w in workflows if w['total_tokens'] > 0]\n\n# Take top 5 by total_tokens, randomly pick one\ntop5 = candidates[:5]\nselected = random.choice(top5) if top5 else None\n\nresult = {\n    'selected': selected['workflow_name'] if selected else '',\n    'selected_tokens': selected['total_tokens'] if selected else 0,\n    'selected_runs': selected['run_count'] if selected else 0,\n    'candidates': [{'name': w['workflow_name'], 'tokens': w['total_tokens'], 'runs': w['run_count']} for w in top5],\n    'snapshot_date': snap.get('date', ''),\n    'snapshot_period_days': snap.get('period_days', 0),\n    'total_workflows': len(workflows),\n    'total_tokens': snap.get('overall', {}).get('total_tokens', 0),\n}\njson.dump(result, open('/tmp/gh-aw/token-audit/selection.json', 'w'), indent=2)\n\nprint(f\\\"✅ Selected: {result['selected']} ({result['selected_tokens']:,} tokens, {result['selected_runs']} runs)\\\")\nprint(f\\\"   Candidates: {', '.join(c['name'] for c in result['candidates'])}\\\")\n\"\n"
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Download logs for selected workflow
-        run: "set -euo pipefail\n\nSELECTED=$(jq -r '.selected' /tmp/gh-aw/token-audit/selection.json)\nif [ -z \"$SELECTED\" ] || [ \"$SELECTED\" = \"\" ]; then\n  echo \"⚠️ No workflow selected — skipping log download\"\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/target-runs.json\n  exit 0\nfi\n\necho \"📥 Downloading logs for: $SELECTED\"\n\nLOGS_EXIT=0\ngh aw logs \\\n  --engine copilot \\\n  --start-date -7d \\\n  --json \\\n  -c 20 \\\n  > /tmp/gh-aw/token-audit/target-runs.json || LOGS_EXIT=$?\n\nif [ -s /tmp/gh-aw/token-audit/target-runs.json ]; then\n  # Filter to only the selected workflow's runs\n  TOTAL=$(jq --arg name \"$SELECTED\" '[.runs[] | select(.workflow_name == $name)] | length' /tmp/gh-aw/token-audit/target-runs.json)\n  echo \"✅ Downloaded logs — $TOTAL runs found for $SELECTED\"\n  if [ \"$LOGS_EXIT\" -ne 0 ]; then\n    echo \"⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)\"\n  fi\nelse\n  echo \"❌ No log data downloaded (exit code $LOGS_EXIT)\"\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/target-runs.json\nfi"
+        name: Download recent Copilot workflow logs
+        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\necho \"📥 Downloading Copilot workflow logs (last 7 days)...\"\n\nLOGS_EXIT=0\ngh aw logs \\\n  --engine copilot \\\n  --start-date -7d \\\n  --json \\\n  -c 50 \\\n  > /tmp/gh-aw/token-audit/all-runs.json || LOGS_EXIT=$?\n\nif [ -s /tmp/gh-aw/token-audit/all-runs.json ]; then\n  TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/all-runs.json)\n  echo \"✅ Downloaded $TOTAL Copilot workflow runs (last 7 days)\"\n  if [ \"$LOGS_EXIT\" -ne 0 ]; then\n    echo \"⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)\"\n  fi\nelse\n  echo \"❌ No log data downloaded (exit code $LOGS_EXIT)\"\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/all-runs.json\nfi"
 
       # Repo memory git-based storage configuration from frontmatter processed below
       - name: Clone repo-memory branch (default)
@@ -434,12 +432,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_1016147f69f06e5d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_9dc2b7656ea6e48c_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"max":1,"title_prefix":"[copilot-token-optimizer] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":51200}]}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1016147f69f06e5d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9dc2b7656ea6e48c_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_d3a07ad8dda1bc2f_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_b3993967fce2e755_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[copilot-token-optimizer] \"."
@@ -447,8 +445,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_d3a07ad8dda1bc2f_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ee64eafdec875fa8_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_b3993967fce2e755_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_6eb4944bb449c6a5_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -541,7 +539,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ee64eafdec875fa8_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_6eb4944bb449c6a5_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -611,7 +609,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.12'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_d2ae87fbba48c45b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_3ce483d5745680bb_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -652,7 +650,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d2ae87fbba48c45b_EOF
+          GH_AW_MCP_CONFIG_3ce483d5745680bb_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/copilot-token-optimizer.md
+++ b/.github/workflows/copilot-token-optimizer.md
@@ -35,121 +35,46 @@ imports:
 features:
   copilot-requests: true
 steps:
-  - name: Select target workflow from audit snapshot
-    run: |
-      set -euo pipefail
-      mkdir -p /tmp/gh-aw/token-audit
-
-      # Find the most recent audit snapshot
-      LATEST=$(ls -1 /tmp/gh-aw/repo-memory/default/*.json 2>/dev/null \
-        | grep -v rolling \
-        | grep -v optimization \
-        | sort -r \
-        | head -1)
-
-      if [ -z "$LATEST" ]; then
-        echo "⚠️ No audit snapshots found — copilot-token-audit may not have run yet."
-        echo '{"selected":"","candidates":[]}' > /tmp/gh-aw/token-audit/selection.json
-        exit 0
-      fi
-
-      echo "Latest snapshot: $LATEST"
-
-      # Load optimization history (if any)
-      OPT_LOG="/tmp/gh-aw/repo-memory/default/optimization-log.json"
-      OPT_CUTOFF=$(date -u -d '14 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-14d +%Y-%m-%d)
-
-      # Select top 5 candidates, excluding recently optimized workflows
-      python3 -c "
-      import json, random, sys
-
-      snap = json.load(open('$LATEST'))
-      workflows = snap.get('workflows', [])
-
-      # Load optimization log
-      try:
-          opt_log = json.load(open('$OPT_LOG'))
-          recent = {e['workflow_name'] for e in opt_log if e.get('date','') >= '$OPT_CUTOFF'}
-      except (FileNotFoundError, json.JSONDecodeError):
-          recent = set()
-
-      # Filter: non-zero tokens, not recently optimized, skip self
-      candidates = [
-          w for w in workflows
-          if w['total_tokens'] > 0
-          and w['workflow_name'] not in recent
-          and 'Token' not in w['workflow_name']
-      ]
-
-      if not candidates:
-          # Fall back to all non-zero workflows
-          candidates = [w for w in workflows if w['total_tokens'] > 0]
-
-      # Take top 5 by total_tokens, randomly pick one
-      top5 = candidates[:5]
-      selected = random.choice(top5) if top5 else None
-
-      result = {
-          'selected': selected['workflow_name'] if selected else '',
-          'selected_tokens': selected['total_tokens'] if selected else 0,
-          'selected_runs': selected['run_count'] if selected else 0,
-          'candidates': [{'name': w['workflow_name'], 'tokens': w['total_tokens'], 'runs': w['run_count']} for w in top5],
-          'snapshot_date': snap.get('date', ''),
-          'snapshot_period_days': snap.get('period_days', 0),
-          'total_workflows': len(workflows),
-          'total_tokens': snap.get('overall', {}).get('total_tokens', 0),
-      }
-      json.dump(result, open('/tmp/gh-aw/token-audit/selection.json', 'w'), indent=2)
-
-      print(f\"✅ Selected: {result['selected']} ({result['selected_tokens']:,} tokens, {result['selected_runs']} runs)\")
-      print(f\"   Candidates: {', '.join(c['name'] for c in result['candidates'])}\")
-      "
-  - name: Download logs for selected workflow
+  - name: Download recent Copilot workflow logs
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     run: |
       set -euo pipefail
+      mkdir -p /tmp/gh-aw/token-audit
 
-      SELECTED=$(jq -r '.selected' /tmp/gh-aw/token-audit/selection.json)
-      if [ -z "$SELECTED" ] || [ "$SELECTED" = "" ]; then
-        echo "⚠️ No workflow selected — skipping log download"
-        echo '{"runs":[],"summary":{}}' > /tmp/gh-aw/token-audit/target-runs.json
-        exit 0
-      fi
-
-      echo "📥 Downloading logs for: $SELECTED"
+      echo "📥 Downloading Copilot workflow logs (last 7 days)..."
 
       LOGS_EXIT=0
       gh aw logs \
         --engine copilot \
         --start-date -7d \
         --json \
-        -c 20 \
-        > /tmp/gh-aw/token-audit/target-runs.json || LOGS_EXIT=$?
+        -c 50 \
+        > /tmp/gh-aw/token-audit/all-runs.json || LOGS_EXIT=$?
 
-      if [ -s /tmp/gh-aw/token-audit/target-runs.json ]; then
-        # Filter to only the selected workflow's runs
-        TOTAL=$(jq --arg name "$SELECTED" '[.runs[] | select(.workflow_name == $name)] | length' /tmp/gh-aw/token-audit/target-runs.json)
-        echo "✅ Downloaded logs — $TOTAL runs found for $SELECTED"
+      if [ -s /tmp/gh-aw/token-audit/all-runs.json ]; then
+        TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/all-runs.json)
+        echo "✅ Downloaded $TOTAL Copilot workflow runs (last 7 days)"
         if [ "$LOGS_EXIT" -ne 0 ]; then
           echo "⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)"
         fi
       else
         echo "❌ No log data downloaded (exit code $LOGS_EXIT)"
-        echo '{"runs":[],"summary":{}}' > /tmp/gh-aw/token-audit/target-runs.json
+        echo '{"runs":[],"summary":{}}' > /tmp/gh-aw/token-audit/all-runs.json
       fi
 ---
 {{#runtime-import? .github/shared-instructions.md}}
 
 # Copilot Token Usage Optimizer
 
-You are the Copilot Token Optimizer — an analyst that deeply audits a pre-selected high-token-usage workflow and produces actionable recommendations to reduce token consumption.
+You are the Copilot Token Optimizer — an analyst that picks one high-token-usage workflow, deeply audits its recent runs, and produces actionable recommendations to reduce token consumption.
 
 ## Mission
 
-1. Read the pre-selected target workflow and its pre-downloaded run data.
-2. Analyze token usage patterns, tool usage, error rates, and prompt efficiency.
-3. Produce a conservative, evidence-based optimization issue with specific recommendations.
+1. Select a target workflow from the audit snapshot in repo-memory.
+2. Filter the pre-downloaded run data for that workflow.
+3. Analyze token usage patterns, tool usage, error rates, and prompt efficiency.
+4. Produce a conservative, evidence-based optimization issue with specific recommendations.
 
 ## Guiding Principles
 
@@ -163,49 +88,51 @@ You are the Copilot Token Optimizer — an analyst that deeply audits a pre-sele
 
 The following data has been pre-downloaded and is available for analysis:
 
-### Target workflow selection
-
-The file `/tmp/gh-aw/token-audit/selection.json` contains the pre-selected target:
-
-```json
-{
-  "selected": "Workflow Name",
-  "selected_tokens": 12345678,
-  "selected_runs": 5,
-  "candidates": [...],
-  "snapshot_date": "2026-04-04",
-  "total_workflows": 42,
-  "total_tokens": 122587011
-}
-```
-
 ### Workflow run logs
 
-The file `/tmp/gh-aw/token-audit/target-runs.json` contains the output of `gh aw logs --json` for the last 7 days. Filter to the selected workflow:
-
-```bash
-SELECTED=$(jq -r '.selected' /tmp/gh-aw/token-audit/selection.json)
-jq --arg name "$SELECTED" '{
-  runs: [.runs[] | select(.workflow_name == $name)],
-  summary: .summary,
-  tool_usage: .tool_usage
-}' /tmp/gh-aw/token-audit/target-runs.json > /tmp/gh-aw/token-audit/filtered-runs.json
-```
+The file `/tmp/gh-aw/token-audit/all-runs.json` contains the output of `gh aw logs --json` for the last 7 days across all workflows. This includes per-run token usage, tool calls, and run metadata.
 
 ### Audit snapshots (repo-memory)
 
-Historical daily snapshots are at `/tmp/gh-aw/repo-memory/default/`. Each `YYYY-MM-DD.json` file has per-workflow token totals.
+Historical daily snapshots are at `/tmp/gh-aw/repo-memory/default/`. Each `YYYY-MM-DD.json` file has per-workflow token totals from the daily audit.
 
-## Phase 1 — Analyze Run Data
+### Optimization history
 
-### Step 1.1: Load Target and Run Data
+If `/tmp/gh-aw/repo-memory/default/optimization-log.json` exists, it lists previously optimized workflows with dates.
+
+## Phase 1 — Select Target Workflow
+
+### Step 1.1: Load Audit Snapshot and Select Target
+
+Read the latest audit snapshot from repo-memory and select a target:
 
 ```bash
-# Show selection
-cat /tmp/gh-aw/token-audit/selection.json | jq .
+# Find the most recent snapshot
+LATEST=$(ls -1 /tmp/gh-aw/repo-memory/default/*.json 2>/dev/null | grep -v rolling | grep -v optimization | sort -r | head -1)
+if [ -z "$LATEST" ]; then
+  echo "⚠️ No audit snapshots found"
+fi
+echo "Latest snapshot: $LATEST"
+cat "$LATEST" | jq '.workflows[:10]'
 
-# Filter runs for selected workflow
-SELECTED=$(jq -r '.selected' /tmp/gh-aw/token-audit/selection.json)
+# Check optimization history
+OPT_LOG="/tmp/gh-aw/repo-memory/default/optimization-log.json"
+if [ -f "$OPT_LOG" ]; then
+  echo "Previous optimizations:"
+  cat "$OPT_LOG" | jq -r '.[] | "\(.date): \(.workflow_name)"'
+else
+  echo "No previous optimization history found."
+fi
+```
+
+Pick the workflow with the highest `total_tokens` from the audit snapshot that does **not** appear in the optimization log within the last 14 days. Randomly select from the top 5 candidates to ensure variety. Skip any workflow with "Token" in the name (to avoid optimizing ourselves).
+
+If no audit snapshot exists, aggregate the pre-downloaded run data from `/tmp/gh-aw/token-audit/all-runs.json` to find the highest consumer.
+
+### Step 1.2: Filter Run Data for Selected Workflow
+
+```bash
+SELECTED="<the workflow name you selected>"
 jq --arg name "$SELECTED" '{
   workflow: $name,
   total_runs: [.runs[] | select(.workflow_name == $name)] | length,
@@ -219,18 +146,10 @@ jq --arg name "$SELECTED" '{
     conclusion: .conclusion,
     created_at: .created_at
   }]
-}' /tmp/gh-aw/token-audit/target-runs.json
+}' /tmp/gh-aw/token-audit/all-runs.json
 ```
 
-If no runs are found for the selected workflow, report this in the issue and skip to Phase 3.
-
-### Step 1.2: Per-Run Token Analysis
-
-For each run, extract:
-- **Token usage** and **effective tokens** — a large gap suggests poor cache utilization
-- **Turns** — high turn counts relative to task complexity suggest the prompt could be clearer
-- **Model used** — different models have different cost profiles
-- **Conclusion** — failed runs waste tokens
+If no runs are found for the selected workflow in the pre-downloaded data, report this in the issue and base your analysis on the audit snapshot and workflow source code.
 
 ### Step 1.3: Read the Workflow Source
 
@@ -372,7 +291,7 @@ Load the existing array, append the new entry, trim to the last 30 entries, and 
 
 ## Important Notes
 
-- Run data is pre-downloaded to `/tmp/gh-aw/token-audit/target-runs.json` — use `jq` to filter and analyze it. Do not try to download logs yourself.
+- Run data is pre-downloaded to `/tmp/gh-aw/token-audit/all-runs.json` — use `jq` to filter and analyze it. Do not try to download logs yourself.
 - Treat null/missing `token_usage` and `estimated_cost` as 0.
 - The repo-memory branch `memory/token-audit` is shared with the `copilot-token-audit` workflow — read its snapshots but don't overwrite them. Only write to `optimization-log.json`.
 - Use `cat` and `jq` to inspect the pre-downloaded data. Use GitHub MCP tools to read workflow source files.


### PR DESCRIPTION
## Problem

PR #24625 added pre-steps to select a target workflow and download logs. However, `steps:` in frontmatter are inserted **before** the compiler-generated `Clone repo-memory branch` step. The selection script tried to read `/tmp/gh-aw/repo-memory/default/*.json` but the directory was empty because the clone hadn't happened yet.

Failed run: https://github.com/github/gh-aw/actions/runs/23991300193

## Fix

- Keep only the log download as a pre-step (it doesn't need repo-memory)
- Move target selection into the agent prompt (Phase 1), which runs after repo-memory is cloned
- Agent reads audit snapshots from `/tmp/gh-aw/repo-memory/default/` and selects the highest-token workflow
- Agent filters pre-downloaded log data (`/tmp/gh-aw/token-audit/all-runs.json`) for the selected workflow

## Step ordering (verified)

1. **Download recent Copilot workflow logs** (pre-step, line 373)
2. **Clone repo-memory branch** (compiler-generated, line 377)  
3. **Execute GitHub Copilot CLI** (agent, line 662)

## Fixes
Fixes the step ordering bug introduced in #24625