### PR TITLE
[FAQ] Add: external admission authority vs guardrail validation

### DIFF
--- a/docs/src/content/docs/reference/faq.md
+++ b/docs/src/content/docs/reference/faq.md
@@ -216,6 +216,41 @@ See [Text Sanitization](/gh-aw/reference/safe-outputs/#text-sanitization-allowed
 
 Guardrails are foundational to the design. Agentic workflows implement defense-in-depth through compilation-time validation (schema checks, expression safety, action SHA pinning), runtime isolation (sandboxed containers with network controls), permission separation (read-only defaults with [safe outputs](/gh-aw/reference/safe-outputs/) for writes), tool allowlisting, and output sanitization. See the [Security Architecture](/gh-aw/introduction/architecture/).
 
+### Who owns the final admission decision — is guardrail validation the same as external admission authority?
+
+No, and the distinction matters for high-privilege operations.
+
+gh-aw's built-in guardrails (threat detection, output limits, sanitization) run *within the same GitHub Actions workflow* that initiated execution. They answer whether the agent's proposed output looks acceptable — but the admission authority remains inside the system that produced the output.
+
+For a genuinely external admission boundary, gh-aw provides two extension points:
+
+**1. GitHub Actions environment protection rules** — add a required-reviewer environment to a [custom safe-output job](/gh-aw/reference/custom-safe-outputs/). GitHub Actions infrastructure enforces this gate before the write job runs, regardless of what the workflow logic says.
+
+```yaml wrap
+safe-outputs:
+  jobs:
+    deploy:
+      environment: production-approval   # human approval required before execution
+      runs-on: ubuntu-latest
+      steps:
+        - run: echo "Deploying..."
+```
+
+**2. External admission service in custom threat detection steps** — use [`threat-detection.post-steps:`](/gh-aw/reference/threat-detection/#custom-detection-steps) to call an external policy service. A non-zero exit blocks all write operations.
+
+```yaml wrap
+safe-outputs:
+  create-pull-request:
+  threat-detection:
+    post-steps:
+      - name: External admission gate
+        run: |
+          curl --fail -X POST https://your-admission-service/evaluate \
+            -d @/tmp/gh-aw/threat-detection/agent_output.json
+```
+
+By default, neither mechanism is enabled — you need to opt in. For workflows that request deployment authority, credentials, or other trusted context, explicitly adding one of these external gates is recommended. See the [Security Architecture](/gh-aw/introduction/architecture/#layer-3-plan-level-trust) for the full trust model.
+
 ### How is my code and data processed?
 
 By default, your workflow is run on GitHub Actions, like any other GitHub Actions workflow, and as one if its jobs it invokes your nominated [AI Engine (coding agent)](/gh-aw/reference/engines/), run in a container. This engine may in turn make tool calls and MCP calls. When using the default **GitHub Copilot CLI**, the workflow is processed by the `copilot` CLI tool which uses GitHub Copilot's services and related AI models. The specifics depend on your engine choice:


### PR DESCRIPTION
Adds a new FAQ entry under the **Guardrails** section addressing the question of whether gh-aw's built-in guardrail validation constitutes genuine external admission authority.

## What changed

New entry: **"Who owns the final admission decision — is guardrail validation the same as external admission authority?"**

The entry:
- Clarifies that gh-aw's default guardrails (threat detection, output limits) are internal to the execution system — they answer whether output *looks acceptable*, not whether the execution intent is *allowed* by a separate authority boundary
- Documents two supported extension points for genuine external admission:
  1. GitHub Actions environment protection rules on custom safe-output jobs
  2. Custom `threat-detection.post-steps:` calling an external policy service
- Notes that neither is enabled by default, and recommends opting in for high-privilege operations

## Source

Community question from [`@pinfloyd`](https://github.com/pinfloyd) in a discussion thread about safe outputs, captured in github/agentic-workflows#484.

## Type of change

New FAQ entry (no changes to existing entries).




> Generated by [Feedback Question Answerer](https://github.com/github/agentic-workflows/actions/runs/25052340192/agentic_workflow) for issue #484 · ● 1M · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-id%3A+feedback-question-answerer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Feedback Question Answerer, engine: copilot, model: auto, id: 25052340192, workflow_id: feedback-question-answerer, run: https://github.com/github/agentic-workflows/actions/runs/25052340192 -->

<!-- gh-aw-workflow-id: feedback-question-answerer -->