### PR TITLE
[FAQ] Add: writing large content and wiki pages from agentic workflows

### DIFF
--- a/docs/src/content/docs/reference/faq.md
+++ b/docs/src/content/docs/reference/faq.md
@@ -166,6 +166,47 @@ if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
 See [Conditional Execution](/gh-aw/reference/frontmatter/#conditional-execution-if) in the Frontmatter Reference for details.
 
+### How do I write large content (like a wiki page) from an agentic workflow?
+
+Use `tools: repo-memory` with `wiki: true`. This lets the agent write files directly to the wiki's git repository — there is no body size limit because content is written as a file, not passed as a tool call parameter.
+
+```yaml wrap
+---
+tools:
+  repo-memory:
+    wiki: true
+    max-file-size: 1048576   # 1MB per file (default 10KB)
+    max-patch-size: 102400   # 100KB total diff (default 10KB)
+    allowed-extensions: [".md"]
+---
+```
+
+The agent writes to `/tmp/gh-aw/repo-memory-default/` at runtime. After the workflow completes, the framework automatically commits and pushes the changes to the wiki git endpoint (`{repo}.wiki.git`). See [Repo Memory](/gh-aw/reference/repo-memory/) for full configuration.
+
+If you use a custom safe output job to write large content, the framework saves body content that exceeds the inline size limit to a file under `/tmp/gh-aw/safeoutputs/` and stores a reference string `[Content too large, saved to file: <filename>]` in the agent output JSON instead. That file is included in the downloaded artifact, so it is accessible from the safe output job runner. To handle it robustly, extract the resolution into a helper:
+
+```javascript
+function resolveAgentField(value, fieldName = 'field') {
+  const FILE_REF_PREFIX = '[Content too large, saved to file: ';
+  if (typeof value === 'string' && value.startsWith(FILE_REF_PREFIX) && value.endsWith(']')) {
+    const filename = value.slice(FILE_REF_PREFIX.length, -1);
+    const filePath = path.join('/tmp/gh-aw/safeoutputs', filename);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`${fieldName}: referenced content file not found: ${filePath}`);
+    }
+    const content = fs.readFileSync(filePath, 'utf8');
+    core.info(`Resolved ${fieldName} from file (${content.length} bytes)`);
+    return content;
+  }
+  return value;
+}
+
+// Usage:
+const body = resolveAgentField(item.body, 'body');
+```
+
+For wiki pages specifically, `repo-memory` with `wiki: true` is the recommended approach as it avoids the size limit entirely. See [Custom Safe Output Jobs](/gh-aw/reference/custom-safe-outputs/) for details on the custom job pattern.
+
 ## Guardrails
 
 ### Agentic workflows run in GitHub Actions. Can they access my repository secrets?


### PR DESCRIPTION
Adds a new FAQ entry under the **Capabilities** section: "How do I write large content (like a wiki page) from an agentic workflow?"

## What changed

New FAQ entry covering two related topics:

1. **Recommended approach**: `tools: repo-memory` with `wiki: true` — purpose-built for writing wiki pages. The agent writes files directly to the wiki git repo, bypassing the body size limit entirely.

2. **Custom safe output jobs**: Documents the framework's `[Content too large, saved to file: <filename>]` behavior and provides a robust JavaScript helper pattern for custom jobs that must receive large content.

## Why

Source issue: github/agentic-workflows#491

An OSS maintainer (aspire project) hit the inline body size limit in their custom safe output job that writes wiki pages. The workaround they discovered works, but the pattern wasn't documented anywhere and the better solution (`repo-memory: wiki: true`) wasn't surfaced. This FAQ entry makes both the proper solution and the workaround discoverable.

## Type of change

New entry (no existing entry covers this topic).




> Generated by [Feedback Question Answerer](https://github.com/github/agentic-workflows/actions/runs/25075333780/agentic_workflow) · ● 5.4M · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-id%3A+feedback-question-answerer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Feedback Question Answerer, engine: copilot, model: auto, id: 25075333780, workflow_id: feedback-question-answerer, run: https://github.com/github/agentic-workflows/actions/runs/25075333780 -->

<!-- gh-aw-workflow-id: feedback-question-answerer -->