### PR TITLE
chore: add sentry dsn span transport

### DIFF
--- a/actions/setup/js/send_otlp_span.cjs
+++ b/actions/setup/js/send_otlp_span.cjs
@@ -852,6 +852,211 @@ async function sendOTLPToAllEndpoints(endpoints, payload, opts = {}) {
   );
 }
 
+/** @type {string} */
+const SENTRY_ENVELOPE_CONTENT_TYPE = "application/x-sentry-envelope";
+/** @type {string} */
+const SENTRY_SPAN_ITEM_CONTENT_TYPE = "application/vnd.sentry.items.span.v2+json";
+
+/**
+ * Parse a Sentry DSN and derive its envelope ingestion URL.
+ *
+ * @param {string} endpoint
+ * @returns {{ dsn: string, publicKey: string, envelopeUrl: string } | null}
+ */
+function parseSentryDSN(endpoint) {
+  try {
+    const parsed = new URL(endpoint);
+    if ((parsed.protocol !== "https:" && parsed.protocol !== "http:") || !parsed.username) {
+      return null;
+    }
+    const pathSegments = parsed.pathname.split("/").filter(Boolean);
+    const projectId = pathSegments.pop();
+    if (!projectId) {
+      return null;
+    }
+    const basePath = pathSegments.length > 0 ? `/${pathSegments.join("/")}` : "";
+    return {
+      dsn: parsed.toString(),
+      publicKey: decodeURIComponent(parsed.username),
+      envelopeUrl: `${parsed.origin}${basePath}/api/${projectId}/envelope/`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string | number | bigint} nanoString
+ * @returns {number}
+ */
+function nanoStringToUnixSeconds(nanoString) {
+  const nanos = BigInt(String(nanoString || "0"));
+  const seconds = nanos / 1_000_000_000n;
+  const micros = (nanos % 1_000_000_000n) / 1_000n;
+  return Number(`${seconds}.${micros.toString().padStart(6, "0")}`);
+}
+
+/**
+ * @param {unknown} otlpValue
+ * @returns {{ type: string, value: string | number | boolean } | null}
+ */
+function convertOTLPValueToSentryAttribute(otlpValue) {
+  if (!otlpValue || typeof otlpValue !== "object") {
+    return null;
+  }
+  if ("stringValue" in otlpValue) {
+    return { type: "string", value: String(otlpValue.stringValue) };
+  }
+  if ("intValue" in otlpValue) {
+    return { type: "integer", value: Number(otlpValue.intValue) };
+  }
+  if ("doubleValue" in otlpValue) {
+    return { type: "number", value: Number(otlpValue.doubleValue) };
+  }
+  if ("boolValue" in otlpValue) {
+    return { type: "boolean", value: Boolean(otlpValue.boolValue) };
+  }
+  if ("arrayValue" in otlpValue) {
+    return { type: "string", value: JSON.stringify(otlpValue.arrayValue) };
+  }
+  return null;
+}
+
+/**
+ * @param {Array<{ key?: string, value?: unknown }> | undefined} attributes
+ * @returns {Record<string, { type: string, value: string | number | boolean }>}
+ */
+function convertOTLPAttributesToSentry(attributes) {
+  /** @type {Record<string, { type: string, value: string | number | boolean }> } */
+  const sentryAttributes = Object.create(null);
+  if (!Array.isArray(attributes)) {
+    return sentryAttributes;
+  }
+  for (const attribute of attributes) {
+    if (!attribute || typeof attribute.key !== "string" || !attribute.key) {
+      continue;
+    }
+    const converted = convertOTLPValueToSentryAttribute(attribute.value);
+    if (!converted) {
+      continue;
+    }
+    sentryAttributes[attribute.key] = converted;
+  }
+  return sentryAttributes;
+}
+
+/**
+ * @param {object} span
+ * @param {Record<string, { type: string, value: string | number | boolean }>} resourceAttributes
+ * @returns {object}
+ */
+function convertOTLPSpanToSentrySpan(span, resourceAttributes) {
+  const spanAttributes = {
+    ...resourceAttributes,
+    ...convertOTLPAttributesToSentry(span.attributes),
+    "sentry.origin": { type: "string", value: "auto.gh-aw.otlp" },
+  };
+  const isSegment = !span.parentSpanId;
+  if (isSegment) {
+    spanAttributes["sentry.segment.name"] = { type: "string", value: String(span.name || "gh-aw") };
+    spanAttributes["sentry.segment.id"] = { type: "string", value: String(span.spanId || "") };
+  }
+
+  return {
+    trace_id: String(span.traceId || ""),
+    ...(span.parentSpanId ? { parent_span_id: String(span.parentSpanId) } : {}),
+    span_id: String(span.spanId || ""),
+    name: String(span.name || "gh-aw"),
+    status: span.status?.code === 2 ? "error" : "ok",
+    is_segment: isSegment,
+    start_timestamp: nanoStringToUnixSeconds(span.startTimeUnixNano || "0"),
+    end_timestamp: nanoStringToUnixSeconds(span.endTimeUnixNano || "0"),
+    attributes: spanAttributes,
+  };
+}
+
+/**
+ * @param {object} payload
+ * @returns {Array<{ span: object, resourceAttributes: Record<string, { type: string, value: string | number | boolean }> }>}
+ */
+function extractSentrySpansFromOTLPPayload(payload) {
+  /** @type {Array<{ span: object, resourceAttributes: Record<string, { type: string, value: string | number | boolean }> }> } */
+  const result = [];
+  if (!payload || !Array.isArray(payload.resourceSpans)) {
+    return result;
+  }
+
+  for (const resourceSpan of payload.resourceSpans) {
+    const resourceAttributes = convertOTLPAttributesToSentry(resourceSpan?.resource?.attributes);
+    if (!Array.isArray(resourceSpan?.scopeSpans)) {
+      continue;
+    }
+    for (const scopeSpan of resourceSpan.scopeSpans) {
+      if (!Array.isArray(scopeSpan?.spans)) {
+        continue;
+      }
+      for (const span of scopeSpan.spans) {
+        result.push({ span, resourceAttributes });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * @param {string} endpoint
+ * @param {object} payload
+ * @returns {{ url: string, headers: Record<string, string>, body: string } | null}
+ */
+function buildSentryEnvelopeRequest(endpoint, payload) {
+  const sentryDSN = parseSentryDSN(endpoint);
+  if (!sentryDSN) {
+    return null;
+  }
+
+  const otlpSpans = extractSentrySpansFromOTLPPayload(payload);
+  if (otlpSpans.length === 0) {
+    return null;
+  }
+
+  const sentrySpans = otlpSpans.map(({ span, resourceAttributes }) => convertOTLPSpanToSentrySpan(span, resourceAttributes));
+  const segmentSpan = sentrySpans.find(span => span.is_segment) || sentrySpans[0];
+  const segmentAttributes = segmentSpan && segmentSpan.attributes && typeof segmentSpan.attributes === "object" ? segmentSpan.attributes : {};
+  const traceHeader = {
+    trace_id: segmentSpan.trace_id,
+    public_key: sentryDSN.publicKey,
+    sample_rate: "1.0",
+    sample_rand: "0.0",
+    sampled: "true",
+    ...(segmentSpan.name ? { transaction: segmentSpan.name } : {}),
+    ...(segmentAttributes["service.version"]?.type === "string" ? { release: String(segmentAttributes["service.version"].value) } : {}),
+    ...(segmentAttributes["deployment.environment"]?.type === "string" ? { environment: String(segmentAttributes["deployment.environment"].value) } : {}),
+  };
+  const itemPayload = JSON.stringify({ version: 2, items: sentrySpans });
+  const envelopeHeader = JSON.stringify({
+    sent_at: new Date().toISOString(),
+    dsn: sentryDSN.dsn,
+    sdk: {
+      name: "gh-aw",
+      version: process.env.GH_AW_INFO_VERSION || "unknown",
+    },
+    trace: traceHeader,
+  });
+  const itemHeader = JSON.stringify({
+    type: "span",
+    item_count: sentrySpans.length,
+    content_type: SENTRY_SPAN_ITEM_CONTENT_TYPE,
+    length: Buffer.byteLength(itemPayload, "utf8"),
+  });
+
+  return {
+    url: sentryDSN.envelopeUrl,
+    headers: { "Content-Type": SENTRY_ENVELOPE_CONTENT_TYPE },
+    body: `${envelopeHeader}\n${itemHeader}\n${itemPayload}`,
+  };
+}
+
 /**
  * POST an OTLP traces payload to `{endpoint}/v1/traces` with automatic retries.
  *
@@ -877,26 +1082,28 @@ async function sendOTLPSpan(endpoint, payload, { maxRetries = 2, baseDelayMs = 1
     appendToOTLPJSONL(payload);
   }
 
-  const url = endpoint.replace(/\/$/, "") + "/v1/traces";
+  const sanitizedPayload = sanitizeOTLPPayload(payload);
+  const sentryEnvelopeRequest = buildSentryEnvelopeRequest(endpoint, sanitizedPayload);
+  const url = sentryEnvelopeRequest ? sentryEnvelopeRequest.url : endpoint.replace(/\/$/, "") + "/v1/traces";
   // Use headersOverride when explicitly provided (including empty string, which means
   // "this endpoint has no configured headers" in the multi-endpoint fan-out path).
   // Fall back to OTEL_EXPORTER_OTLP_HEADERS only when headersOverride is absent
   // (undefined), which is the legacy single-endpoint case.
   const rawHeaders = headersOverride !== undefined ? headersOverride : process.env.OTEL_EXPORTER_OTLP_HEADERS || "";
-  const extraHeaders = parseOTLPHeaders(rawHeaders);
-  const headers = { "Content-Type": "application/json", ...extraHeaders };
-  const sanitizedBody = JSON.stringify(sanitizeOTLPPayload(payload));
+  const extraHeaders = sentryEnvelopeRequest ? {} : parseOTLPHeaders(rawHeaders);
+  const headers = sentryEnvelopeRequest ? sentryEnvelopeRequest.headers : { "Content-Type": "application/json", ...extraHeaders };
+  const requestBody = sentryEnvelopeRequest ? sentryEnvelopeRequest.body : JSON.stringify(sanitizedPayload);
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (attempt > 0) {
       await new Promise(resolve => setTimeout(resolve, baseDelayMs * 2 ** (attempt - 1)));
     }
     try {
       const response = hasProxyConfigured(endpoint)
-        ? sendOTLPViaCurl(url, headers, sanitizedBody)
+        ? sendOTLPViaCurl(url, headers, requestBody)
         : await fetch(url, {
             method: "POST",
             headers,
-            body: sanitizedBody,
+            body: requestBody,
           });
       if (response.ok) {
         return;

--- a/actions/setup/js/send_otlp_span.test.cjs
+++ b/actions/setup/js/send_otlp_span.test.cjs
@@ -737,6 +737,106 @@ describe("sendOTLPSpan", () => {
     expect(url).toBe("https://traces.example.com/v1/traces");
   });
 
+  it("uses Sentry envelope transport when endpoint is a DSN", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const payload = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: "service.name", value: { stringValue: "gh-aw" } },
+              { key: "service.version", value: { stringValue: "v1.2.3" } },
+              { key: "deployment.environment", value: { stringValue: "production" } },
+            ],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: "6cf173d587eb48568a9b2e12dcfbea52",
+                  spanId: "438f40bd3b4a41ee",
+                  name: "gh-aw.job.setup",
+                  startTimeUnixNano: "1742921669158209000",
+                  endTimeUnixNano: "1742921669180536000",
+                  status: { code: 1 },
+                  attributes: [{ key: "github.repository", value: { stringValue: "github/gh-aw" } }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    await sendOTLPSpan("https://public@example.ingest.sentry.io/42", payload);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://example.ingest.sentry.io/api/42/envelope/");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/x-sentry-envelope");
+
+    const [envelopeHeaderLine, itemHeaderLine, itemPayloadLine] = String(init.body).split("\n");
+    const envelopeHeader = JSON.parse(envelopeHeaderLine);
+    const itemHeader = JSON.parse(itemHeaderLine);
+    const itemPayload = JSON.parse(itemPayloadLine);
+
+    expect(envelopeHeader.dsn).toBe("https://public@example.ingest.sentry.io/42");
+    expect(envelopeHeader.trace).toMatchObject({
+      trace_id: "6cf173d587eb48568a9b2e12dcfbea52",
+      public_key: "public",
+      transaction: "gh-aw.job.setup",
+      release: "v1.2.3",
+      environment: "production",
+      sample_rate: "1.0",
+      sampled: "true",
+    });
+    expect(itemHeader).toMatchObject({
+      type: "span",
+      item_count: 1,
+      content_type: "application/vnd.sentry.items.span.v2+json",
+    });
+    expect(itemPayload).toMatchObject({
+      version: 2,
+      items: [
+        {
+          trace_id: "6cf173d587eb48568a9b2e12dcfbea52",
+          span_id: "438f40bd3b4a41ee",
+          name: "gh-aw.job.setup",
+          status: "ok",
+          is_segment: true,
+        },
+      ],
+    });
+    expect(itemPayload.items[0].attributes["github.repository"]).toEqual({ type: "string", value: "github/gh-aw" });
+  });
+
+  it("does not forward OTLP headers when using Sentry DSN envelope transport", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+    vi.stubGlobal("fetch", mockFetch);
+    process.env.OTEL_EXPORTER_OTLP_HEADERS = "Authorization=Bearer should-not-be-forwarded";
+
+    await sendOTLPSpan("https://public@example.ingest.sentry.io/42", {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              spans: [
+                { traceId: "6cf173d587eb48568a9b2e12dcfbea52", spanId: "438f40bd3b4a41ee", name: "gh-aw.job.setup", startTimeUnixNano: "1742921669158209000", endTimeUnixNano: "1742921669180536000", status: { code: 1 }, attributes: [] },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers).toEqual({ "Content-Type": "application/x-sentry-envelope" });
+  });
+
   it("uses curl when a proxy is configured", async () => {
     process.env.HTTPS_PROXY = "http://proxy.internal:3128";
     spawnSyncSpy.mockReturnValue({ error: undefined, status: 0, stdout: "200", stderr: "" });

--- a/docs/src/content/docs/reference/open-telemetry.md
+++ b/docs/src/content/docs/reference/open-telemetry.md
@@ -28,8 +28,8 @@ observability:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `observability.otlp.endpoint` | string, object, or array | OTLP/HTTP collector endpoint URL. Accepts a plain URL string, a single `{url, headers}` object, or an array of `{url, headers}` objects for concurrent fan-out to multiple collectors. When a static URL is provided, its hostname is automatically added to the network firewall allowlist. |
-| `observability.otlp.headers` | map or string | HTTP headers sent with every OTLP export request. Only applies when `endpoint` is a plain string; object and array endpoint entries carry their own per-endpoint headers. |
+| `observability.otlp.endpoint` | string, object, or array | OTLP/HTTP collector endpoint URL or Sentry DSN. Accepts a plain string, a single `{url, headers}` object, or an array of `{url, headers}` objects for concurrent fan-out to multiple collectors. When a static URL is provided, its hostname is automatically added to the network firewall allowlist. |
+| `observability.otlp.headers` | map | HTTP headers sent with every OTLP export request. Only applies when `endpoint` is a plain string; object and array endpoint entries carry their own per-endpoint headers. |
 | `observability.otlp.if-missing` | string (`error`, `warn`, `ignore`) | Controls behavior when OTLP endpoint/header values resolve to empty values at runtime. `error` (default) fails startup. `warn` logs a warning and skips MCP gateway OTLP configuration. `ignore` skips MCP gateway OTLP configuration without warning. This setting affects MCP gateway setup only. |
 
 ### Endpoint forms
@@ -75,12 +75,28 @@ observability:
 If one endpoint fails in array mode, export still continues
 for the remaining endpoints.
 
-### Header forms
+Sentry DSN form (native Sentry span envelope transport):
+
+```yaml wrap
+observability:
+  otlp:
+    endpoint: ${{ secrets.SENTRY_DSN }}
+```
+
+When the endpoint resolves to a Sentry DSN, gh-aw converts spans into Sentry's
+native `span` envelope format and sends them to `/api/<project>/envelope/`.
+Use the DSN itself as the endpoint value. Do not configure OTLP auth headers for
+this mode.
+
+### Headers
 
 The `headers` field applies to the string endpoint form and
-accepts either a map or a comma-separated string.
+must be a map of header names to values.
 
-Map form:
+Headers are for OTLP/HTTP collector requests. They are not used for the Sentry
+DSN transport shown above.
+
+Example:
 
 ```yaml wrap
 observability:
@@ -89,15 +105,6 @@ observability:
     headers:
       Authorization: ${{ secrets.OTLP_TOKEN }}
       X-Tenant: acme
-```
-
-String form:
-
-```yaml wrap
-observability:
-  otlp:
-    endpoint: ${{ secrets.OTLP_ENDPOINT }}
-    headers: "Authorization=${{ secrets.OTLP_TOKEN }},X-Tenant=acme"
 ```
 
 ## Runtime environment variables

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -9281,22 +9281,14 @@
                   "properties": {
                     "url": {
                       "type": "string",
-                      "description": "OTLP collector endpoint URL (e.g. 'https://traces.example.com:4317'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_ENDPOINT }}. When a static URL is provided, its hostname is automatically added to the network firewall allowlist."
+                      "description": "OTLP collector endpoint URL or Sentry DSN (for example 'https://traces.example.com:4317' or 'https://public@sentry.example.com/42'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_ENDPOINT }}. When a static URL is provided, its hostname is automatically added to the network firewall allowlist."
                     },
                     "headers": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "description": "Map of HTTP header names to values. Values support GitHub Actions expressions such as ${{ secrets.TOKEN }}.",
-                          "additionalProperties": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "string",
-                          "description": "Deprecated: use the map form instead. Comma-separated list of key=value HTTP headers (e.g. 'Authorization=Bearer <token>'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_HEADERS }}."
-                        }
-                      ]
+                      "type": "object",
+                      "description": "Map of HTTP header names to values. Values support GitHub Actions expressions such as ${{ secrets.TOKEN }}.",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
                     }
                   },
                   "additionalProperties": false
@@ -9311,22 +9303,14 @@
                     "properties": {
                       "url": {
                         "type": "string",
-                        "description": "OTLP collector endpoint URL (e.g. 'https://traces.example.com:4317'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_ENDPOINT }}. When a static URL is provided, its hostname is automatically added to the network firewall allowlist."
+                        "description": "OTLP collector endpoint URL or Sentry DSN (for example 'https://traces.example.com:4317' or 'https://public@sentry.example.com/42'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_ENDPOINT }}. When a static URL is provided, its hostname is automatically added to the network firewall allowlist."
                       },
                       "headers": {
-                        "oneOf": [
-                          {
-                            "type": "object",
-                            "description": "Map of HTTP header names to values. Values support GitHub Actions expressions such as ${{ secrets.TOKEN }}.",
-                            "additionalProperties": {
-                              "type": "string"
-                            }
-                          },
-                          {
-                            "type": "string",
-                            "description": "Deprecated: use the map form instead. Comma-separated list of key=value HTTP headers (e.g. 'Authorization=Bearer <token>'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_HEADERS }}."
-                          }
-                        ]
+                        "type": "object",
+                        "description": "Map of HTTP header names to values. Values support GitHub Actions expressions such as ${{ secrets.TOKEN }}.",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
                       }
                     },
                     "additionalProperties": false
@@ -9336,19 +9320,11 @@
             },
             "headers": {
               "description": "HTTP headers for the backward-compat string endpoint form. Only used when endpoint is a plain string; object/array endpoint entries carry their own per-endpoint headers.",
-              "oneOf": [
-                {
-                  "type": "object",
-                  "description": "Map of HTTP header names to values to include with every OTLP export request. Values support GitHub Actions expressions such as ${{ secrets.TOKEN }}. Injected as the OTEL_EXPORTER_OTLP_HEADERS environment variable.",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string",
-                  "description": "Deprecated: use the map form instead. Comma-separated list of key=value HTTP headers to include with every OTLP export request (e.g. 'Authorization=Bearer <token>'). Supports GitHub Actions expressions such as ${{ secrets.OTLP_HEADERS }}. Injected as the OTEL_EXPORTER_OTLP_HEADERS environment variable."
-                }
-              ]
+              "type": "object",
+              "description": "Map of HTTP header names to values to include with every OTLP export request. Values support GitHub Actions expressions such as ${{ secrets.TOKEN }}. Injected as the OTEL_EXPORTER_OTLP_HEADERS environment variable.",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "if-missing": {
               "type": "string",

--- a/pkg/workflow/frontmatter_types.go
+++ b/pkg/workflow/frontmatter_types.go
@@ -193,7 +193,8 @@ type RateLimitConfig struct {
 // OTLPEndpointConfig holds configuration for a single OTLP endpoint entry
 // used when the `endpoint` field is an object or an element of an array.
 type OTLPEndpointConfig struct {
-	// URL is the OTLP collector endpoint URL (e.g. "https://traces.example.com:4317").
+	// URL is the OTLP collector endpoint URL or Sentry DSN
+	// (e.g. "https://traces.example.com:4317" or "https://public@sentry.example.com/42").
 	// Supports GitHub Actions expressions such as ${{ secrets.OTLP_ENDPOINT }}.
 	// When a static URL is provided, its hostname is automatically added to the
 	// network firewall allowlist.
@@ -207,7 +208,8 @@ type OTLPEndpointConfig struct {
 // OTLPConfig holds configuration for OTLP (OpenTelemetry Protocol) trace export.
 type OTLPConfig struct {
 	// Endpoint accepts one of three forms:
-	//   - string:        backward-compat URL  (e.g. "https://traces.example.com:4317")
+	//   - string:        backward-compat URL or Sentry DSN
+	//                    (e.g. "https://traces.example.com:4317" or "https://public@sentry.example.com/42")
 	//   - object:        single endpoint with URL and optional headers
 	//                    (e.g. {url: "https://...", headers: {Authorization: "Bearer ${{ secrets.TOKEN }}"}})
 	//   - array:         multiple endpoints for concurrent fan-out

--- a/pkg/workflow/observability_otlp.go
+++ b/pkg/workflow/observability_otlp.go
@@ -17,15 +17,10 @@ var otlpLog = logger.New("workflow:observability_otlp")
 
 var sentryEndpointExpressionPattern = regexp.MustCompile(`(?i)^\$\{\{\s*secrets\.` + regexp.QuoteMeta(constants.OTELSentryEndpointSecretName) + `\s*\}\}$`)
 
-// normalizeOTLPHeaders converts the headers field value (which may be a string or a map)
+// normalizeOTLPHeaders converts the headers field value (map form only)
 // into the comma-separated key=value format required by OTEL_EXPORTER_OTLP_HEADERS.
 //
-// String form: "Authorization=Bearer tok,X-Tenant=acme"
 // Map form:    map[string]any{"Authorization": "Bearer tok", "X-Tenant": "acme"}
-//
-// Header values that themselves contain commas must use the map form because the
-// OTEL_EXPORTER_OTLP_HEADERS string format is a comma-separated list of
-// key=value pairs.
 func normalizeOTLPHeaders(raw any) string {
 	return normalizeOTLPHeadersForEndpoint(raw, "")
 }
@@ -36,10 +31,11 @@ func normalizeOTLPHeadersForEndpoint(raw any, endpoint string) string {
 	}
 	switch v := raw.(type) {
 	case string:
-		if v == "" {
+		if strings.TrimSpace(v) == "" {
 			return ""
 		}
-		return rewriteOTLPHeaderPairsForEndpoint(v, endpoint)
+		otlpLog.Printf("Ignoring unsupported string form for observability.otlp.headers; use a map of header names to values instead")
+		return ""
 	case map[string]any:
 		if len(v) == 0 {
 			return ""

--- a/pkg/workflow/observability_otlp_test.go
+++ b/pkg/workflow/observability_otlp_test.go
@@ -379,7 +379,7 @@ func TestInjectOTLPConfig(t *testing.T) {
 				Observability: &ObservabilityConfig{
 					OTLP: &OTLPConfig{
 						Endpoint: "https://traces.example.com",
-						Headers:  "Authorization=Bearer tok,X-Tenant=acme",
+						Headers:  map[string]any{"Authorization": "Bearer tok", "X-Tenant": "acme"},
 					},
 				},
 			},
@@ -388,7 +388,7 @@ func TestInjectOTLPConfig(t *testing.T) {
 		assert.Contains(t, wd.Env, "OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer tok,X-Tenant=acme", "headers var should be injected")
 	})
 
-	t.Run("injects OTEL_EXPORTER_OTLP_HEADERS for secret expression", func(t *testing.T) {
+	t.Run("does not inject OTEL_EXPORTER_OTLP_HEADERS for unsupported string form", func(t *testing.T) {
 		c := newCompiler()
 		wd := &WorkflowData{
 			ParsedFrontmatter: &FrontmatterConfig{
@@ -401,7 +401,7 @@ func TestInjectOTLPConfig(t *testing.T) {
 			},
 		}
 		c.injectOTLPConfig(wd)
-		assert.Contains(t, wd.Env, "OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}", "headers var should support secret expressions")
+		assert.NotContains(t, wd.Env, "OTEL_EXPORTER_OTLP_HEADERS:", "string-form headers should be ignored")
 	})
 
 	t.Run("does not inject OTEL_EXPORTER_OTLP_HEADERS when headers not configured", func(t *testing.T) {
@@ -480,7 +480,7 @@ func TestObservabilityConfigParsing(t *testing.T) {
 				"observability": map[string]any{
 					"otlp": map[string]any{
 						"endpoint": "https://traces.example.com",
-						"headers":  "Authorization=Bearer tok,X-Tenant=acme",
+						"headers":  map[string]any{"Authorization": "Bearer tok", "X-Tenant": "acme"},
 					},
 				},
 			},
@@ -489,7 +489,7 @@ func TestObservabilityConfigParsing(t *testing.T) {
 			expectedHeaders:  "Authorization=Bearer tok,X-Tenant=acme",
 		},
 		{
-			name: "observability with otlp headers as secret expression",
+			name: "observability with otlp headers as unsupported string expression",
 			frontmatter: map[string]any{
 				"observability": map[string]any{
 					"otlp": map[string]any{
@@ -500,7 +500,7 @@ func TestObservabilityConfigParsing(t *testing.T) {
 			},
 			wantOTLPConfig:   true,
 			expectedEndpoint: "https://traces.example.com",
-			expectedHeaders:  "${{ secrets.OTLP_HEADERS }}",
+			expectedHeaders:  "",
 		},
 	}
 
@@ -540,7 +540,7 @@ func TestInjectOTLPConfig_RawFrontmatterFallback(t *testing.T) {
 				"observability": map[string]any{
 					"otlp": map[string]any{
 						"endpoint": "${{ secrets.GH_AW_OTEL_ENDPOINT }}",
-						"headers":  "${{ secrets.GH_AW_OTEL_HEADERS }}",
+						"headers":  map[string]any{"Authorization": "${{ secrets.GH_AW_OTEL_HEADERS }}"},
 					},
 				},
 				// Simulate complex engine object that would cause ParseFrontmatterConfig to fail.
@@ -552,7 +552,7 @@ func TestInjectOTLPConfig_RawFrontmatterFallback(t *testing.T) {
 		require.NotEmpty(t, wd.Env, "Env should be set even without ParsedFrontmatter")
 		assert.Contains(t, wd.Env, "OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.GH_AW_OTEL_ENDPOINT }}", "endpoint should be injected from raw")
 		assert.Contains(t, wd.Env, "OTEL_SERVICE_NAME: gh-aw", "service name should be set")
-		assert.Contains(t, wd.Env, "OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.GH_AW_OTEL_HEADERS }}", "headers should be injected from raw")
+		assert.Contains(t, wd.Env, "OTEL_EXPORTER_OTLP_HEADERS: Authorization=${{ secrets.GH_AW_OTEL_HEADERS }}", "headers should be injected from raw")
 	})
 
 	t.Run("no-op when neither raw nor parsed frontmatter has OTLP", func(t *testing.T) {
@@ -601,7 +601,7 @@ func TestIsOTLPHeadersPresent(t *testing.T) {
 		{
 			name: "Env with secret expression headers returns true",
 			data: &WorkflowData{
-				Env: "env:\n  OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}\n  OTEL_SERVICE_NAME: gh-aw\n  OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTLP_HEADERS }}",
+				Env: "env:\n  OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}\n  OTEL_SERVICE_NAME: gh-aw\n  OTEL_EXPORTER_OTLP_HEADERS: Authorization=${{ secrets.OTLP_HEADERS }}",
 			},
 			expected: true,
 		},
@@ -758,7 +758,7 @@ func TestInjectOTLPConfig_OTLPHeadersField(t *testing.T) {
 		assert.Equal(t, "Authorization=Bearer tok,X-Tenant=acme", wd.OTLPHeaders, "OTLPHeaders should be set from map form")
 	})
 
-	t.Run("sets OTLPHeaders when headers are configured (string form)", func(t *testing.T) {
+	t.Run("ignores OTLPHeaders when headers are configured in unsupported string form", func(t *testing.T) {
 		wd := &WorkflowData{
 			RawFrontmatter: map[string]any{
 				"observability": map[string]any{
@@ -770,7 +770,7 @@ func TestInjectOTLPConfig_OTLPHeadersField(t *testing.T) {
 			},
 		}
 		c.injectOTLPConfig(wd)
-		assert.Equal(t, "Authorization=Bearer tok", wd.OTLPHeaders, "OTLPHeaders should be set from string form")
+		assert.Empty(t, wd.OTLPHeaders, "OTLPHeaders should be empty for unsupported string form")
 	})
 
 	t.Run("OTLPHeaders is empty when no headers are configured", func(t *testing.T) {
@@ -804,14 +804,14 @@ func TestNormalizeOTLPHeaders(t *testing.T) {
 			expectedHeaders: "",
 		},
 		{
-			name:            "non-empty string returns string",
+			name:            "non-empty string returns empty",
 			input:           "Authorization=Bearer tok",
-			expectedHeaders: "Authorization=Bearer tok",
+			expectedHeaders: "",
 		},
 		{
-			name:            "secret expression string",
+			name:            "secret expression string returns empty",
 			input:           "${{ secrets.OTLP_HEADERS }}",
-			expectedHeaders: "${{ secrets.OTLP_HEADERS }}",
+			expectedHeaders: "",
 		},
 		{
 			name:            "empty map returns empty",
@@ -871,28 +871,28 @@ func TestNormalizeOTLPHeadersForEndpoint(t *testing.T) {
 		assert.Equal(t, "x-sentry-auth=Bearer tok", gotHeaders, "Sentry endpoints should use x-sentry-auth")
 	})
 
-	t.Run("rewrites Authorization header for known sentry endpoint expression", func(t *testing.T) {
+	t.Run("ignores string-form headers for known sentry endpoint expression", func(t *testing.T) {
 		gotHeaders := normalizeOTLPHeadersForEndpoint(
 			"Authorization=Bearer tok,X-Tenant=acme",
 			"${{ secrets.GH_AW_OTEL_SENTRY_ENDPOINT }}",
 		)
-		assert.Equal(t, "x-sentry-auth=Bearer tok,X-Tenant=acme", gotHeaders, "Sentry-named endpoint expressions should use x-sentry-auth")
+		assert.Equal(t, "", gotHeaders, "string-form headers should be ignored")
 	})
 
-	t.Run("rewrites Authorization header for sentry URL with additional headers", func(t *testing.T) {
+	t.Run("ignores string-form headers for sentry URL with additional headers", func(t *testing.T) {
 		gotHeaders := normalizeOTLPHeadersForEndpoint(
 			"Authorization=Bearer tok,X-Tenant=acme",
 			"https://o123.ingest.sentry.io/api/123/envelope/",
 		)
-		assert.Equal(t, "x-sentry-auth=Bearer tok,X-Tenant=acme", gotHeaders, "Sentry endpoints should rewrite Authorization while preserving additional headers")
+		assert.Equal(t, "", gotHeaders, "string-form headers should be ignored")
 	})
 
-	t.Run("preserves Authorization header for non-standard sentry endpoint expressions", func(t *testing.T) {
+	t.Run("ignores string-form headers for non-standard sentry endpoint expressions", func(t *testing.T) {
 		gotHeaders := normalizeOTLPHeadersForEndpoint(
 			"Authorization=Bearer tok,X-Tenant=acme",
 			"${{ secrets.TEAM_SENTRY_PROXY_ENDPOINT }}",
 		)
-		assert.Equal(t, "Authorization=Bearer tok,X-Tenant=acme", gotHeaders, "Only the known Sentry endpoint expression should use x-sentry-auth")
+		assert.Equal(t, "", gotHeaders, "string-form headers should be ignored")
 	})
 
 	t.Run("preserves Authorization header for grafana endpoint", func(t *testing.T) {
@@ -903,12 +903,12 @@ func TestNormalizeOTLPHeadersForEndpoint(t *testing.T) {
 		assert.Equal(t, "Authorization=Bearer tok,X-Scope-OrgID=tenant", gotHeaders, "Non-Sentry endpoints should keep Authorization")
 	})
 
-	t.Run("preserves Authorization header when sentry appears outside URL host", func(t *testing.T) {
+	t.Run("ignores string-form headers when sentry appears outside URL host", func(t *testing.T) {
 		gotHeaders := normalizeOTLPHeadersForEndpoint(
 			"Authorization=Bearer tok,X-Tenant=acme",
 			"https://otlp-gateway-prod-us-central-0.grafana.net/sentry/proxy",
 		)
-		assert.Equal(t, "Authorization=Bearer tok,X-Tenant=acme", gotHeaders, "Only Sentry hosts should use x-sentry-auth")
+		assert.Equal(t, "", gotHeaders, "string-form headers should be ignored")
 	})
 }
 
@@ -1019,7 +1019,7 @@ func TestObservabilityConfigParsing_MapHeaders(t *testing.T) {
 		assert.Equal(t, "acme", headersMap["X-Tenant"])
 	})
 
-	t.Run("string headers parsed as any string", func(t *testing.T) {
+	t.Run("string headers remain parsed but normalize to empty", func(t *testing.T) {
 		frontmatter := map[string]any{
 			"observability": map[string]any{
 				"otlp": map[string]any{
@@ -1035,6 +1035,7 @@ func TestObservabilityConfigParsing_MapHeaders(t *testing.T) {
 		headersStr, ok := config.Observability.OTLP.Headers.(string)
 		require.True(t, ok, "Headers should be a string when string form is used")
 		assert.Equal(t, "Authorization=Bearer tok", headersStr)
+		assert.Empty(t, normalizeOTLPHeaders(config.Observability.OTLP.Headers))
 	})
 }
 
@@ -1075,7 +1076,7 @@ func TestCollectAllOTLPEndpoints(t *testing.T) {
 				},
 			},
 			wantEntries: []otlpEndpointEntry{
-				{URL: "https://traces.example.com:4317", Headers: "Authorization=Bearer tok"},
+				{URL: "https://traces.example.com:4317"},
 			},
 		},
 		{


### PR DESCRIPTION
- Adds first-class support for sending OpenTelemetry (OTLP) spans directly to Sentry using a Sentry DSN, in addition to standard OTLP/HTTP collector endpoints.
- When a Sentry DSN is used as the endpoint, spans are automatically converted to Sentry's native envelope format and sent to the appropriate Sentry API endpoint.