### PR TITLE
[FAQ] Add: fail-closed admission control FAQ entry

### DIFF
--- a/docs/src/content/docs/reference/faq.md
+++ b/docs/src/content/docs/reference/faq.md
@@ -259,6 +259,53 @@ tools:
 
 See [Integrity Filtering](/gh-aw/reference/integrity/) for available levels, user blocking, and approval labels.
 
+### Should agentic workflows fail closed when an external check can't confirm execution is allowed?
+
+Yes — fail-closed is the design default. The architecture is intentionally layered so that if something can't be confirmed, nothing writes to your repository. The AI agent runs read-only, write operations only happen in a separate gated safe-outputs job after the agent finishes, and [threat detection](/gh-aw/reference/threat-detection/) runs between the agent and any writes.
+
+You can also add an admission boundary *before the agent ever runs*. This is the right place for external authority checks — environment freeze gates, deployment windows, external approval services, and so on.
+
+**`on.steps:` — pre-activation steps**
+
+Inject deterministic steps into the pre-activation job. If any step exits non-zero, the job fails and the activation job (where the agent runs) never starts:
+
+```yaml
+on:
+  issues:
+    types: [opened]
+  steps:
+    - name: Check external gate
+      run: |
+        STATUS=$(curl -sf https://your-authority.example.com/allow?repo=${{ github.repository }})
+        [ "$STATUS" = "allowed" ] || exit 1
+```
+
+If the external service is unreachable, `curl -sf` returns non-zero and the workflow fails closed — the agent won't run.
+
+**`skip-if-match:` / `skip-if-no-match:`**
+
+When the gate can be expressed as a GitHub search query (e.g., the presence of a `ops:freeze` label on an open issue), these fields skip the workflow cleanly before the agent starts:
+
+```yaml
+on:
+  schedule: daily
+  skip-if-match: 'label:ops:freeze is:issue is:open'
+```
+
+**`manual-approval:`**
+
+Gate execution on a GitHub environment protection rule — required reviewers, wait timers:
+
+```yaml
+on:
+  workflow_dispatch:
+  manual-approval: production
+```
+
+**Both layers together** — a pre-agent check answers "can this workflow run at all?"; the safe-outputs / threat-detection layer answers "is this specific output safe to write?" For high-assurance scenarios, using both is appropriate.
+
+See [Pre-Activation Steps](/gh-aw/reference/triggers/#pre-activation-steps-onsteps), [Skip-If-Match](/gh-aw/reference/triggers/#skip-if-match-condition-skip-if-match), [Manual Approval Gates](/gh-aw/reference/triggers/#manual-approval-gates-manual-approval), and [Safe Outputs](/gh-aw/reference/safe-outputs/).
+
 ## Configuration & Setup
 
 ### Why do slash-command workflows show many "started then skipped" runs on comments?


### PR DESCRIPTION
Adds a new entry to the Guardrails section of the FAQ covering fail-closed behavior and admission boundaries in agentic workflows.

## What changed

New FAQ entry: **"Should agentic workflows fail closed when an external check can't confirm execution is allowed?"**

- Explains that fail-closed is the design default (read-only agent, safe outputs gated, threat detection as backstop)
- Shows how to add an admission boundary *before the agent runs* using `on.steps:`, `skip-if-match:`/`skip-if-no-match:`, and `manual-approval:`
- Includes a `curl`-based external gate example in `on.steps:` that fails closed if the service is unreachable
- Clarifies the distinction between "can this workflow run?" (pre-agent gate) and "is this output safe?" (safe-outputs layer)

## Source

Community question in github/agentic-workflows#473 — a broadly reusable design question about where to place admission control boundaries.

## Type of change

New FAQ entry (no existing entry covered this topic).




> Generated by [Feedback Question Answerer](https://github.com/github/agentic-workflows/actions/runs/25026677870/agentic_workflow) · ● 1.1M · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-id%3A+feedback-question-answerer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Feedback Question Answerer, engine: copilot, model: auto, id: 25026677870, workflow_id: feedback-question-answerer, run: https://github.com/github/agentic-workflows/actions/runs/25026677870 -->

<!-- gh-aw-workflow-id: feedback-question-answerer -->