### PR TITLE
Fix golint stringsseq modernize finding in nolint.go

### DIFF
--- a/pkg/linters/internal/nolint/nolint.go
+++ b/pkg/linters/internal/nolint/nolint.go
@@ -52,7 +52,7 @@ func BuildLineIndex(pass *analysis.Pass, linterName string) map[string]map[int]s
 					payload = payload[:i]
 				}
 				matched := false
-				for _, token := range strings.Split(payload, ",") {
+				for token := range strings.SplitSeq(payload, ",") {
 					name := strings.TrimSpace(token)
 					if name == linterName || name == "all" {
 						matched = true


### PR DESCRIPTION
## Summary

Replace `strings.Split` with the iterator-based `strings.SplitSeq` in the
token loop inside `BuildLineIndex` (`pkg/linters/internal/nolint/nolint.go`),
eliminating an intermediate slice allocation and aligning the code with the
modernised Go strings API.

## Changes

| File | Change |
|------|--------|
| `pkg/linters/internal/nolint/nolint.go` | Replaced `strings.Split` → `strings.SplitSeq` in `BuildLineIndex` token loop |

## Motivation

The `golint` **stringsseq** finding flags `strings.Split` calls whose results
are only ever range-iterated, because `strings.SplitSeq` provides the same
iteration without materialising the intermediate `[]string` slice. This fix
resolves that finding in `nolint.go`.

## Impact

- **Allocations**: one fewer `[]string` heap allocation per `BuildLineIndex` call (low but measurable in hot linter paths).
- **Behaviour**: no functional change — the iteration order and results are identical.
- **Breaking change**: none.
- **Tests**: no new tests required; existing coverage for `BuildLineIndex` continues to apply.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27094058367) for issue #37567 · 96.9 AIC · ⌖ 12.4 AIC · ⊞ 20.5K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.59, model: claude-sonnet-4.6, id: 27094058367, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27094058367 -->