### PR TITLE
Honor safe-outputs.mentions.allowed during NDJSON collection

### DIFF
--- a/.github/workflows/bot-detection.lock.yml
+++ b/.github/workflows/bot-detection.lock.yml
@@ -571,6 +571,11 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "allowed": [
+                  "pelikhan"
+                ]
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/constraint-solving-potd.lock.yml
+++ b/.github/workflows/constraint-solving-potd.lock.yml
@@ -541,6 +541,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/copilot-opt.lock.yml
+++ b/.github/workflows/copilot-opt.lock.yml
@@ -603,6 +603,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-agentrx-trace-optimizer.lock.yml
+++ b/.github/workflows/daily-agentrx-trace-optimizer.lock.yml
@@ -687,6 +687,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-ambient-context-optimizer.lock.yml
+++ b/.github/workflows/daily-ambient-context-optimizer.lock.yml
@@ -625,6 +625,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-aw-cross-repo-compile-check.lock.yml
+++ b/.github/workflows/daily-aw-cross-repo-compile-check.lock.yml
@@ -577,6 +577,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-experiment-report.lock.yml
+++ b/.github/workflows/daily-experiment-report.lock.yml
@@ -642,6 +642,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-reliability-review.lock.yml
+++ b/.github/workflows/daily-reliability-review.lock.yml
@@ -563,6 +563,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-spdd-spec-planner.lock.yml
+++ b/.github/workflows/daily-spdd-spec-planner.lock.yml
@@ -582,6 +582,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/daily-token-consumption-report.lock.yml
+++ b/.github/workflows/daily-token-consumption-report.lock.yml
@@ -592,6 +592,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/otlp-data-quality-validator.lock.yml
+++ b/.github/workflows/otlp-data-quality-validator.lock.yml
@@ -554,6 +554,9 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "enabled": false
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/.github/workflows/pr-sous-chef.lock.yml
+++ b/.github/workflows/pr-sous-chef.lock.yml
@@ -596,6 +596,11 @@ jobs:
                   }
                 }
               },
+              "mentions": {
+                "allowed": [
+                  "copilot"
+                ]
+              },
               "missing_data": {
                 "defaultMax": 20,
                 "fields": {

--- a/pkg/workflow/mcp_setup_generator.go
+++ b/pkg/workflow/mcp_setup_generator.go
@@ -295,7 +295,13 @@ func generateSafeOutputsSetup(c *Compiler, yaml *strings.Builder, safeOutputConf
 			}
 		}
 	}
