### PR TITLE
fix: activation comment uses wrong repo/client and fires on empty commits

### DIFF
--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -1172,9 +1172,9 @@ async function main(config = {}) {
     // These are noise — they don't represent meaningful work and would clutter PRs on every scheduled run.
     if (hasChanges) {
       let isEmptyCommit = false;
-      if (remoteHeadBeforePatch) {
+      if (rangeBaseRef) {
         try {
-          const { stdout: diffStat } = await exec.getExecOutput("git", ["diff", "--stat", remoteHeadBeforePatch, "HEAD"], baseGitOpts);
+          const { stdout: diffStat } = await exec.getExecOutput("git", ["diff", "--stat", rangeBaseRef, "HEAD"], baseGitOpts);
           isEmptyCommit = !diffStat.trim();
           if (isEmptyCommit) {
             core.info("Skipping activation comment: pushed commit has no file changes (empty commit)");

--- a/actions/setup/js/push_to_pull_request_branch.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.cjs
@@ -1164,10 +1164,32 @@ async function main(config = {}) {
     // Update the activation comment with commit link (if a comment was created and changes were pushed)
     // Pass pullNumber so a new comment is created on the PR when no activation comment exists (e.g., schedule triggers)
     //
-    // NOTE: we pass 'github' (global octokit) instead of githubClient (repo-scoped octokit) because the issue is created
-    // in the same repo as the activation, so the global client has the correct context for updating the comment.
+    // NOTE: we pass 'github' (global octokit) for updating the activation comment (same repo as workflow).
+    // For the fallback path (no activation comment), we pass githubClient and targetRepo so the comment
+    // is created in the correct target repository with the right authentication.
+    //
+    // Skip the activation comment for empty commits (0 file changes, e.g. CI trigger commits).
+    // These are noise — they don't represent meaningful work and would clutter PRs on every scheduled run.
     if (hasChanges) {
-      await updateActivationCommentWithCommit(github, context, core, commitSha, commitUrl, { targetIssueNumber: pullNumber });
+      let isEmptyCommit = false;
+      if (remoteHeadBeforePatch) {
+        try {
+          const { stdout: diffStat } = await exec.getExecOutput("git", ["diff", "--stat", remoteHeadBeforePatch, "HEAD"], baseGitOpts);
+          isEmptyCommit = !diffStat.trim();
+          if (isEmptyCommit) {
+            core.info("Skipping activation comment: pushed commit has no file changes (empty commit)");
+          }
+        } catch {
+          // Non-fatal — proceed with the comment if we can't determine
+        }
+      }
+      if (!isEmptyCommit) {
+        await updateActivationCommentWithCommit(github, context, core, commitSha, commitUrl, {
+          targetIssueNumber: pullNumber,
+          targetRepo: `${repoParts.owner}/${repoParts.repo}`,
+          targetGithubClient: githubClient,
+        });
+      }
     }
 
     // Write summary to GitHub Actions summary

--- a/actions/setup/js/push_to_pull_request_branch.test.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.test.cjs
@@ -783,7 +783,9 @@ index 0000000..abc1234
         mockExec.getExecOutput
           .mockResolvedValueOnce({ exitCode: 0, stdout: "preflight-sha\trefs/heads/feature-branch\n", stderr: "" }) // preflight ls-remote
           .mockResolvedValueOnce({ exitCode: 0, stdout: "local-head-before\n", stderr: "" }) // rev-parse HEAD before patch
-          .mockResolvedValueOnce({ exitCode: 0, stdout: "1\n", stderr: "" }); // rev-list --count
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "0\n", stderr: "" }) // rev-list --merges --count (no merge commits)
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "1\n", stderr: "" }) // rev-list --count (new commits)
+          .mockResolvedValueOnce({ exitCode: 0, stdout: " file.txt | 1 +\n 1 file changed, 1 insertion(+)\n", stderr: "" }); // git diff --stat (non-empty = has file changes)
 
         const module = await loadModule();
         const handler = await module.main({});
@@ -792,7 +794,40 @@ index 0000000..abc1234
         expect(result.success).toBe(true);
         expect(result.commit_sha).toBe("remote-head-after");
         expect(result.commit_url).toContain("/commit/remote-head-after");
-        expect(updateCommitSpy).toHaveBeenCalledWith(mockGithub, mockContext, mockCore, "remote-head-after", "https://github.com/test-owner/test-repo/commit/remote-head-after", { targetIssueNumber: 123 });
+        expect(updateCommitSpy).toHaveBeenCalledWith(mockGithub, mockContext, mockCore, "remote-head-after", "https://github.com/test-owner/test-repo/commit/remote-head-after", {
+          targetIssueNumber: 123,
+          targetRepo: "test-owner/test-repo",
+          targetGithubClient: expect.anything(),
+        });
+      } finally {
+        pushSignedSpy.mockRestore();
+        updateCommitSpy.mockRestore();
+      }
+    });
+
+    it("should skip activation comment for empty commits (no file changes)", async () => {
+      const patchPath = createPatchFile();
+      const updateActivationCommentModule = require("./update_activation_comment.cjs");
+      const updateCommitSpy = vi.spyOn(updateActivationCommentModule, "updateActivationCommentWithCommit").mockResolvedValue(undefined);
+      const pushSignedCommitsModule = require("./push_signed_commits.cjs");
+      const pushSignedSpy = vi.spyOn(pushSignedCommitsModule, "pushSignedCommits").mockResolvedValue("remote-head-after");
+
+      try {
+        mockExec.getExecOutput
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "preflight-sha\trefs/heads/feature-branch\n", stderr: "" }) // preflight ls-remote
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "local-head-before\n", stderr: "" }) // rev-parse HEAD before patch
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "0\n", stderr: "" }) // rev-list --merges --count (no merge commits)
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "1\n", stderr: "" }) // rev-list --count (new commits)
+          .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" }); // git diff --stat (empty = no file changes)
+
+        const module = await loadModule();
+        const handler = await module.main({});
+        const result = await handler({ patch_path: patchPath }, {});
+
+        expect(result.success).toBe(true);
+        expect(result.commit_sha).toBe("remote-head-after");
+        expect(mockCore.info).toHaveBeenCalledWith("Skipping activation comment: pushed commit has no file changes (empty commit)");
+        expect(updateCommitSpy).not.toHaveBeenCalled();
       } finally {
         pushSignedSpy.mockRestore();
         updateCommitSpy.mockRestore();

--- a/actions/setup/js/update_activation_comment.cjs
+++ b/actions/setup/js/update_activation_comment.cjs
@@ -43,6 +43,8 @@ async function updateActivationComment(github, context, core, itemUrl, itemNumbe
  * @param {string} commitUrl - URL of the commit
  * @param {object} [options] - Optional configuration
  * @param {number} [options.targetIssueNumber] - PR/issue number to post a new comment on if no activation comment exists
+ * @param {string} [options.targetRepo] - Target repo "owner/repo" for fallback comment (cross-repo scenarios)
+ * @param {any} [options.targetGithubClient] - Authenticated GitHub client for the target repo (cross-repo scenarios)
  */
 async function updateActivationCommentWithCommit(github, context, core, commitSha, commitUrl, options = {}) {
   const shortSha = commitSha.substring(0, 7);
@@ -65,6 +67,8 @@ async function updateActivationCommentWithCommit(github, context, core, commitSh
  * @param {string} label - Optional label for log messages (e.g., "pull request", "issue", "commit")
  * @param {object} [options] - Optional configuration
  * @param {number} [options.targetIssueNumber] - PR/issue number to post a new comment on if no activation comment exists
+ * @param {string} [options.targetRepo] - Target repo "owner/repo" for fallback comment (cross-repo scenarios)
+ * @param {any} [options.targetGithubClient] - Authenticated GitHub client for the target repo (cross-repo scenarios)
  */
 async function updateActivationCommentWithMessage(github, context, core, message, label = "", options = {}) {
   const commentId = process.env.GH_AW_COMMENT_ID;
@@ -187,12 +191,25 @@ async function updateActivationCommentWithMessage(github, context, core, message
     // Determine target issue/PR number: explicit option, or from event payload
     const targetNumber = options.targetIssueNumber || context.payload?.issue?.number || context.payload?.pull_request?.number;
     if (targetNumber) {
-      core.info(`No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on #${targetNumber}`);
+      // For cross-repo scenarios, use the explicitly provided target repo and client
+      // so the fallback comment is created in the correct repository
+      let fallbackOwner = repoOwner;
+      let fallbackRepo = repoName;
+      if (options.targetRepo) {
+        const parts = options.targetRepo.split("/");
+        if (parts.length === 2) {
+          fallbackOwner = parts[0];
+          fallbackRepo = parts[1];
+        }
+      }
+      const fallbackClient = options.targetGithubClient || github;
+
+      core.info(`No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on ${fallbackOwner}/${fallbackRepo}#${targetNumber}`);
       try {
         const sanitizedMessage = sanitizeContent(message);
-        const response = await github.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
-          owner: repoOwner,
-          repo: repoName,
+        const response = await fallbackClient.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+          owner: fallbackOwner,
+          repo: fallbackRepo,
           issue_number: targetNumber,
           body: sanitizedMessage,
           headers: {
@@ -205,7 +222,7 @@ async function updateActivationCommentWithMessage(github, context, core, message
         if (response?.data?.id) core.info(`Comment ID: ${response.data.id}`);
         if (response?.data?.html_url) core.info(`Comment URL: ${response.data.html_url}`);
       } catch (error) {
-        core.warning(`Failed to create comment on #${targetNumber}: ${getErrorMessage(error)}`);
+        core.warning(`Failed to create comment on ${fallbackOwner}/${fallbackRepo}#${targetNumber}: ${getErrorMessage(error)}`);
       }
     } else {
       core.info("No activation comment to update (GH_AW_COMMENT_ID not set)");

--- a/actions/setup/js/update_activation_comment.test.cjs
+++ b/actions/setup/js/update_activation_comment.test.cjs
@@ -184,7 +184,7 @@ describe("update_activation_comment.cjs", () => {
       });
       const { updateActivationComment } = createFunctionFromScript(mockDependencies);
       await updateActivationComment(mockDependencies.github, mockDependencies.context, mockDependencies.core, "https://github.com/testowner/testrepo/pull/42", 42);
-      expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on #10");
+      expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on testowner/testrepo#10");
       expect(mockDependencies.github.request).toHaveBeenCalledWith(
         "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
         expect.objectContaining({
@@ -370,7 +370,7 @@ describe("update_activation_comment.cjs", () => {
           "https://github.com/testowner/testrepo/commit/41b061a0abc1c574c8ca4344bb69961efee7b45c",
           { targetIssueNumber: 225 }
         );
-        expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on #225");
+        expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on testowner/testrepo#225");
         expect(mockDependencies.github.request).toHaveBeenCalledWith(
           "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
           expect.objectContaining({
@@ -390,7 +390,7 @@ describe("update_activation_comment.cjs", () => {
           });
           const { updateActivationCommentWithMessage } = createFunctionFromScript(mockDependencies);
           await updateActivationCommentWithMessage(mockDependencies.github, mockDependencies.context, mockDependencies.core, "\n\n✅ Test message", "test");
-          expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on #100");
+          expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on testowner/testrepo#100");
           expect(mockDependencies.github.request).toHaveBeenCalledWith("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", expect.objectContaining({ issue_number: 100 }));
         }),
         it("should use context.payload.issue.number when no targetIssueNumber and no pull_request", async () => {
@@ -401,7 +401,7 @@ describe("update_activation_comment.cjs", () => {
           });
           const { updateActivationCommentWithMessage } = createFunctionFromScript(mockDependencies);
           await updateActivationCommentWithMessage(mockDependencies.github, mockDependencies.context, mockDependencies.core, "\n\n✅ Test message", "test");
-          expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on #50");
+          expect(mockDependencies.core.info).toHaveBeenCalledWith("No activation comment to update (GH_AW_COMMENT_ID not set), creating new comment on testowner/testrepo#50");
           expect(mockDependencies.github.request).toHaveBeenCalledWith("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", expect.objectContaining({ issue_number: 50 }));
         }),
         it("should not fail if fallback comment creation fails", async () => {
@@ -416,7 +416,7 @@ describe("update_activation_comment.cjs", () => {
             "https://github.com/testowner/testrepo/commit/41b061a0abc1c574c8ca4344bb69961efee7b45c",
             { targetIssueNumber: 225 }
           );
-          expect(mockDependencies.core.warning).toHaveBeenCalledWith("Failed to create comment on #225: API rate limit exceeded");
+          expect(mockDependencies.core.warning).toHaveBeenCalledWith("Failed to create comment on testowner/testrepo#225: API rate limit exceeded");
           expect(mockDependencies.core.setFailed).not.toHaveBeenCalled();
         }),
         it("should log skip message when no activation comment, no targetIssueNumber, and no context payload", async () => {


### PR DESCRIPTION
## PR #35982 — fix: activation comment uses wrong repo/client and fires on empty commits

### Summary

Fixes two related bugs in the activation comment logic triggered during push-to-pull-request-branch flows:

1. **Wrong repo/client**: `updateActivationCommentWithCommit` was using the source repo and its GitHub client instead of the cross-repo target when creating or updating activation comments on PRs that live in a different repository.
2. **Fires on empty commits**: The activation comment was being posted even when a commit introduced no file changes (empty diff), causing spurious comment noise.

---

### Changes

#### `actions/setup/js/push_to_pull_request_branch.cjs` *(high impact)*
- Added a `git diff --stat` check before posting the activation comment; skips the comment entirely when the commit has no file changes.
- Now passes `targetRepo` and `targetGithubClient` to `updateActivationCommentWithCommit` so the correct repo context and authenticated client are used for cross-repo PRs.

#### `actions/setup/js/update_activation_comment.cjs` *(high impact)*
- Extended `updateActivationCommentWithCommit` and `updateActivationCommentWithMessage` to accept and use `targetRepo` and `targetGithubClient` options.
- Falls back to the target repo/client when creating a new comment, fixing the wrong-repo bug for cross-repo pull request scenarios.
- Updated log messages to include the `owner/repo` prefix in "creating new comment on" info strings for clearer observability.

#### `actions/setup/js/push_to_pull_request_branch.test.cjs` *(medium impact)*
- Updated existing test mocks to account for the new `git diff --stat` exec call inserted into the flow.
- Added a new test case asserting that the activation comment is **not** posted when the commit produces an empty diff.

#### `actions/setup/js/update_activation_comment.test.cjs` *(low impact)*
- Updated log message assertions to match the new `owner/repo`-prefixed "creating new comment on" format.

---

### Risk & Compatibility

| Dimension | Assessment |
|---|---|
| Breaking change | No |
| Affected runtime | JS actions only (`actions/setup/js/`) — no Go changes |
| Blast radius | Activation comment posting during cross-repo push-to-PR flows |
| Rollback safety | Safe — purely additive guards and option threading |

---

### Testing

- Existing test suite updated to mock the new `git diff --stat` exec call; all prior scenarios continue to pass.
- New unit test covers the empty-commit skip path explicitly.
- Log assertion tests updated to reflect new `owner/repo`-prefixed format.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/26692560920) for issue #35982 · sonnet46 1.2M · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.55, model: claude-sonnet-4.6, id: 26692560920, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/26692560920 -->