### PR TITLE
fix: emit filter:'' in agent checkout when sparse-checkout is enabled (#35947)

### DIFF
--- a/docs/sparseness.md
+++ b/docs/sparseness.md
@@ -1,0 +1,86 @@
+# Sparse Checkout, Blobless Clones, and Credential Lifecycle
+
+This document explains how `actions/checkout@v6` interacts with sparse-checkout and blobless clones in gh-aw compiled workflows, and why the agent job and safe_outputs job require different treatment.
+
+## Background: Clone Modes
+
+Git supports three orthogonal mechanisms for reducing clone size:
+
+| Mechanism | Flag | Effect | Offline checkout? |
+|-----------|------|--------|-------------------|
+| Shallow clone | `--depth=N` | Downloads only last N commits (commit + tree + blob objects) | Yes — all blobs present for commits in window |
+| Sparse checkout | `sparse-checkout` | Filters which paths appear in working tree; does not affect object fetching | Yes — purely a working-tree filter |
+| Blobless/partial clone | `--filter=blob:none` | Omits blob objects entirely; configures a "promisor remote" for lazy fetches | **No** — any operation needing file content triggers a network fetch |
+
+**Key insight**: `--filter=blob:none` is the only setting that prevents offline git operations. Shallow and sparse are both safe for agents.
+
+## How `actions/checkout@v6` Introduces Blobless
+
+When `sparse-checkout` is specified with a non-zero `fetch-depth`, `actions/checkout@v6` automatically adds `--filter=blob:none` as a bandwidth optimization. This configures the repository as a partial clone with a "promisor remote" in `.git/config`:
+
+```ini
+[remote "origin"]
+    partialclonefilter = blob:none
+    promisor = true
+```
+
+Once configured, git will lazily fetch missing blobs from the promisor remote on demand — but only if credentials are available.
+
+## Agent Job: Why Blobless Breaks
+
+Agent jobs always set `persist-credentials: false` to prevent credential exfiltration. After `actions/checkout` completes, no credentials remain on disk. The credential lifecycle is:
+
+1. **`actions/checkout`** — uses its internal token to clone and materialize working tree blobs for the sparse cone. Sets `persist-credentials: false`, so credentials are removed after the step.
+2. **Agent execution** — the agent performs arbitrary git operations (`git checkout`, `git show`, `git diff`, etc.). Any operation touching a blob not in the initial sparse cone triggers a lazy fetch from the promisor remote — which fails because no credentials exist.
+
+This means `git checkout <fetched-branch>` prompts for a username or fails with "unable to read tree", even though the branch ref is correctly available as `origin/<branch>`.
+
+### Fix: `filter: ''`
+
+The compiled workflow passes `filter: ''` (empty string) in the `actions/checkout` `with:` block when sparse-checkout is configured. This prevents `actions/checkout` from adding `--filter=blob:none`, ensuring the repository is never configured as a partial clone. All blobs within the shallow window are downloaded upfront.
+
+This is only emitted when sparse-checkout patterns are present, since that is the condition under which `actions/checkout@v6` would automatically add the blobless filter.
+
+**Size impact**: For a large repository (e.g. github/github) with a typical sparse-checkout pattern, removing blobless increases the initial checkout from ~500 MB to ~1.3 GB (~800 MB extra, ~8-15 seconds on a GH runner). This is far preferable to agent failures and 4+ minutes of wasted retry time.
+
+## Safe Outputs Job: Why Blobless is Safe
+
+The safe_outputs job has a different credential lifecycle that makes blobless clones safe:
+
+1. **`actions/checkout`** with `persist-credentials: false` — checks out the base branch. `actions/checkout` uses its own internal token to materialize working tree blobs during this step, so the initial checkout succeeds.
+
+2. **"Configure Git credentials" step** — runs immediately after checkout and embeds the token directly in the remote URL:
+   ```bash
+   git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL}/${REPO_NAME}.git"
+   ```
+   From this point forward, any lazy blob fetch from the promisor remote will authenticate successfully via the embedded URL credentials.
+
+3. **`applyBundleToBranch`** — applies the agent's git bundle, then calls `git checkout <branch>` and `git reset --hard`. These operations may trigger lazy blob fetches, but they succeed because the remote URL has embedded credentials from step 2.
+
+4. **Push** — uses either the GraphQL signed-commits API (no git needed) or `git push` with the same token-embedded remote URL.
+
+### The Fetch Refs Optimization
+
+The safe_outputs job's "Fetch additional refs" step (in `compiler_safe_outputs_steps.go`) explicitly uses `--filter=blob:none` when fetching refs declared in `checkout.fetch`. This is correct because:
+
+- These refs are fetched solely to make bundle prerequisite commits reachable locally
+- They are never checked out in the safe_outputs job
+- Their blob objects are genuinely unnecessary
+- Credentials are available via the embedded remote URL if needed
+
+## Summary Table
+
+| Job | `persist-credentials` | Credentials after checkout | Blobless safe? | Action taken |
+|-----|----------------------|---------------------------|----------------|--------------|
+| Agent | `false` | None | **No** | Emit `filter: ''` to prevent blobless |
+| Safe outputs | `false` | Re-added via `git remote set-url` | Yes | Allow blobless (bandwidth optimization) |
+| Activation | `false` | None | Yes* | No action needed |
+
+\* The activation job only checks out `.github` and `.agents` folders — it never performs arbitrary git operations on other branches.
+
+## Related
+
+- Issue: [#35947](https://github.com/github/gh-aw/issues/35947)
+- Source (agent job): `pkg/workflow/checkout_step_generator.go`
+- Source (safe_outputs job): `pkg/workflow/compiler_safe_outputs_steps.go`
+- Source (bundle application): `actions/setup/js/create_pull_request.cjs` (`applyBundleToBranch`)

--- a/pkg/workflow/checkout_manager_test.go
+++ b/pkg/workflow/checkout_manager_test.go
@@ -179,6 +179,16 @@ func TestGenerateDefaultCheckoutStep(t *testing.T) {
 		assert.Contains(t, combined, "sparse-checkout: |", "should include sparse-checkout header")
 		assert.Contains(t, combined, ".github/", "should include first pattern")
 		assert.Contains(t, combined, "src/", "should include second pattern")
+		assert.Contains(t, combined, "filter: ''", "sparse-checkout should emit filter:'' to prevent blobless clone")
+	})
+
+	t.Run("no filter emitted without sparse-checkout", func(t *testing.T) {
+		cm := NewCheckoutManager([]*CheckoutConfig{
+			{Ref: "develop"},
+		})
+		lines := cm.GenerateDefaultCheckoutStep(false, "", getPin)
+		combined := strings.Join(lines, "")
+		assert.NotContains(t, combined, "filter:", "should not emit filter when no sparse-checkout")
 	})
 
 	t.Run("force-clean-git-credentials enables persist true and cleanup step", func(t *testing.T) {
@@ -257,6 +267,25 @@ func TestGenerateAdditionalCheckoutSteps(t *testing.T) {
 		combined := strings.Join(lines, "")
 		assert.Contains(t, combined, "persist-credentials: true", "force-clean-git-credentials should switch persist-credentials to true")
 		assert.Contains(t, combined, "Clean git credentials after checkout", "should inject post-checkout clean step")
+	})
+
+	t.Run("additional checkout with sparse-checkout emits filter empty", func(t *testing.T) {
+		cm := NewCheckoutManager([]*CheckoutConfig{
+			{Path: "./libs", Repository: "owner/libs", SparseCheckout: "src/\nlib/"},
+		})
+		lines := cm.GenerateAdditionalCheckoutSteps(getPin)
+		combined := strings.Join(lines, "")
+		assert.Contains(t, combined, "sparse-checkout: |", "should include sparse-checkout header")
+		assert.Contains(t, combined, "filter: ''", "sparse-checkout should emit filter:'' to prevent blobless clone")
+	})
+
+	t.Run("additional checkout without sparse-checkout does not emit filter", func(t *testing.T) {
+		cm := NewCheckoutManager([]*CheckoutConfig{
+			{Path: "./libs", Repository: "owner/libs"},
+		})
+		lines := cm.GenerateAdditionalCheckoutSteps(getPin)
+		combined := strings.Join(lines, "")
+		assert.NotContains(t, combined, "filter:", "should not emit filter when no sparse-checkout")
 	})
 }
 

--- a/pkg/workflow/checkout_step_generator.go
+++ b/pkg/workflow/checkout_step_generator.go
@@ -309,7 +309,7 @@ func generateCheckoutStepLines(entry *resolvedCheckout, index int, getActionPin 
 		}
 		// Prevent actions/checkout from adding --filter=blob:none when sparse-checkout
 		// is specified. Blobless clones require credentials for lazy blob fetches, but
-		// agent jobs use persist-credentials: false, making offline git operations fail.
+		// agent jobs intentionally do not retain git credentials after checkout, making offline git operations fail.
 		sb.WriteString("          filter: ''\n")
 	}
 	if entry.submodules != "" {

--- a/pkg/workflow/checkout_step_generator.go
+++ b/pkg/workflow/checkout_step_generator.go
@@ -193,6 +193,12 @@ func (cm *CheckoutManager) GenerateDefaultCheckoutStep(
 		if override.ref != "" {
 			fmt.Fprintf(&sb, "          ref: %s\n", override.ref)
 		}
+		// Prevent actions/checkout from adding --filter=blob:none when sparse-checkout
+		// is specified. Blobless clones require credentials for lazy blob fetches, but
+		// agent jobs use persist-credentials: false, making offline git operations fail.
+		if len(override.sparsePatterns) > 0 {
+			sb.WriteString("          filter: ''\n")
+		}
 		// Determine effective token: github-app-minted token takes precedence
 		effectiveOverrideToken := override.token
 		if override.githubApp != nil {
@@ -301,6 +307,10 @@ func generateCheckoutStepLines(entry *resolvedCheckout, index int, getActionPin 
 		for _, pattern := range entry.sparsePatterns {
 			fmt.Fprintf(&sb, "            %s\n", strings.TrimSpace(pattern))
 		}
+		// Prevent actions/checkout from adding --filter=blob:none when sparse-checkout
+		// is specified. Blobless clones require credentials for lazy blob fetches, but
+		// agent jobs use persist-credentials: false, making offline git operations fail.
+		sb.WriteString("          filter: ''\n")
 	}
 	if entry.submodules != "" {
 		fmt.Fprintf(&sb, "          submodules: %s\n", entry.submodules)

--- a/pkg/workflow/checkout_step_generator.go
+++ b/pkg/workflow/checkout_step_generator.go
@@ -195,7 +195,7 @@ func (cm *CheckoutManager) GenerateDefaultCheckoutStep(
 		}
 		// Prevent actions/checkout from adding --filter=blob:none when sparse-checkout
 		// is specified. Blobless clones require credentials for lazy blob fetches, but
-		// agent jobs use persist-credentials: false, making offline git operations fail.
+		// agent jobs intentionally do not retain git credentials after checkout, making offline git operations fail.
 		if len(override.sparsePatterns) > 0 {
 			sb.WriteString("          filter: ''\n")
 		}


### PR DESCRIPTION
## Summary

Fixes a bug where agent jobs using sparse-checkout would silently fail due to `actions/checkout` enabling blobless clones when a `filter` value is not explicitly set. When sparse-checkout is active, blobless clones require persistent credentials for subsequent `git fetch` calls — credentials that are not available in agent job contexts. This PR emits `filter: ''` in generated checkout steps whenever sparse-checkout patterns are present, disabling blobless clone behaviour and restoring pull request findability.

## Changes

### `pkg/workflow/checkout_step_generator.go` — Bug Fix _(high impact)_
- Emits `filter: ''` in both the **default** and **additional** checkout step generators when sparse-checkout patterns are configured.
- Prevents `actions/checkout` from implicitly enabling blobless clones that would fail in agent contexts lacking persistent credentials.

### `pkg/workflow/checkout_manager_test.go` — Tests _(medium impact)_
- Adds test cases asserting `filter: ''` is present in checkout steps when sparse-checkout is configured.
- Adds complementary test cases asserting no `filter` key is emitted when sparse-checkout is absent.
- Covers both default and additional checkout step paths.

### `docs/sparseness.md` — Documentation _(low impact, new file)_
- New technical reference document explaining the interaction between sparse-checkout and blobless clones.
- Documents why `filter: ''` must be explicitly emitted for agent jobs when sparse-checkout is enabled.
- Covers the difference in behaviour between agent jobs and `safe_outputs` jobs.

## Motivation

`actions/checkout` enables blobless clones by default when a sparse-checkout pattern list is provided. Blobless clones defer blob fetching and require that git credentials remain available beyond the initial checkout step. Agent jobs do not retain these credentials, causing subsequent `git` operations (including pull request discovery) to fail. Explicitly passing `filter: ''` suppresses the blobless clone and ensures a standard full-content sparse checkout that works without persistent credentials.

## Testing

- Unit tests added in `checkout_manager_test.go` covering the presence and absence of `filter: ''` under sparse-checkout conditions.
- No breaking changes. No changes to public APIs or schema.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/26689023226) for issue #35949 · sonnet46 1.1M · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.55, model: claude-sonnet-4.6, id: 26689023226, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/26689023226 -->