### PR TITLE
Accept runtime ${{ ... }} expressions in safe-outputs samples

### DIFF
--- a/.changeset/patch-samples-runtime-expressions.md
+++ b/.changeset/patch-samples-runtime-expressions.md
@@ -1,0 +1,5 @@
+---
+"gh-aw": patch
+---
+
+Accept `${{ ... }}` GitHub Actions expressions inside `safe-outputs.*.samples` entries: such values now bypass compile-time JSON-schema validation and are preserved verbatim in the lock file's `GH_AW_SAMPLES` env value, so GitHub Actions substitutes the real value on the runner before `apply_samples.cjs` reads it. This unblocks `--use-samples` mode for `workflow_dispatch`-triggered safe-output tests that target a runtime-supplied issue/PR number (e.g. `item_number: ${{ github.event.inputs.issue_number }}`).

--- a/pkg/workflow/samples_replay_test.go
+++ b/pkg/workflow/samples_replay_test.go
@@ -339,3 +339,67 @@ emit a valid empty-array GH_AW_SAMPLES under --use-samples.
 		t.Fatalf("GH_AW_SAMPLES = %q, want %q", samplesJSON, "[]")
 	}
 }
+
+// TestUseSamplesPreservesRuntimeExpressionsInLockFile verifies that a sample
+// value containing a `${{ ... }}` GitHub Actions expression compiles cleanly
+// AND lands verbatim in the GH_AW_SAMPLES env value of the lock file, so that
+// GitHub Actions substitutes the real value on the runner before
+// apply_samples.cjs reads it.
+//
+// Regression for https://github.com/github/gh-aw/issues/37532.
+func TestUseSamplesPreservesRuntimeExpressionsInLockFile(t *testing.T) {
+	const md = `---
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number'
+        required: true
+        type: number
+permissions: read-all
+engine:
+  id: claude
+safe-outputs:
+  add-labels:
+    samples:
+      - item_number: ${{ github.event.inputs.issue_number }}
+        labels: ["copilot-safe-output-label-test"]
+---
+
+Runtime-templated sample for workflow_dispatch-driven testing.
+`
+
+	tmpFile, err := os.CreateTemp("", "use-samples-runtime-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(md); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	compiler := NewCompiler()
+	compiler.SetUseSamples(true)
+	if err := compiler.CompileWorkflow(tmpFile.Name()); err != nil {
+		t.Fatalf("compile failed: %v", err)
+	}
+	lockPath := strings.TrimSuffix(tmpFile.Name(), ".md") + ".lock.yml"
+	defer os.Remove(lockPath)
+	b, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lock: %v", err)
+	}
+	lock := string(b)
+
+	samplesJSON := extractGHAWSamplesJSON(t, lock)
+	if !strings.Contains(samplesJSON, "${{ github.event.inputs.issue_number }}") {
+		t.Fatalf("expected GH_AW_SAMPLES to preserve the live ${{ github.event.inputs.issue_number }} expression for runtime substitution; got: %s", samplesJSON)
+	}
+	// The marshalled payload must still be valid JSON (the expression sits
+	// inside a JSON string, so no escaping concerns at compile time).
+	var parsed []any
+	if err := json.Unmarshal([]byte(samplesJSON), &parsed); err != nil {
+		t.Fatalf("GH_AW_SAMPLES must remain valid JSON at compile time, got error %v for: %s", err, samplesJSON)
+	}
+}

--- a/pkg/workflow/samples_validation.go
+++ b/pkg/workflow/samples_validation.go
@@ -12,12 +12,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-// sampleRuntimeExpressionPattern matches GitHub Actions runtime expressions
-// (`${{ ... }}`) embedded inside sample values. Such values are substituted by
-// GitHub Actions on the runner before `apply_samples.cjs` reads
-// `GH_AW_SAMPLES`, so they cannot be validated against the MCP tool's
-// inputSchema at compile time.
-var sampleRuntimeExpressionPattern = regexp.MustCompile(`\$\{\{[^}]*\}\}`)
+var sampleRuntimeExpressionPattern = regexp.MustCompile(`(?s)\$\{\{.*?\}\}`)
 
 // sampleRuntimeExpressionPlaceholder is the sentinel substituted for any
 // sample value that contains a `${{ ... }}` GitHub Actions expression, used

