### PR TITLE
AOAI endpoint smoke test

### DIFF
--- a/.github/workflows/aoai-endpoint-smoke-test.yml
+++ b/.github/workflows/aoai-endpoint-smoke-test.yml
@@ -1,0 +1,76 @@
+name: AOAI Endpoint Smoke Test
+
+# AOAI endpoint smoke test that hits an Azure OpenAI (AOAI) model two ways:
+#   1. Entra ID / OIDC, via a user-assigned managed identity (no secrets).
+#   2. A static API key stored as a repository secret.
+# Both jobs run in parallel and issue a raw curl against the same endpoint.
+# NOTE: this only checks connectivity to responses API, it does not test Copilot CLI nor end-to-end Agentic workflows
+#   Since there are no agentics in this workflow, it does not use gh-aw-firewall.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  AOAI_ENDPOINT: https://githubnext-eastus2.openai.azure.com/openai/responses?api-version=2025-04-01-preview
+  AOAI_MODEL: gpt-5.5
+
+jobs:
+  oidc:
+    name: AOAI via OIDC (managed identity)
+    runs-on: ubuntu-latest
+    environment: aoai-model
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AZURE_CLIENT_ID: adb907fd-188c-4029-b67f-2559d96b2f1b
+      AZURE_TENANT_ID: 398a6654-997b-47e9-b12b-9515b896b4de
+      AZURE_SUBSCRIPTION_ID: 606c8d64-a781-4e22-94d6-937f051e26e9
+    steps:
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get AOAI access token
+        run: |
+          TOKEN=$(az account get-access-token \
+            --resource https://cognitiveservices.azure.com \
+            --query accessToken \
+            --output tsv)
+          echo "::add-mask::$TOKEN"
+          echo "AOAI_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Query AOAI model
+        run: |
+          curl --fail-with-body -sS -X POST "${AOAI_ENDPOINT}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $AOAI_TOKEN" \
+            -d "$(jq -n --arg model "$AOAI_MODEL" '{
+              model: $model,
+              input: "Write a random sentence.",
+              max_output_tokens: 1024
+            }')"
+
+  api-key:
+    name: AOAI via API key
+    runs-on: ubuntu-latest
+    environment: aoai-model
+    steps:
+      - name: Query AOAI model
+        env:
+          AOAI_KEY_GITHUBNEXT_EASTUS2: ${{ secrets.AOAI_KEY_GITHUBNEXT_EASTUS2 }}
+        run: |
+          curl --fail-with-body -sS -X POST "${AOAI_ENDPOINT}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $AOAI_KEY_GITHUBNEXT_EASTUS2" \
+            -d "$(jq -n --arg model "$AOAI_MODEL" '{
+              model: $model,
+              input: "Write a random sentence.",
+              max_output_tokens: 1024
+            }')"


### PR DESCRIPTION
## What

Adds a new manually-triggered GitHub Actions workflow (`.github/workflows/aoai-endpoint-smoke-test.yml`) that validates connectivity and authentication to an Azure OpenAI (AOAI) endpoint using two distinct auth paths:

1. **OIDC managed identity** — federated, secretless auth via GitHub's OIDC token and a user-assigned managed identity
2. **Static API key** — classic bearer auth via a repository secret (`AOAI_KEY_GITHUBNEXT_EASTUS2`)

Both jobs run in parallel against the same endpoint (`githubnext-eastus2.openai.azure.com`) and model (`gpt-5.5`).

## Why

Provides a quick, on-demand health check to confirm that the AOAI endpoint is reachable and responding before relying on it in production agentic workflows. Having both auth modes covered lets operators verify that managed-identity federation is working correctly — and fall back to key-based auth to isolate the failure if it isn't.

## How

- Trigger: `workflow_dispatch` (manual only)
- OIDC job logs in via `azure/login@v2`, fetches an access token scoped to `(cognitiveservices.azure.com/redacted)`, then POSTs a minimal completion request
- API-key job POSTs the same request using the static key from secrets
- Both jobs use `curl --fail-with-body` to surface non-2xx HTTP errors as job failures
- Target model: `gpt-5.5`; endpoint uses responses API preview (`api-version=2025-04-01-preview`)
- No production code paths are modified; this is purely operational tooling
- Does not use `gh-aw-firewall` (no agentic engine involved)

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/aoai-endpoint-smoke-test.yml` | **Added** — 76-line workflow defining the two parallel smoke-test jobs |

## Testing

Run the workflow manually via **Actions → AOAI Endpoint Smoke Test → Run workflow** and confirm both jobs (`oidc` and `api-key`) pass.

## Notes

- Breaking change: **No**
- No application logic, schemas, or existing workflows modified
- Requires the `aoai-model` GitHub environment and the `AOAI_KEY_GITHUBNEXT_EASTUS2` secret to be configured

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/26793469447) for issue #36384 · sonnet46 900K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.55, model: claude-sonnet-4.6, id: 26793469447, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/26793469447 -->