### PR TITLE
fix: propagate sparse-checkout patterns and fetch-depth to safe_outputs checkout

### DIFF
--- a/pkg/workflow/compiler_safe_outputs_steps.go
+++ b/pkg/workflow/compiler_safe_outputs_steps.go
@@ -47,8 +47,14 @@ func (c *Compiler) buildSharedPRCheckoutSteps(data *WorkflowData) []string {
 	consolidatedSafeOutputsStepsLog.Print("Building shared PR checkout steps")
 	var steps []string
 	fetchDepth := 1
+	var sparsePatterns []string
 
-	if defaultCheckout := NewCheckoutManager(data.CheckoutConfigs).GetDefaultCheckoutOverride(); defaultCheckout != nil && defaultCheckout.fetchDepth != nil {
+	// Build a single CheckoutManager so we can query both the default and cross-repo entries.
+	checkoutMgr := NewCheckoutManager(data.CheckoutConfigs)
+
+	// Same-repo fallback: use the default (workspace-root) checkout's fetch-depth.
+	// Overridden below for cross-repo targets once targetRepoSlug is known.
+	if defaultCheckout := checkoutMgr.GetDefaultCheckoutOverride(); defaultCheckout != nil && defaultCheckout.fetchDepth != nil {
 		fetchDepth = *defaultCheckout.fetchDepth
 		consolidatedSafeOutputsStepsLog.Printf("Using custom checkout fetch-depth for safe_outputs: %d", fetchDepth)
 	}
@@ -88,6 +94,24 @@ func (c *Compiler) buildSharedPRCheckoutSteps(data *WorkflowData) []string {
 	} else if c.trialMode && c.trialLogicalRepoSlug != "" {
 		targetRepoSlug = c.trialLogicalRepoSlug
 		consolidatedSafeOutputsStepsLog.Printf("Using trialLogicalRepoSlug: %s", targetRepoSlug)
+	}
+
+	// For cross-repo targets, override fetch-depth and sparse-checkout patterns
+	// from the checkout: config entry that targets the same repository.  The agent
+	// job already uses these values; the safe_outputs job must mirror them so that
+	// (a) large repos are not checked out in full unnecessarily and (b) the working
+	// tree is consistent with what the agent operated on.
+	if targetRepoSlug != "" {
+		if targetEntry := checkoutMgr.GetCheckoutForRepository(targetRepoSlug); targetEntry != nil {
+			if targetEntry.fetchDepth != nil {
+				fetchDepth = *targetEntry.fetchDepth
+				consolidatedSafeOutputsStepsLog.Printf("Using checkout fetch-depth for cross-repo target %s: %d", targetRepoSlug, fetchDepth)
+			}
+			if len(targetEntry.sparsePatterns) > 0 {
+				sparsePatterns = targetEntry.sparsePatterns
+				consolidatedSafeOutputsStepsLog.Printf("Using %d sparse-checkout pattern(s) for cross-repo target %s", len(sparsePatterns), targetRepoSlug)
+			}
+		}
 	}
 
 	// Determine the ref (branch) to checkout
@@ -149,6 +173,12 @@ func (c *Compiler) buildSharedPRCheckoutSteps(data *WorkflowData) []string {
 		steps = append(steps, fmt.Sprintf("          token: %s\n", checkoutToken))
 		steps = append(steps, "          persist-credentials: false\n")
 		steps = append(steps, fmt.Sprintf("          fetch-depth: %d\n", fetchDepth))
+		if len(sparsePatterns) > 0 {
+			steps = append(steps, "          sparse-checkout: |\n")
+			for _, pattern := range sparsePatterns {
+				steps = append(steps, fmt.Sprintf("            %s\n", strings.TrimSpace(pattern)))
+			}
+		}
 	}
 
 	// Step 1b: Checkout repository with conditional execution
@@ -172,6 +202,12 @@ func (c *Compiler) buildSharedPRCheckoutSteps(data *WorkflowData) []string {
 	steps = append(steps, fmt.Sprintf("          token: %s\n", checkoutToken))
 	steps = append(steps, "          persist-credentials: false\n")
 	steps = append(steps, fmt.Sprintf("          fetch-depth: %d\n", fetchDepth))
+	if len(sparsePatterns) > 0 {
+		steps = append(steps, "          sparse-checkout: |\n")
+		for _, pattern := range sparsePatterns {
+			steps = append(steps, fmt.Sprintf("            %s\n", strings.TrimSpace(pattern)))
+		}
+	}
 
 	// Step 2: Configure Git credentials with conditional execution
 	// Security: Pass GitHub token through environment variable to prevent template injection
@@ -207,7 +243,6 @@ func (c *Compiler) buildSharedPRCheckoutSteps(data *WorkflowData) []string {
 	// Without this, applyBundleToBranch must fall back to per-SHA git fetch (prerequisite
 	// recovery), which requires uploadpack.allowReachableSHA1InWant on the server.
 	if targetRepoSlug != "" {
-		checkoutMgr := NewCheckoutManager(data.CheckoutConfigs)
 		if matchedEntry := checkoutMgr.GetCheckoutForRepository(targetRepoSlug); matchedEntry != nil && len(matchedEntry.fetchRefs) > 0 {
 			consolidatedSafeOutputsStepsLog.Printf("Adding fetch refs step for cross-repo target %s (%d refs)", targetRepoSlug, len(matchedEntry.fetchRefs))
 			if fetchStep := buildSafeOutputsFetchRefsStep(targetRepoSlug, checkoutToken, matchedEntry.fetchRefs, RenderCondition(condition)); fetchStep != "" {

--- a/pkg/workflow/compiler_safe_outputs_steps.go
+++ b/pkg/workflow/compiler_safe_outputs_steps.go
@@ -52,11 +52,18 @@ func (c *Compiler) buildSharedPRCheckoutSteps(data *WorkflowData) []string {
 	// Build a single CheckoutManager so we can query both the default and cross-repo entries.
 	checkoutMgr := NewCheckoutManager(data.CheckoutConfigs)
 
-	// Same-repo fallback: use the default (workspace-root) checkout's fetch-depth.
-	// Overridden below for cross-repo targets once targetRepoSlug is known.
-	if defaultCheckout := checkoutMgr.GetDefaultCheckoutOverride(); defaultCheckout != nil && defaultCheckout.fetchDepth != nil {
-		fetchDepth = *defaultCheckout.fetchDepth
-		consolidatedSafeOutputsStepsLog.Printf("Using custom checkout fetch-depth for safe_outputs: %d", fetchDepth)
+	// Same-repo fallback: use the default (workspace-root) checkout's fetch-depth and
+	// sparse-checkout patterns. Both are overridden below for cross-repo targets once
+	// targetRepoSlug is known.
+	if defaultCheckout := checkoutMgr.GetDefaultCheckoutOverride(); defaultCheckout != nil {
+		if defaultCheckout.fetchDepth != nil {
+			fetchDepth = *defaultCheckout.fetchDepth
+			consolidatedSafeOutputsStepsLog.Printf("Using custom checkout fetch-depth for safe_outputs: %d", fetchDepth)
+		}
+		if len(defaultCheckout.sparsePatterns) > 0 {
+			sparsePatterns = defaultCheckout.sparsePatterns
+			consolidatedSafeOutputsStepsLog.Printf("Using %d sparse-checkout pattern(s) from default checkout for safe_outputs", len(sparsePatterns))
+		}
 	}
 
 	// Determine which token to use for checkout

--- a/pkg/workflow/compiler_safe_outputs_steps_test.go
+++ b/pkg/workflow/compiler_safe_outputs_steps_test.go
@@ -471,6 +471,29 @@ func TestBuildSharedPRCheckoutSteps(t *testing.T) {
 				"fetch-depth: 0",
 			},
 		},
+		{
+			name: "same-repo sparse-checkout from default checkout override propagates to safe_outputs",
+			safeOutputs: &SafeOutputsConfig{
+				CreatePullRequests: &CreatePullRequestsConfig{
+					BaseSafeOutputConfig: BaseSafeOutputConfig{
+						GitHubToken: "${{ secrets.GITHUB_TOKEN }}",
+					},
+					// No TargetRepoSlug: same-repo operation
+				},
+			},
+			checkoutConfigs: []*CheckoutConfig{
+				{
+					// Default workspace-root checkout with sparse patterns
+					SparseCheckout: ".github\napp\nlib",
+				},
+			},
+			checkContains: []string{
+				"sparse-checkout: |",
+				"            .github",
+				"            app",
+				"            lib",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/workflow/compiler_safe_outputs_steps_test.go
+++ b/pkg/workflow/compiler_safe_outputs_steps_test.go
@@ -406,6 +406,71 @@ func TestBuildSharedPRCheckoutSteps(t *testing.T) {
 				"contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')",
 			},
 		},
+		{
+			name: "cross-repo with sparse-checkout patterns propagates them to safe_outputs checkout",
+			safeOutputs: &SafeOutputsConfig{
+				CreatePullRequests: &CreatePullRequestsConfig{
+					BaseSafeOutputConfig: BaseSafeOutputConfig{
+						GitHubToken: "${{ secrets.CROSS_PAT }}",
+					},
+					TargetRepoSlug: "org/monorepo",
+					BaseBranch:     "main",
+				},
+			},
+			checkoutConfigs: []*CheckoutConfig{
+				{
+					Repository:     "org/monorepo",
+					SparseCheckout: ".github\nscripts\ntest",
+				},
+			},
+			checkContains: []string{
+				"sparse-checkout: |",
+				"            .github",
+				"            scripts",
+				"            test",
+			},
+		},
+		{
+			name: "cross-repo without sparse-checkout does not emit sparse-checkout block",
+			safeOutputs: &SafeOutputsConfig{
+				CreatePullRequests: &CreatePullRequestsConfig{
+					TargetRepoSlug: "org/full-repo",
+				},
+			},
+			checkoutConfigs: []*CheckoutConfig{
+				{
+					Repository: "org/full-repo",
+				},
+			},
+			checkNotContains: []string{
+				"sparse-checkout:",
+			},
+		},
+		{
+			name: "cross-repo fetch-depth is read from checkout config for target repo, not default override",
+			safeOutputs: &SafeOutputsConfig{
+				CreatePullRequests: &CreatePullRequestsConfig{
+					TargetRepoSlug: "org/target",
+				},
+			},
+			checkoutConfigs: []*CheckoutConfig{
+				{
+					// The "default" checkout (empty repo/path) has a different fetch-depth.
+					// The cross-repo entry's fetch-depth should win for the safe_outputs checkout.
+					FetchDepth: func() *int { d := 0; return &d }(),
+				},
+				{
+					Repository: "org/target",
+					FetchDepth: func() *int { d := 10; return &d }(),
+				},
+			},
+			checkContains: []string{
+				"fetch-depth: 10",
+			},
+			checkNotContains: []string{
+				"fetch-depth: 0",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Propagates `sparse-checkout` patterns and `fetch-depth` from `CheckoutConfig` entries into the generated `safe_outputs` checkout steps. Previously, these settings were silently dropped, causing `safe_outputs` jobs to check out more code than intended and ignore custom fetch depths.

## Changes

### `pkg/workflow/compiler_safe_outputs_steps.go`
- Extended `buildSharedPRCheckoutSteps` to read `sparse-checkout` patterns from matching `CheckoutConfig` entries and emit them into the generated checkout step.
- Covers both **same-repo** targets (via the default checkout override) and **cross-repo** targets.
- Also propagates `fetch-depth` for cross-repo checkout configs.

### `pkg/workflow/compiler_safe_outputs_steps_test.go`
- Added four new test cases:
  1. Sparse-checkout pattern propagation for **cross-repo** targets.
  2. Sparse-checkout pattern propagation for **same-repo** (default override) targets.
  3. Absence of the `sparse-checkout` block when no patterns are configured (regression guard).
  4. Correct `fetch-depth` priority between default and cross-repo checkout entries.

## Why

`safe_outputs` jobs synthesise their own checkout steps independently of the caller's workflow steps. Any `sparse-checkout` or `fetch-depth` settings declared in `CheckoutConfig` were not being forwarded, meaning `safe_outputs` jobs always performed a full checkout — defeating the intent of the configuration and potentially making jobs slower or accessing unintended files.

## Risk

**Low.** The change is additive: when no sparse-checkout patterns are present the generated steps are identical to before. New behaviour only activates when the caller has explicitly configured patterns in `CheckoutConfig`.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/26608475881) for issue #35593 · sonnet46 997.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26608475881, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/26608475881 -->