-	validationConfigJSON, err := GetValidationConfigJSON(enabledTypes)
+	// Propagate mentions config to the collection pass so that allowed @-mentions
+	// (e.g. "@copilot") are not backtick-escaped before publish-side handlers run.
+	var mentionsBlock map[string]any
+	if workflowData.SafeOutputs != nil && workflowData.SafeOutputs.Mentions != nil {
+		mentionsBlock = buildMentionsHandlerConfig(workflowData.SafeOutputs.Mentions)
+	}
+	validationConfigJSON, err := GetValidationConfigJSON(enabledTypes, mentionsBlock)
 	if err != nil {
 		mcpSetupGeneratorLog.Printf("CRITICAL: Error generating validation config JSON: %v - validation will not work correctly", err)
 		validationConfigJSON = "{}"

--- a/pkg/workflow/safe_output_validation_config_test.go
+++ b/pkg/workflow/safe_output_validation_config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGetValidationConfigJSON(t *testing.T) {
 	// Test with nil (all types)
-	jsonStr, err := GetValidationConfigJSON(nil)
+	jsonStr, err := GetValidationConfigJSON(nil, nil)
 	if err != nil {
 		t.Fatalf("GetValidationConfigJSON() error = %v", err)
 	}
@@ -72,7 +72,7 @@ func TestGetValidationConfigJSON(t *testing.T) {
 func TestGetValidationConfigJSONFiltered(t *testing.T) {
 	// Test with filtered types
 	enabledTypes := []string{"create_issue", "add_comment"}
-	jsonStr, err := GetValidationConfigJSON(enabledTypes)
+	jsonStr, err := GetValidationConfigJSON(enabledTypes, nil)
 	if err != nil {
 		t.Fatalf("GetValidationConfigJSON() error = %v", err)
 	}
@@ -104,7 +104,7 @@ func TestGetValidationConfigJSONFiltered(t *testing.T) {
 
 func TestGetValidationConfigJSONEmpty(t *testing.T) {
 	// Test with empty slice (should return all types, same as nil)
-	jsonStr, err := GetValidationConfigJSON([]string{})
+	jsonStr, err := GetValidationConfigJSON([]string{}, nil)
 	if err != nil {
 		t.Fatalf("GetValidationConfigJSON() error = %v", err)
 	}
@@ -118,6 +118,66 @@ func TestGetValidationConfigJSONEmpty(t *testing.T) {
 	// Empty slice should return all types
 	if len(parsed) != len(ValidationConfig) {
 		t.Errorf("Expected %d types with empty slice, got %d", len(ValidationConfig), len(parsed))
+	}
+}
+
+func TestGetValidationConfigJSONWithMentions(t *testing.T) {
+	mentions := map[string]any{
+		"enabled":          true,
+		"allowTeamMembers": false,
+		"allowContext":     false,
+		"allowed":          []string{"copilot", "github-actions"},
+		"max":              5,
+	}
+
+	jsonStr, err := GetValidationConfigJSON([]string{"add_comment"}, mentions)
+	if err != nil {
+		t.Fatalf("GetValidationConfigJSON() error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		t.Fatalf("Failed to parse validation config JSON: %v", err)
+	}
+
+	if _, ok := parsed["add_comment"]; !ok {
+		t.Error("Expected add_comment type entry to be present")
+	}
+
+	raw, ok := parsed["mentions"]
+	if !ok {
+		t.Fatal("Expected top-level mentions key to be present in validation JSON")
+	}
+	mentionsParsed, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected mentions to be an object, got %T", raw)
+	}
+
+	allowed, ok := mentionsParsed["allowed"].([]any)
+	if !ok {
+		t.Fatalf("Expected mentions.allowed to be an array, got %T", mentionsParsed["allowed"])
+	}
+	if len(allowed) != 2 || allowed[0] != "copilot" || allowed[1] != "github-actions" {
+		t.Errorf("Unexpected mentions.allowed contents: %v", allowed)
+	}
+	if enabled, _ := mentionsParsed["enabled"].(bool); !enabled {
+		t.Errorf("Expected mentions.enabled to be true, got %v", mentionsParsed["enabled"])
+	}
+	if allowTeam, _ := mentionsParsed["allowTeamMembers"].(bool); allowTeam {
+		t.Errorf("Expected mentions.allowTeamMembers to be false, got %v", mentionsParsed["allowTeamMembers"])
+	}
+
+	// A second call without mentions must not include the key (cache safety).
+	plainJSON, err := GetValidationConfigJSON([]string{"add_comment"}, nil)
+	if err != nil {
+		t.Fatalf("GetValidationConfigJSON() error = %v", err)
+	}
+	var plainParsed map[string]any
+	if err := json.Unmarshal([]byte(plainJSON), &plainParsed); err != nil {
+		t.Fatalf("Failed to parse plain validation config JSON: %v", err)
+	}
+	if _, ok := plainParsed["mentions"]; ok {
+		t.Error("Did not expect mentions key in JSON produced without mentions argument")
 	}
 }
 

--- a/pkg/workflow/safe_outputs_validation_config.go
+++ b/pkg/workflow/safe_outputs_validation_config.go
@@ -437,22 +437,28 @@ var ValidationConfig = map[string]TypeValidationConfig{
 // json.MarshalIndent calls on every workflow compilation.
 var validationConfigJSONCache sync.Map // key: string → value: string
 
-// GetValidationConfigJSON returns the validation configuration as indented JSON
-// If enabledTypes is empty or nil, returns all validation configs
-// If enabledTypes is provided, returns only configs for the specified types
-func GetValidationConfigJSON(enabledTypes []string) (string, error) {
-	safeOutputValidationLog.Printf("Getting validation config JSON for %d types", len(enabledTypes))
+// GetValidationConfigJSON returns the validation configuration as indented JSON.
+// If enabledTypes is empty or nil, returns all validation configs.
+// If enabledTypes is provided, returns only configs for the specified types.
+// If mentions is non-empty, a top-level "mentions" key is included in the JSON
+// so that collect_ndjson_output.cjs honours the configured @mention allowlist
+// during the initial sanitization pass (mirroring what the publish-side handlers
+// receive via GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG).
+func GetValidationConfigJSON(enabledTypes []string, mentions map[string]any) (string, error) {
+	safeOutputValidationLog.Printf("Getting validation config JSON for %d types (mentions=%t)", len(enabledTypes), len(mentions) > 0)
 
-	// Build a stable cache key from the sorted enabled types.
-	cacheKey := buildValidationConfigCacheKey(enabledTypes)
-	if cached, ok := validationConfigJSONCache.Load(cacheKey); ok {
-		safeOutputValidationLog.Print("Returning cached validation config JSON")
-		result, ok := cached.(string)
-		if !ok {
-			// The cache exclusively stores string values; a non-string indicates a programmer error.
-			return "", fmt.Errorf("validationConfigJSONCache: unexpected type %T for key %s", cached, cacheKey)
+	// Cache only the schema-only path; mentions are workflow-specific and cheap to remarshal.
+	if len(mentions) == 0 {
+		cacheKey := buildValidationConfigCacheKey(enabledTypes)
+		if cached, ok := validationConfigJSONCache.Load(cacheKey); ok {
+			safeOutputValidationLog.Print("Returning cached validation config JSON")
+			result, ok := cached.(string)
+			if !ok {
+				// The cache exclusively stores string values; a non-string indicates a programmer error.
+				return "", fmt.Errorf("validationConfigJSONCache: unexpected type %T for key %s", cached, cacheKey)
+			}
+			return result, nil
 		}
-		return result, nil
 	}
 
 	configToMarshal := ValidationConfig
@@ -468,14 +474,27 @@ func GetValidationConfigJSON(enabledTypes []string) (string, error) {
 		safeOutputValidationLog.Print("Returning all validation configs")
 	}
 
-	data, err := json.MarshalIndent(configToMarshal, "", "  ")
+	var data []byte
+	var err error
+	if len(mentions) > 0 {
+		composite := make(map[string]any, len(configToMarshal)+1)
+		for k, v := range configToMarshal {
+			composite[k] = v
+		}
+		composite["mentions"] = mentions
+		data, err = json.MarshalIndent(composite, "", "  ")
+	} else {
+		data, err = json.MarshalIndent(configToMarshal, "", "  ")
+	}
 	if err != nil {
 		safeOutputValidationLog.Printf("Failed to marshal validation config: %v", err)
 		return "", err
 	}
 	result := string(data)
 	safeOutputValidationLog.Printf("Generated validation config JSON with %d bytes", len(result))
-	validationConfigJSONCache.Store(cacheKey, result)
+	if len(mentions) == 0 {
+		validationConfigJSONCache.Store(buildValidationConfigCacheKey(enabledTypes), result)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
## Honor `safe-outputs.mentions.allowed` during NDJSON collection

### Summary

Ensures that `@`-mention tokens listed under `safe-outputs.mentions.allowed` in a workflow definition are **not** backtick-escaped during the NDJSON collection pass — i.e., before publish-side safe-output handlers run. Previously, `GetValidationConfigJSON` had no awareness of allowed mentions, so the collection-time validator treated every `@token` as unsafe and escaped it, defeating the intent of the `mentions` allow-list.

---

### What changed

| File | Type | Description |
|---|---|---|
| `pkg/workflow/safe_outputs_validation_config.go` | **breaking change** | `GetValidationConfigJSON` gains a second parameter `mentions map[string]any`. When non-nil, a top-level `"mentions"` key is injected into the returned JSON and the `sync.Map` cache is **bypassed** (mentions are workflow-specific, so caching would be incorrect). The zero-mentions path is unchanged and continues to use the cache. |
| `pkg/workflow/mcp_setup_generator.go` | changed | Updated the call site to derive a `mentionsBlock` from `workflowData.SafeOutputs.Mentions` and pass it as the new second argument, threading the allow-list through to the validator. |
| `pkg/workflow/safe_output_validation_config_test.go` | changed | All pre-existing `GetValidationConfigJSON` call sites updated to pass `nil` (preserving current behaviour). New test `TestGetValidationConfigJSONWithMentions` asserts: (1) the `mentions` block is present in JSON output when mentions are supplied, and (2) it is absent — and the cached path is unaffected — when `nil` is supplied. |

---

### Breaking change

`GetValidationConfigJSON` now requires a second argument. All callers outside this PR must be updated to pass `nil` (to preserve existing behaviour) or a valid mentions map.

---

### Why the cache is bypassed for mentions

The `sync.Map` cache key is not parameterised by workflow identity, so caching a config that embeds a workflow-specific mentions allow-list would cause cross-workflow contamination. The no-mentions fast path (cache hit) is unaffected.

---

### Testing

- Existing tests: updated to pass `nil`; all should continue to pass without behavioural change.
- New: `TestGetValidationConfigJSONWithMentions` — covers the embedded-mentions path and the cache-safety invariant.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27036702151) for issue #37177 · agent 79.9 AIC · threat-detection 12.9 AIC · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.57, model: claude-sonnet-4.6, id: 27036702151, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27036702151 -->