### PR TITLE
trigger canary on release promotion

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -89,3 +89,28 @@ jobs:
             });
 
             core.info(`✅ "${version}" has been promoted to latest (prerelease: false, make_latest: true)`);
+
+      - name: Trigger canary
+        if: success()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          CANARY_DISPATCH_URL: ${{ secrets.CANARY_DISPATCH_URL }}
+          CANARY_DISPATCH_TOKEN: ${{ secrets.CANARY_DISPATCH_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        with:
+          script: |
+            const url = process.env.CANARY_DISPATCH_URL;
+            const token = process.env.CANARY_DISPATCH_TOKEN;
+            if (!url || !token) {
+              core.info('Canary dispatch not configured — skipping');
+              return;
+            }
+            const [owner, repo] = url.replace('repos/', '').replace('/dispatches', '').split('/');
+            const octokit = github.getOctokit(token);
+            await octokit.rest.repos.createDispatchEvent({
+              owner,
+              repo,
+              event_type: 'gh-aw-release',
+              client_payload: { version: process.env.INPUT_VERSION },
+            });
+            core.info(`✅ Canary dispatch sent for ${process.env.INPUT_VERSION}`);


### PR DESCRIPTION
Adds a canary dispatch step to `promote-release.yml` that fires after a release is promoted to latest.

Uses two secrets (`CANARY_DISPATCH_TOKEN` + `CANARY_DISPATCH_URL`) so the target repo is not exposed in the workflow file. No-op if secrets are not configured.

The canary repo listens for `repository_dispatch` events with type `gh-aw-release` and triggers end-to-end agentic workflow tests across all scenarios.

**Secrets needed** (add to this repo's settings before merging):
- `CANARY_DISPATCH_TOKEN` — fine-grained PAT scoped to the canary repo with `contents: write`
- `CANARY_DISPATCH_URL` — API path for the canary repo dispatches endpoint