### PR TITLE
feat(cli): add --gh-aw-ref convenience flag to compile

### DIFF
--- a/cmd/gh-aw/main.go
+++ b/cmd/gh-aw/main.go
@@ -265,6 +265,14 @@ Examples:
 		actionMode, _ := cmd.Flags().GetString("action-mode")
 		actionTag, _ := cmd.Flags().GetString("action-tag")
 		actionsRepo, _ := cmd.Flags().GetString("actions-repo")
+		ghAwRef, _ := cmd.Flags().GetString("gh-aw-ref")
+		if ghAwRef != "" {
+			// --gh-aw-ref is a convenience alias: emit refs like
+			// `github/gh-aw/actions/setup@<ref>` so external e2e harnesses can
+			// test the compiled workflows against a specific gh-aw branch/SHA.
+			actionMode = string(workflow.ActionModeRelease)
+			actionTag = ghAwRef
+		}
 		validate, _ := cmd.Flags().GetBool("validate")
 		watch, _ := cmd.Flags().GetBool("watch")
 		dir, _ := cmd.Flags().GetString("dir")
@@ -684,6 +692,7 @@ Use "` + string(constants.CLIExtensionPrefix) + ` help all" to show help for all
 	compileCmd.Flags().String("action-mode", "", "Action script inlining mode (inline, dev, release). Auto-detected if not specified")
 	compileCmd.Flags().String("action-tag", "", "Override action SHA or tag for actions/setup (overrides action-mode to release). Accepts full SHA or tag name")
 	compileCmd.Flags().String("actions-repo", "", "Override the external actions repository used in action mode (default: github/gh-aw-actions)")
+	compileCmd.Flags().String("gh-aw-ref", "", "Compile workflows to reference github/gh-aw at the given branch, tag, or SHA (e.g. main, my-feature, abc123). Convenience alias for --action-mode release --action-tag <ref>. Use this to E2E-test workflows compiled by an external repo against a specific gh-aw revision.")
 	compileCmd.Flags().Bool("validate", false, "Enable GitHub Actions workflow schema validation, container image validation, and action SHA validation")
 	compileCmd.Flags().BoolP("watch", "w", false, "Watch for changes to workflow files and recompile automatically")
 	compileCmd.Flags().StringP("dir", "d", "", "Workflow directory (default: .github/workflows)")


### PR DESCRIPTION
## feat(cli): add `--gh-aw-ref` convenience flag to compile

### Summary
Adds a `--gh-aw-ref` convenience flag to the `compile` command in `cmd/gh-aw/main.go`. The flag is a shorthand alias that expands to `--action-mode release --action-tag <ref>`, reducing the boilerplate required when external E2E harnesses need to compile workflows pinned to a specific gh-aw branch, tag, or SHA.

### Changes
| File | Type | Description |
|---|---|---|
| `cmd/gh-aw/main.go` | modified | Added `--gh-aw-ref` flag to the `compile` command as an alias for `--action-mode release --action-tag <ref>` |

### Motivation
External E2E test harnesses that drive `gh aw compile` against a specific release, branch, or SHA currently have to pass two flags (`--action-mode` and `--action-tag`). The new flag collapses this into a single, self-documenting option, making harness invocations shorter and less error-prone.

### Behaviour
- `--gh-aw-ref <ref>` is equivalent to `--action-mode release --action-tag <ref>`.
- The flag is additive; existing flags are unchanged.
- No configuration schema changes; no breaking changes.

### Impact
- **Scope**: `compile` command only (`cmd/gh-aw/main.go`)
- **Breaking change**: No
- **Risk**: Low — new optional flag with no effect on existing call-sites

### Testing
Intended for use by external E2E harnesses; validate by invoking:
```sh
gh aw compile --gh-aw-ref <branch|tag|sha> <workflow-file>
```
and confirming the compiled output matches that produced by the explicit `--action-mode release --action-tag <ref>` form.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27063493350) for issue #37313 · 76.3 AIC · ⌖ 13 AIC · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.59, model: claude-sonnet-4.6, id: 27063493350, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27063493350 -->