### PR TITLE
chore: set AWFCliProxyMinVersion to v0.25.17

### DIFF
--- a/pkg/constants/version_constants.go
+++ b/pkg/constants/version_constants.go
@@ -53,9 +53,9 @@ const DefaultFirewallVersion Version = "v0.25.17"
 // Workflows pinning an older AWF version must not emit --exclude-env flags or the run will fail.
 const AWFExcludeEnvMinVersion Version = "v0.25.3"
 
-// AWFCliProxyMinVersion is the minimum AWF version that supports the CLI proxy flags
-// (--difc-proxy-host, --difc-proxy-ca-cert). Workflows pinning an older AWF version
-// must not emit CLI proxy flags or the run will fail.
+// AWFCliProxyMinVersion is the minimum supported AWF version for emitting the CLI proxy flags
+// (--difc-proxy-host, --difc-proxy-ca-cert). Workflows pinning an older AWF version than
+// v0.25.17 must not emit CLI proxy flags or the run will fail.
 const AWFCliProxyMinVersion Version = "v0.25.17"
 
 // DefaultMCPGatewayVersion is the default version of the MCP Gateway (gh-aw-mcpg) Docker image

--- a/pkg/constants/version_constants.go
+++ b/pkg/constants/version_constants.go
@@ -56,7 +56,7 @@ const AWFExcludeEnvMinVersion Version = "v0.25.3"
 // AWFCliProxyMinVersion is the minimum AWF version that supports the CLI proxy flags
 // (--difc-proxy-host, --difc-proxy-ca-cert). Workflows pinning an older AWF version
 // must not emit CLI proxy flags or the run will fail.
-const AWFCliProxyMinVersion Version = "v0.26.0"
+const AWFCliProxyMinVersion Version = "v0.25.17"
 
 // DefaultMCPGatewayVersion is the default version of the MCP Gateway (gh-aw-mcpg) Docker image
 const DefaultMCPGatewayVersion Version = "v0.2.16"

--- a/pkg/workflow/awf_helpers_test.go
+++ b/pkg/workflow/awf_helpers_test.go
@@ -830,7 +830,7 @@ func TestBuildAWFArgsCliProxy(t *testing.T) {
 			NetworkPermissions: &NetworkPermissions{
 				Firewall: &FirewallConfig{
 					Enabled: true,
-					Version: "v0.25.16", // older than AWFCliProxyMinVersion v0.26.0
+					Version: "v0.25.16", // older than AWFCliProxyMinVersion v0.25.17
 				},
 			},
 			Features: map[string]any{
@@ -866,14 +866,14 @@ func TestAWFSupportsCliProxy(t *testing.T) {
 		want           bool
 	}{
 		{
-			name:           "nil firewall config returns false (default version below minimum)",
+			name:           "nil firewall config returns true (uses default version)",
 			firewallConfig: nil,
-			want:           false,
+			want:           true,
 		},
 		{
-			name:           "empty version returns false (default version below minimum)",
+			name:           "empty version returns true (uses default version)",
 			firewallConfig: &FirewallConfig{},
-			want:           false,
+			want:           true,
 		},
 		{
 			name:           "latest returns true",
@@ -881,7 +881,12 @@ func TestAWFSupportsCliProxy(t *testing.T) {
 			want:           true,
 		},
 		{
-			name:           "v0.26.0 supports CLI proxy flags (exact minimum version)",
+			name:           "v0.25.17 supports CLI proxy flags (exact minimum version)",
+			firewallConfig: &FirewallConfig{Version: "v0.25.17"},
+			want:           true,
+		},
+		{
+			name:           "v0.26.0 supports CLI proxy flags",
 			firewallConfig: &FirewallConfig{Version: "v0.26.0"},
 			want:           true,
 		},


### PR DESCRIPTION
## Summary

Lowers `AWFCliProxyMinVersion` from `v0.26.0` to `v0.25.17`, aligning the CLI proxy version gate with the current `DefaultFirewallVersion` (`v0.25.17`).

## Changes

- `pkg/constants/version_constants.go`: `AWFCliProxyMinVersion` → `v0.25.17`
- `pkg/workflow/awf_helpers_test.go`: Updated version-gate tests to match new minimum (nil/empty configs now return `true`, added `v0.25.17` exact-minimum test case)

## Testing

- `TestAWFSupportsCliProxy` ✅ (all 9 cases pass)
- `TestBuildAWFArgsCliProxy` ✅ (all 4 cases pass)