--- a/pkg/workflow/samples_validation.go
+++ b/pkg/workflow/samples_validation.go
@@ -4,12 +4,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
+
+// sampleRuntimeExpressionPattern matches GitHub Actions runtime expressions
+// (`${{ ... }}`) embedded inside sample values. Such values are substituted by
+// GitHub Actions on the runner before `apply_samples.cjs` reads
+// `GH_AW_SAMPLES`, so they cannot be validated against the MCP tool's
+// inputSchema at compile time.
+var sampleRuntimeExpressionPattern = regexp.MustCompile(`\$\{\{[^}]*\}\}`)
+
+// sampleRuntimeExpressionPlaceholder is the sentinel substituted for any
+// sample value that contains a `${{ ... }}` GitHub Actions expression, used
+// for compile-time schema validation only. It is chosen to satisfy every
+// pattern currently declared in pkg/workflow/js/safe_outputs_tools.json that
+// accepts an `aw_`-prefixed temporary id (3-12 chars after the prefix).
+const sampleRuntimeExpressionPlaceholder = "aw_sample"
 
 // sampleSidecarFields lists fields recognized inside a `samples` entry
 // that are NOT passed to the MCP tool's `tools/call` arguments. They are stripped
@@ -136,11 +151,44 @@ func validateSamplesForTool(toolName string, samples []map[string]any) error {
 	sidecars := sampleSidecarFields[toolName]
 	for i, sample := range samples {
 		stripped := stripSidecarFields(sample, sidecars)
-		if err := schema.Validate(stripped); err != nil {
+		substituted, ok := substituteRuntimeExpressionsForValidation(stripped).(map[string]any)
+		if !ok {
+			substituted = stripped
+		}
+		if err := schema.Validate(substituted); err != nil {
 			return fmt.Errorf("safe-outputs.%s.samples[%d]: %w", displayKey, i, err)
 		}
 	}
 	return nil
+}
+
+// substituteRuntimeExpressionsForValidation returns a deep copy of v in which
+// every string value containing a `${{ ... }}` GitHub Actions expression has
+// been replaced by sampleRuntimeExpressionPlaceholder. The original sample is
+// left unchanged and is what gets emitted into the lock file, so the real
+// expression is preserved for GitHub Actions to substitute at runtime.
+func substituteRuntimeExpressionsForValidation(v any) any {
+	switch val := v.(type) {
+	case string:
+		if sampleRuntimeExpressionPattern.MatchString(val) {
+			return sampleRuntimeExpressionPlaceholder
+		}
+		return val
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, vv := range val {
+			out[k] = substituteRuntimeExpressionsForValidation(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, vv := range val {
+			out[i] = substituteRuntimeExpressionsForValidation(vv)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // stripSidecarFields returns a shallow copy of sample with sidecar keys removed.

--- a/pkg/workflow/samples_validation_test.go
+++ b/pkg/workflow/samples_validation_test.go
@@ -168,3 +168,123 @@ func TestCollectSampleEntries_SidecarPartitioning(t *testing.T) {
 		t.Errorf("expected patch to be present in Sidecars as a git diff string, got %#v", e.Sidecars["patch"])
 	}
 }
+
+// TestValidateSafeOutputsSamples_RuntimeExpressionsBypassValidation verifies
+// that sample values containing `${{ ... }}` GitHub Actions expressions
+// (e.g. `item_number: ${{ github.event.inputs.issue_number }}`) bypass
+// compile-time schema validation, since GitHub Actions substitutes them on
+// the runner before apply_samples.cjs reads GH_AW_SAMPLES.
+//
+// Regression for https://github.com/github/gh-aw/issues/37532.
+func TestValidateSafeOutputsSamples_RuntimeExpressionsBypassValidation(t *testing.T) {
+	cfg := &SafeOutputsConfig{
+		AddLabels: &AddLabelsConfig{
+			BaseSafeOutputConfig: BaseSafeOutputConfig{
+				Samples: []map[string]any{
+					{
+						// item_number's pattern is `^(\d+|#?aw_[A-Za-z0-9_]{3,12})$`,
+						// so the raw expression string would otherwise fail validation.
+						"item_number": "${{ github.event.inputs.issue_number }}",
+						"labels":      []any{"runtime-sample"},
+					},
+				},
+			},
+		},
+	}
+	if err := validateSafeOutputsSamples(cfg); err != nil {
+		t.Fatalf("expected runtime expression in sample value to bypass validation, got: %v", err)
+	}
+
+	// Original sample must be preserved (validation must not mutate) so that
+	// generateSamplesReplayStep emits the live `${{ ... }}` expression for
+	// GitHub Actions to substitute at runtime.
+	got := cfg.AddLabels.Samples[0]["item_number"]
+	if got != "${{ github.event.inputs.issue_number }}" {
+		t.Errorf("validation must not mutate the original sample; got item_number=%v", got)
+	}
+}
+
+// TestValidateSafeOutputsSamples_RuntimeExpressionsInNestedValues verifies
+// that runtime-expression substitution works for nested arrays and objects
+// (e.g. fields inside create_issue.fields[*].value).
+func TestValidateSafeOutputsSamples_RuntimeExpressionsInNestedValues(t *testing.T) {
+	cfg := &SafeOutputsConfig{
+		CreateIssues: &CreateIssuesConfig{
+			BaseSafeOutputConfig: BaseSafeOutputConfig{
+				Samples: []map[string]any{
+					{
+						"title": "Issue ${{ github.event.inputs.title_suffix }}",
+						"body":  "Body",
+						"labels": []any{
+							"static-label",
+							"${{ github.event.inputs.dynamic_label }}",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateSafeOutputsSamples(cfg); err != nil {
+		t.Fatalf("expected nested runtime expressions to bypass validation, got: %v", err)
+	}
+}
+
+// TestValidateSafeOutputsSamples_NonExpressionErrorsStillReported verifies
+// that swapping in the runtime-expression placeholder does NOT mask genuine
+// validation errors on adjacent fields (e.g. a still-missing required field).
+func TestValidateSafeOutputsSamples_NonExpressionErrorsStillReported(t *testing.T) {
+	cfg := &SafeOutputsConfig{
+		CreateIssues: &CreateIssuesConfig{
+			BaseSafeOutputConfig: BaseSafeOutputConfig{
+				Samples: []map[string]any{
+					{
+						// title is required and is missing; an expression on
+						// the body must not paper over that.
+						"body": "${{ github.event.inputs.body }}",
+					},
+				},
+			},
+		},
+	}
+	if err := validateSafeOutputsSamples(cfg); err == nil {
+		t.Fatal("expected missing-title error to still surface even though body is a runtime expression")
+	}
+}
+
+// TestSubstituteRuntimeExpressionsForValidation_LeavesLiteralsUntouched
+// verifies that the substitution helper only touches strings containing
+// `${{ ... }}` and otherwise returns equivalent values.
+func TestSubstituteRuntimeExpressionsForValidation_LeavesLiteralsUntouched(t *testing.T) {
+	in := map[string]any{
+		"title": "literal title",
+		"count": float64(5),
+		"flags": []any{"a", "${{ github.run_id }}", "b"},
+		"nested": map[string]any{
+			"id": "${{ inputs.id }}",
+		},
+	}
+	out := substituteRuntimeExpressionsForValidation(in).(map[string]any)
+
+	if out["title"] != "literal title" {
+		t.Errorf("expected literal string to be unchanged, got %v", out["title"])
+	}
+	if out["count"] != float64(5) {
+		t.Errorf("expected numeric value to be unchanged, got %v", out["count"])
+	}
+	flags := out["flags"].([]any)
+	if flags[0] != "a" || flags[2] != "b" {
+		t.Errorf("expected literal array elements to be unchanged, got %v", flags)
+	}
+	if flags[1] != sampleRuntimeExpressionPlaceholder {
+		t.Errorf("expected array element with ${{...}} to be substituted, got %v", flags[1])
+	}
+	nested := out["nested"].(map[string]any)
+	if nested["id"] != sampleRuntimeExpressionPlaceholder {
+		t.Errorf("expected nested ${{...}} string to be substituted, got %v", nested["id"])
+	}
+
+	// Original input must not be mutated.
+	if in["nested"].(map[string]any)["id"] != "${{ inputs.id }}" {
+		t.Error("substituteRuntimeExpressionsForValidation must not mutate its input")
+	}
+}


### PR DESCRIPTION
## Accept runtime `${{ ... }}` expressions in `safe-outputs` samples

**PR #37537** · `pkg/workflow` · patch

---

### Problem

`safe-outputs.*.samples` values are validated at compile-time against the MCP tool's `inputSchema`. This caused compilation to reject any sample value containing a GitHub Actions runtime expression such as `${{ github.event.inputs.issue_number }}` — even though the expression would resolve to a valid type at runtime — making it impossible to wire workflow-dispatch inputs into samples.

---

### Approach

During compile-time schema validation, deep-copy each sample map and replace every string value that contains a `${{ ... }}` expression with the sentinel placeholder `aw_sample` (which satisfies common JSON-schema constraints: `string`, `minLength`, `pattern`). Validate the substituted copy only; emit the **original** sample — with the live expression intact — verbatim into the `GH_AW_SAMPLES` block of the generated lock file. GitHub Actions then performs its own substitution at runtime.

> The original sample map is **never mutated**.

---

### Files changed

| File | Change | Impact | Summary |
|---|---|---|---|
| `pkg/workflow/samples_validation.go` | modified | ⭐ high | Introduces `substituteRuntimeExpressionsForValidation` (compiled regex + `aw_sample` sentinel) and wires it into `validateSamplesForTool` so `${{ ... }}` expressions are swapped for validation only, leaving the original expression untouched for lock-file emission. |
| `pkg/workflow/samples_validation_test.go` | modified | medium | Adds four unit tests: top-level expression fields pass without error; nested arrays/objects are handled; genuine missing-required-field errors still surface; literal values are left untouched by the substitution helper. |
| `pkg/workflow/samples_replay_test.go` | modified | medium | Adds `TestUseSamplesPreservesRuntimeExpressionsInLockFile` — a regression test confirming a `${{ ... }}` expression survives compilation and is emitted verbatim into `GH_AW_SAMPLES` in the generated lock file. |
| `.changeset/patch-samples-runtime-expressions.md` | added | low | Patch-level changeset entry documenting the new bypass behaviour for release notes. |

---

### Key design constraint

Validation uses a **substituted copy**; the lock file always receives the **original** sample. This separation ensures:
- Compile-time schema checks still catch real type/required-field errors
- Runtime expressions are never coerced, truncated, or lost in the emitted artifact

---

### Breaking changes

None.

---

### Commits

| SHA | Message |
|---|---|
| `c3b29b3db` | Accept runtime `${{ ... }}` expressions in safe-outputs samples (#37532) |
| `5a6a39a6b` | Potential fix for pull request finding |

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27091890779) for issue #37537 · 122.1 AIC · ⌖ 14.5 AIC · ⊞ 19.5K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.59, model: claude-sonnet-4.6, id: 27091890779, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27091890779 -->