### PR TITLE
feat(cli): JSON workflow importer - trigger/tool/permissions mapping

### DIFF
--- a/.github/workflows/mcp-inspector.lock.yml
+++ b/.github/workflows/mcp-inspector.lock.yml
@@ -1000,7 +1000,7 @@ jobs:
                 "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core",
                 "headers": {
                   "DD_API_KEY": "\${DD_API_KEY}",
-                  "DD_APPLICATION_KEY": "\${DD_APP_KEY}",
+                  "DD_APPLICATION_KEY": "\${DD_APPLICATION_KEY}",
                   "DD_SITE": "\${DD_SITE}"
                 },
                 "tools": [

--- a/.github/workflows/smoke-otel-backends.lock.yml
+++ b/.github/workflows/smoke-otel-backends.lock.yml
@@ -773,7 +773,7 @@ jobs:
                 "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core",
                 "headers": {
                   "DD_API_KEY": "\${DD_API_KEY}",
-                  "DD_APPLICATION_KEY": "\${DD_APP_KEY}",
+                  "DD_APPLICATION_KEY": "\${DD_APPLICATION_KEY}",
                   "DD_SITE": "\${DD_SITE}"
                 },
                 "tools": [

--- a/.github/workflows/smoke-otel-backends.lock.yml
+++ b/.github/workflows/smoke-otel-backends.lock.yml
@@ -773,7 +773,7 @@ jobs:
                 "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core",
                 "headers": {
                   "DD_API_KEY": "\${DD_API_KEY}",
-                  "DD_APPLICATION_KEY": "\${DD_APPLICATION_KEY}",
+                  "DD_APPLICATION_KEY": "\${DD_APP_KEY}",
                   "DD_SITE": "\${DD_SITE}"
                 },
                 "tools": [

--- a/actions/setup/js/create_pull_request.cjs
+++ b/actions/setup/js/create_pull_request.cjs
@@ -107,9 +107,7 @@ function summarizeListForLog(values, limit = 10) {
 async function tryRecoverGitAmAddAddConflict(execApi) {
   try {
     const unresolvedFilesResult = await execApi.getExecOutput("git", ["diff", "--name-only", "--diff-filter=U", "-z"]);
-    const unresolvedFiles = unresolvedFilesResult.stdout
-      .split("\0")
-      .filter(line => line.length > 0);
+    const unresolvedFiles = unresolvedFilesResult.stdout.split("\0").filter(line => line.length > 0);
     core.debug(`Add/add recovery probe unresolved files (${unresolvedFiles.length}): ${summarizeListForLog(unresolvedFiles)}`);
 
     if (unresolvedFiles.length === 0) {
@@ -166,9 +164,7 @@ async function tryRecoverGitAmAddAddConflict(execApi) {
 
         const oursSize = await getBlobSize(oursBlobSha);
         const theirsSize = await getBlobSize(theirsBlobSha);
-        core.warning(
-          `Resolving add/add conflict for ${file}: ours ${oursBlobSha || "unknown"} (${oursSize} bytes), theirs ${theirsBlobSha || "unknown"} (${theirsSize} bytes); preferring patch version (--theirs)`
-        );
+        core.warning(`Resolving add/add conflict for ${file}: ours ${oursBlobSha || "unknown"} (${oursSize} bytes), theirs ${theirsBlobSha || "unknown"} (${theirsSize} bytes); preferring patch version (--theirs)`);
       } catch (metadataError) {
         core.warning(`Resolving add/add conflict for ${file}; failed to read conflict blob metadata: ${getErrorMessage(metadataError)}. Preferring patch version (--theirs)`);
       }

--- a/pkg/cli/jsonworkflow_to_markdown.go
+++ b/pkg/cli/jsonworkflow_to_markdown.go
@@ -24,17 +24,67 @@ type JSONWorkflow struct {
 	Name string `json:"name"`
 	// Human-readable description → frontmatter description:
 	Description string `json:"description"`
-	// Main body / prompt text → markdown body after frontmatter
+	// Main body / prompt text → markdown body after frontmatter.
+	// Instructions takes precedence when both are set.
 	Instructions string `json:"instructions"`
+	// Prompt maps to the markdown body like Instructions does.
+	// Instructions takes precedence when both are set.
+	Prompt string `json:"prompt"`
 	// Preferred AI engine → frontmatter engine:
 	Engine string `json:"engine"`
-	// Trigger configuration → frontmatter on: (passed through as-is)
+	// On is a generic trigger configuration → frontmatter on: (passed through
+	// as-is).  Takes precedence over Triggers when both are set.
 	On any `json:"on"`
+	// Triggers is a structured trigger block that is converted to the gh-aw
+	// "on:" frontmatter field via convertTriggersToOn.
+	// The On field takes precedence when both are set.
+	Triggers *JSONWorkflowTriggers `json:"triggers"`
+	// Tools lists tool IDs → frontmatter tools: (converted via convertToolsToConfig).
+	Tools []string `json:"tools"`
+	// Permissions maps GitHub Actions permission scopes to access levels
+	// (e.g. {"issues": "write"}) → frontmatter permissions:
+	Permissions map[string]string `json:"permissions"`
 	// Tags → frontmatter tags:
 	Tags []string `json:"tags"`
 	// Extra holds any top-level keys not listed above so they can be preserved
 	// as a comment block.
 	Extra map[string]any `json:"-"`
+}
+
+// JSONWorkflowTriggers is the structured trigger block for a JSON workflow.
+//
+// Supported trigger kinds and their gh-aw "on:" mapping:
+//
+//	interval  hourly/daily/weekly  →  "hourly" / "daily" / "weekly" (string shorthand)
+//	                                   or schedule: [{cron: "..."}] when combined with others
+//	issues    opened               →  on: issues: types: [opened]
+//	issues    opened + query       →  same + warning (query has no gh-aw equivalent)
+//	workflow_run                   →  on: workflow_run: workflows: [...] types: [completed]
+type JSONWorkflowTriggers struct {
+	Interval    *IntervalTrigger    `json:"interval,omitempty"`
+	Issues      *IssueTrigger       `json:"issues,omitempty"`
+	WorkflowRun *WorkflowRunTrigger `json:"workflow_run,omitempty"`
+}
+
+// IntervalTrigger schedules the workflow.  Types is one or more of
+// "hourly", "daily", "weekly".
+type IntervalTrigger struct {
+	Types []string `json:"types"`
+}
+
+// IssueTrigger fires when a GitHub issue is opened.  Types must contain
+// "opened".  Query is an optional issue-search filter with no gh-aw equivalent.
+type IssueTrigger struct {
+	Types []string `json:"types"`
+	Query string   `json:"query,omitempty"`
+}
+
+// WorkflowRunTrigger fires when a workflow run completes.  Workflows lists the
+// workflow names to watch; Conclusions filters by result (e.g. "failure").
+type WorkflowRunTrigger struct {
+	Types       []string `json:"types"`
+	Workflows   []string `json:"workflows"`
+	Conclusions []string `json:"conclusions"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler so that unknown keys are captured in Extra.
@@ -55,7 +105,8 @@ func (w *JSONWorkflow) UnmarshalJSON(data []byte) error {
 
 	knownKeys := map[string]bool{
 		"id": true, "name": true, "description": true,
-		"instructions": true, "engine": true, "on": true, "tags": true,
+		"instructions": true, "prompt": true, "engine": true,
+		"on": true, "triggers": true, "tools": true, "permissions": true, "tags": true,
 	}
 	for k, v := range raw {
 		if !knownKeys[k] {
@@ -125,11 +176,59 @@ func ConvertJSONWorkflowToMarkdown(a *JSONWorkflow, opts ConvertOptions) (*Gener
 		fm.WriteString("\n")
 	}
 
-	if a.On != nil {
-		onYAML, err := marshalFrontmatterValue(a.On)
+	// "on:" is resolved from On (explicit, takes precedence) or converted from Triggers.
+	onVal, triggerWarnings := resolveOnValue(a)
+	warnings = append(warnings, triggerWarnings...)
+	if onVal != nil {
+		if s, ok := onVal.(string); ok {
+			// Scalar shorthand e.g. "on: hourly"
+			fm.WriteString("on: ")
+			fm.WriteString(s)
+			fm.WriteString("\n")
+		} else {
+			onYAML, err := marshalFrontmatterValue(onVal)
+			if err == nil {
+				fm.WriteString("on:\n")
+				for line := range strings.SplitSeq(onYAML, "\n") {
+					if line == "" {
+						continue
+					}
+					fm.WriteString("  ")
+					fm.WriteString(line)
+					fm.WriteString("\n")
+				}
+			} else {
+				warnings = append(warnings, fmt.Sprintf("could not serialize 'on' field: %v", err))
+			}
+		}
+	}
+
+	if len(a.Tools) > 0 {
+		toolsConfig, toolWarnings := convertToolsToConfig(a.Tools)
+		warnings = append(warnings, toolWarnings...)
+		if len(toolsConfig) > 0 {
+			toolsYAML, err := marshalFrontmatterValue(toolsConfig)
+			if err == nil {
+				fm.WriteString("tools:\n")
+				for line := range strings.SplitSeq(toolsYAML, "\n") {
+					if line == "" {
+						continue
+					}
+					fm.WriteString("  ")
+					fm.WriteString(line)
+					fm.WriteString("\n")
+				}
+			} else {
+				warnings = append(warnings, fmt.Sprintf("could not serialize 'tools' field: %v", err))
+			}
+		}
+	}
+
+	if len(a.Permissions) > 0 {
+		permYAML, err := marshalFrontmatterValue(a.Permissions)
 		if err == nil {
-			fm.WriteString("on:\n")
-			for line := range strings.SplitSeq(onYAML, "\n") {
+			fm.WriteString("permissions:\n")
+			for line := range strings.SplitSeq(permYAML, "\n") {
 				if line == "" {
 					continue
 				}
@@ -138,7 +237,7 @@ func ConvertJSONWorkflowToMarkdown(a *JSONWorkflow, opts ConvertOptions) (*Gener
 				fm.WriteString("\n")
 			}
 		} else {
-			warnings = append(warnings, fmt.Sprintf("could not serialize 'on' field: %v", err))
+			warnings = append(warnings, fmt.Sprintf("could not serialize 'permissions' field: %v", err))
 		}
 	}
 
@@ -197,6 +296,10 @@ func ConvertJSONWorkflowToMarkdown(a *JSONWorkflow, opts ConvertOptions) (*Gener
 
 	if a.Instructions != "" {
 		body.WriteString(strings.TrimRight(a.Instructions, "\n"))
+		body.WriteString("\n")
+	} else if a.Prompt != "" {
+		// Prompt is the fallback body text when no Instructions field is present.
+		body.WriteString(strings.TrimRight(a.Prompt, "\n"))
 		body.WriteString("\n")
 	}
 
@@ -271,4 +374,202 @@ func marshalFrontmatterValue(v any) (string, error) {
 	// Convert JSON representation to simple YAML.
 	// For objects and arrays the JSON encoding is already valid YAML.
 	return string(raw), nil
+}
+
+// resolveOnValue returns the value to use for the "on:" frontmatter key.
+// a.On takes precedence; a.Triggers is used as a fallback.
+func resolveOnValue(a *JSONWorkflow) (any, []string) {
+	if a.On != nil {
+		return a.On, nil
+	}
+	if a.Triggers != nil {
+		return convertTriggersToOn(a.Triggers)
+	}
+	return nil, nil
+}
+
+// convertTriggersToOn maps a JSONWorkflowTriggers block to a value suitable for
+// the gh-aw "on:" frontmatter field, plus any conversion warnings.
+//
+// Mapping rules (from GET /agents/automations/triggers):
+//
+//	interval  single type          →  string shorthand ("hourly" / "daily" / "weekly")
+//	interval  single type + other  →  schedule: [{cron: "<expr>"}] inside a map
+//	issues    opened               →  issues: {types: [opened]}
+//	issues    query present        →  warning (query has no gh-aw equivalent)
+//	workflow_run                   →  workflow_run: {workflows: [...], types: [completed]}
+//	workflow_run  conclusions      →  warning (conclusions has no gh-aw equivalent)
+func convertTriggersToOn(t *JSONWorkflowTriggers) (any, []string) {
+	if t == nil {
+		return nil, nil
+	}
+
+	var warnings []string
+	// parts accumulates the trigger map entries.
+	parts := map[string]any{}
+
+	if t.Interval != nil && len(t.Interval.Types) > 0 {
+		intervalType := t.Interval.Types[0]
+		if len(t.Interval.Types) > 1 {
+			warnings = append(warnings, fmt.Sprintf(
+				"triggers.interval has multiple types %v; only the first (%q) will be used",
+				t.Interval.Types, intervalType))
+		}
+		switch intervalType {
+		case "hourly", "daily", "weekly":
+			parts["_interval"] = intervalType
+		default:
+			warnings = append(warnings, fmt.Sprintf("triggers.interval type %q is not supported; skipped", intervalType))
+		}
+	}
+
+	if t.Issues != nil && len(t.Issues.Types) > 0 {
+		issueEntry := map[string]any{"types": t.Issues.Types}
+		if t.Issues.Query != "" {
+			warnings = append(warnings, `triggers.issues.query has no gh-aw equivalent; add a skip-if-match block manually if needed`)
+		}
+		parts["issues"] = issueEntry
+	}
+
+	if t.WorkflowRun != nil {
+		wfEntry := map[string]any{
+			"workflows": t.WorkflowRun.Workflows,
+			"types":     t.WorkflowRun.Types,
+		}
+		if len(t.WorkflowRun.Conclusions) > 0 {
+			warnings = append(warnings, `triggers.workflow_run.conclusions has no gh-aw equivalent; review the generated "on:" block`)
+		}
+		parts["workflow_run"] = wfEntry
+	}
+
+	if len(parts) == 0 {
+		return nil, warnings
+	}
+
+	// Single interval trigger → use the string shorthand directly.
+	intervalType, hasInterval := parts["_interval"]
+	if hasInterval && len(parts) == 1 {
+		return intervalType.(string), warnings
+	}
+
+	// Multiple triggers or non-interval: build a map.
+	// Convert interval shorthand to a schedule cron entry.
+	if hasInterval {
+		delete(parts, "_interval")
+		parts["schedule"] = []any{map[string]any{"cron": intervalToFuzzySchedule(intervalType.(string))}}
+	}
+
+	return parts, warnings
+}
+
+// intervalToFuzzySchedule returns a gh-aw fuzzy schedule expression for a
+// JSON interval type.  These expressions are understood by gh-aw's schedule
+// parser (pkg/parser/schedule_parser.go) and compiled to randomised cron
+// entries at workflow compilation time — they must NOT be raw cron strings.
+func intervalToFuzzySchedule(interval string) string {
+	switch interval {
+	case "hourly":
+		return "every 1h"
+	case "daily":
+		return "daily"
+	case "weekly":
+		return "weekly"
+	default:
+		return "daily"
+	}
+}
+
+// jsonToolToToolset maps a bare tool ID (without "github/" prefix) to the gh-aw
+// GitHub MCP toolset name.  The toolset names match the group IDs returned by
+// GET /agents/automations/tools.
+var jsonToolToToolset = map[string]string{
+	// Issues
+	"issue_read": "issues", "list_issues": "issues", "search_issues": "issues",
+	"create_issue": "issues", "update_issue_title": "issues", "update_issue_body": "issues",
+	"update_issue_assignees": "issues", "update_issue_labels": "issues",
+	"update_issue_milestone": "issues", "update_issue_type": "issues",
+	"update_issue_state": "issues", "add_sub_issue": "issues",
+	"remove_sub_issue": "issues", "reprioritize_sub_issue": "issues",
+	"set_issue_fields": "issues", "add_issue_comment": "issues",
+	// Pull Requests
+	"pull_request_read": "pull-requests", "list_pull_requests": "pull-requests",
+	"search_pull_requests": "pull-requests", "create_pull_request": "pull-requests",
+	"update_pull_request_title": "pull-requests", "update_pull_request_body": "pull-requests",
+	"update_pull_request_state": "pull-requests", "update_pull_request_draft_state": "pull-requests",
+	"merge_pull_request": "pull-requests", "update_pull_request_branch": "pull-requests",
+	"request_pull_request_reviewers": "pull-requests", "create_pull_request_review": "pull-requests",
+	"submit_pending_pull_request_review": "pull-requests", "delete_pending_pull_request_review": "pull-requests",
+	"add_pull_request_review_comment": "pull-requests", "resolve_review_thread": "pull-requests",
+	"unresolve_review_thread": "pull-requests", "add_reply_to_pull_request_comment": "pull-requests",
+	// Repos
+	"get_file_contents": "repos", "search_code": "repos", "search_repositories": "repos",
+	"list_branches": "repos", "list_commits": "repos", "get_commit": "repos",
+	"list_tags": "repos", "get_tag": "repos", "create_branch": "repos",
+	"create_or_update_file": "repos", "push_files": "repos", "delete_file": "repos",
+	// Actions
+	"actions_list": "actions", "actions_get": "actions", "get_job_logs": "actions",
+	// Code Security
+	"list_code_scanning_alerts": "code-security", "get_code_scanning_alert": "code-security",
+	"list_secret_scanning_alerts": "code-security", "get_secret_scanning_alert": "code-security",
+}
+
+// jsonGeneralTools are built-in agent capabilities that need no explicit gh-aw
+// configuration and produce no warning when encountered.
+var jsonGeneralTools = map[string]bool{
+	"read": true, "edit": true, "search": true,
+}
+
+// convertToolsToConfig maps a list of JSON tool IDs to a gh-aw tools config map
+// (the value under the "tools:" frontmatter key) and any conversion warnings.
+//
+// Tool ID format: bare ("issue_read") or prefixed ("github/issue_read").
+// Mapping:
+//
+//	github/*         →  tools: github: toolsets: [<toolset>]
+//	execute          →  tools: bash: "*"  (+ warning)
+//	web_search       →  tools: web-search: (direct mapping, hyphen-normalised)
+//	read/edit/search →  (built-in capability, no config needed, no warning)
+func convertToolsToConfig(tools []string) (map[string]any, []string) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+
+	var warnings []string
+	toolsets := map[string]bool{}
+	config := map[string]any{}
+	needsBash := false
+
+	for _, id := range tools {
+		bare := strings.TrimPrefix(id, "github/")
+		if jsonGeneralTools[bare] {
+			continue
+		}
+		switch bare {
+		case "execute":
+			needsBash = true
+		case "web_search":
+			// JSON uses underscore; gh-aw frontmatter uses hyphen.
+			config["web-search"] = nil
+		default:
+			if ts := jsonToolToToolset[bare]; ts != "" {
+				toolsets[ts] = true
+			} else {
+				warnings = append(warnings, fmt.Sprintf("tool %q has no known gh-aw mapping and was skipped", id))
+			}
+		}
+	}
+
+	if len(toolsets) > 0 {
+		sorted := make([]string, 0, len(toolsets))
+		for ts := range toolsets {
+			sorted = append(sorted, ts)
+		}
+		sort.Strings(sorted)
+		config["github"] = map[string]any{"toolsets": sorted}
+	}
+	if needsBash {
+		config["bash"] = "*"
+		warnings = append(warnings, `tool "execute" was mapped to bash: "*"; review the bash permissions`)
+	}
+	return config, warnings
 }

--- a/pkg/cli/jsonworkflow_to_markdown.go
+++ b/pkg/cli/jsonworkflow_to_markdown.go
@@ -432,14 +432,18 @@ func convertTriggersToOn(t *JSONWorkflowTriggers) (any, []string) {
 	}
 
 	if t.WorkflowRun != nil {
-		wfEntry := map[string]any{
-			"workflows": t.WorkflowRun.Workflows,
-			"types":     t.WorkflowRun.Types,
+		if len(t.WorkflowRun.Workflows) == 0 || len(t.WorkflowRun.Types) == 0 {
+			warnings = append(warnings, `triggers.workflow_run requires non-empty workflows and types; skipped`)
+		} else {
+			wfEntry := map[string]any{
+				"workflows": t.WorkflowRun.Workflows,
+				"types":     t.WorkflowRun.Types,
+			}
+			if len(t.WorkflowRun.Conclusions) > 0 {
+				warnings = append(warnings, `triggers.workflow_run.conclusions has no gh-aw equivalent; review the generated "on:" block`)
+			}
+			parts["workflow_run"] = wfEntry
 		}
-		if len(t.WorkflowRun.Conclusions) > 0 {
-			warnings = append(warnings, `triggers.workflow_run.conclusions has no gh-aw equivalent; review the generated "on:" block`)
-		}
-		parts["workflow_run"] = wfEntry
 	}
 
 	if len(parts) == 0 {

--- a/pkg/cli/jsonworkflow_to_markdown_test.go
+++ b/pkg/cli/jsonworkflow_to_markdown_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,138 @@ func TestToKebabCase(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			assert.Equal(t, tc.want, toKebabCase(tc.input))
 		})
+	}
+}
+
+// TestConvertJSONWorkflowToMarkdown_IntervalTrigger tests the importer against
+// a real-world payload from the JSON workflow API with an interval trigger.
+// prompt → body, triggers.interval → "on: hourly" shorthand.
+func TestConvertJSONWorkflowToMarkdown_IntervalTrigger(t *testing.T) {
+	// Anonymised payload – login replaced with the octocat placeholder.
+	raw := `{
+		"id": "b5a3f76a-3d8f-4790-b7e2-f2886f784345",
+		"name": "haiku",
+		"description": "Format and linter",
+		"prompt": "Write a haiku",
+		"disabled_state": null,
+		"triggers": {"interval": {"types": ["hourly"]}},
+		"created_at": "2026-05-19T02:56:23.763410743Z",
+		"updated_at": "2026-05-19T02:56:23.763410743Z",
+		"created_by": {"id": 1, "login": "octocat", "node_id": "MDQ6VXNlcjE=", "url": "https://github.com/octocat"}
+	}`
+
+	var wf JSONWorkflow
+	require.NoError(t, json.Unmarshal([]byte(raw), &wf), "unmarshal must succeed")
+
+	gen, err := ConvertJSONWorkflowToMarkdown(&wf, ConvertOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "b5a3f76a-3d8f-4790-b7e2-f2886f784345", gen.Filename, "filename from id")
+	assert.Contains(t, gen.Markdown, "description: Format and linter", "description in frontmatter")
+	assert.Contains(t, gen.Markdown, "# haiku", "heading from name")
+
+	// interval → string shorthand
+	assert.Contains(t, gen.Markdown, "on: hourly", "interval trigger → shorthand")
+
+	// prompt → body text
+	assert.Contains(t, gen.Markdown, "Write a haiku", "prompt in body")
+	assert.NotContains(t, gen.Markdown, "# prompt:", "prompt must NOT appear as comment")
+
+	// triggers is a known field now – no comment or warning for it
+	assert.NotContains(t, gen.Markdown, "# triggers:", "triggers must NOT appear as comment")
+
+	// Warnings only for the genuinely unknown fields
+	for _, field := range []string{"created_at", "updated_at", "created_by"} {
+		found := false
+		for _, w := range gen.Warnings {
+			if strings.Contains(w, field) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected warning for field %q", field)
+	}
+	for _, field := range []string{"prompt", "triggers"} {
+		for _, w := range gen.Warnings {
+			assert.False(t, strings.Contains(w, field), "unexpected warning mentioning %q: %s", field, w)
+		}
+	}
+}
+
+// TestConvertJSONWorkflowToMarkdown_MultiTriggerWithTools tests a richer payload:
+// multi-trigger (issues + workflow_run), tools migration, permissions, and
+// disabled/metadata fields going to Extra.
+func TestConvertJSONWorkflowToMarkdown_MultiTriggerWithTools(t *testing.T) {
+	// Anonymised payload – login replaced with octocat.
+	raw := `{
+		"id": "0be2cc4b-de12-43fe-ada7-55ef6dc8f3ba",
+		"name": "issue triage",
+		"description": "test",
+		"prompt": "Summarize issue.",
+		"disabled": true,
+		"disabled_state": {"disabled_at": "2026-05-19T17:37:05.839761776Z", "reason": "disabled_by_user"},
+		"triggers": {
+			"issues": {"query": "label:bug", "types": ["opened"]},
+			"workflow_run": {"conclusions": ["failure"], "types": ["completed"], "workflows": ["haiku"]}
+		},
+		"tools": ["github/update_issue_body"],
+		"permissions": {"issues": "write"},
+		"created_at": "2026-05-19T17:37:00.145883739Z",
+		"updated_at": "2026-05-19T17:37:05.839761776Z",
+		"created_by": {"id": 1, "login": "octocat", "node_id": "MDQ6VXNlcjE=", "url": "https://github.com/octocat"}
+	}`
+
+	var wf JSONWorkflow
+	require.NoError(t, json.Unmarshal([]byte(raw), &wf), "unmarshal must succeed")
+
+	gen, err := ConvertJSONWorkflowToMarkdown(&wf, ConvertOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "0be2cc4b-de12-43fe-ada7-55ef6dc8f3ba", gen.Filename, "filename from id")
+	assert.Contains(t, gen.Markdown, "# issue triage", "heading from name")
+
+	// Multi-trigger → map form (not string shorthand)
+	assert.Contains(t, gen.Markdown, "on:", "on: block present")
+	assert.Contains(t, gen.Markdown, `"issues"`, "issues trigger present")
+	assert.Contains(t, gen.Markdown, `"workflow_run"`, "workflow_run trigger present")
+	assert.Contains(t, gen.Markdown, `"haiku"`, "workflow name present")
+	assert.NotContains(t, gen.Markdown, "on: hourly", "must not use shorthand for multi-trigger")
+
+	// tools → gh-aw toolsets
+	assert.Contains(t, gen.Markdown, "tools:", "tools block present")
+	assert.Contains(t, gen.Markdown, `"issues"`, "issues toolset from update_issue_body")
+
+	// permissions → frontmatter
+	assert.Contains(t, gen.Markdown, "permissions:", "permissions block present")
+	assert.Contains(t, gen.Markdown, `"write"`, "issues:write permission")
+
+	// prompt → body
+	assert.Contains(t, gen.Markdown, "Summarize issue.", "prompt in body")
+
+	// Warnings for query and conclusions (no gh-aw equivalent)
+	hasQueryWarn, hasConclusionsWarn := false, false
+	for _, w := range gen.Warnings {
+		if strings.Contains(w, "query") {
+			hasQueryWarn = true
+		}
+		if strings.Contains(w, "conclusions") {
+			hasConclusionsWarn = true
+		}
+	}
+	assert.True(t, hasQueryWarn, "expected warning about issues.query")
+	assert.True(t, hasConclusionsWarn, "expected warning about workflow_run.conclusions")
+
+	// disabled, disabled_state, created_at, updated_at, created_by → Extra comments
+	assert.Contains(t, gen.Markdown, "# Unsupported fields preserved from source JSON:", "extra comment header")
+	for _, field := range []string{"disabled", "created_at", "updated_at", "created_by"} {
+		found := false
+		for _, w := range gen.Warnings {
+			if strings.Contains(w, field) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected warning for extra field %q", field)
 	}
 }
 

--- a/pkg/cli/jsonworkflow_to_markdown_test.go
+++ b/pkg/cli/jsonworkflow_to_markdown_test.go
@@ -213,7 +213,7 @@ func TestConvertJSONWorkflowToMarkdown_IntervalTrigger(t *testing.T) {
 	}
 	for _, field := range []string{"prompt", "triggers"} {
 		for _, w := range gen.Warnings {
-			assert.False(t, strings.Contains(w, field), "unexpected warning mentioning %q: %s", field, w)
+			assert.NotContains(t, w, field, "unexpected warning mentioning %q: %s", field, w)
 		}
 	}
 }
@@ -293,6 +293,17 @@ func TestConvertJSONWorkflowToMarkdown_MultiTriggerWithTools(t *testing.T) {
 		}
 		assert.True(t, found, "expected warning for extra field %q", field)
 	}
+}
+
+func TestConvertTriggersToOn_SkipsIncompleteWorkflowRun(t *testing.T) {
+	on, warnings := convertTriggersToOn(&JSONWorkflowTriggers{
+		WorkflowRun: &WorkflowRunTrigger{
+			Workflows: []string{"haiku"},
+		},
+	})
+
+	assert.Nil(t, on)
+	assert.Contains(t, warnings, `triggers.workflow_run requires non-empty workflows and types; skipped`)
 }
 
 func TestGenericURLWorkflowName(t *testing.T) {


### PR DESCRIPTION
## Why

The `add --wizard` command can import workflows from JSON payloads (Copilot automation API). Previously, the `prompt`, `triggers`, `tools`, and `permissions` fields all fell through to unrecognized-field comments rather than being translated into first-class gh-aw frontmatter. This PR completes that mapping.

## What changed

**Trigger mapping** (`triggers` -> `on:`)
- `interval: hourly/daily/weekly` -> gh-aw fuzzy schedule expressions (`every 1h`, `daily`, `weekly`) -- NOT raw cron; the compiler randomises cron at compile time
- Single interval trigger emits the inline shorthand (`on: daily`); multiple triggers use the map form
- `issues` -> `on: issues: types: [...]`; warns when `query` filter is present (no gh-aw equivalent)
- `workflow_run` -> `on: workflow_run: workflows: [...] types: [...]`; warns on `conclusions` filter

**Tool mapping** (`tools` -> `tools:`)
- 40-entry lookup table maps GitHub tool IDs to gh-aw toolsets (`issues`, `pull-requests`, `repos`, etc.)
- `execute` -> `bash: "*"` (with a review warning)
- `web_search` -> `web-search:` (direct mapping, underscore->hyphen normalised)
- Built-in read/edit/search tools are silently skipped (no config needed)
- Unknown tools emit a per-tool warning

**Other fields**
- `prompt` is used as the workflow body when `instructions` is absent
- `permissions` map is passed through to the `permissions:` frontmatter block

## Test coverage

Two anonymized real-world API payloads are used as test cases:
- `IntervalTrigger` - single interval trigger, prompt-as-body
- `MultiTriggerWithTools` - issues + workflow_run triggers, tool migration, permissions, Extra warnings