### PR TITLE
Fix CI: add missing v0.3.24 MCPG pin and Windows test compatibility

### DIFF
--- a/cmd/gh-aw/version_test.go
+++ b/cmd/gh-aw/version_test.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -16,10 +18,16 @@ func TestVersionIsSetDuringBuild(t *testing.T) {
 		// Build a test binary with a specific version
 		testVersion := "v0.0.0-test"
 
+		binaryName := "gh-aw-test-version"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath := filepath.Join(t.TempDir(), binaryName)
+
 		// Build the binary with version set via ldflags
 		cmd := exec.Command("go", "build",
 			"-ldflags", "-X main.version="+testVersion,
-			"-o", "/tmp/gh-aw-test-version",
+			"-o", binaryPath,
 			".")
 		cmd.Dir = "."
 
@@ -29,7 +37,7 @@ func TestVersionIsSetDuringBuild(t *testing.T) {
 		}
 
 		// Run the test binary to check its version
-		versionCmd := exec.Command("/tmp/gh-aw-test-version", "version")
+		versionCmd := exec.Command(binaryPath, "version")
 		versionOutput, err := versionCmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("Failed to run version command: %v", err)

--- a/pkg/actionpins/data/action_pins.json
+++ b/pkg/actionpins/data/action_pins.json
@@ -385,11 +385,6 @@
       "digest": "sha256:0dd1bd91a41e24a3ccc31b1ec6cb61d36608997fabf91f2d643b64e3fc33180a",
       "pinned_image": "ghcr.io/github/gh-aw-mcpg:v0.3.23@sha256:0dd1bd91a41e24a3ccc31b1ec6cb61d36608997fabf91f2d643b64e3fc33180a"
     },
-    "ghcr.io/github/gh-aw-mcpg:v0.3.24": {
-      "image": "ghcr.io/github/gh-aw-mcpg:v0.3.24",
-      "digest": "sha256:72cc921901afa1d67b6fee568f110c6b84436624c437fb2996d14c83e90a2b54",
-      "pinned_image": "ghcr.io/github/gh-aw-mcpg:v0.3.24@sha256:72cc921901afa1d67b6fee568f110c6b84436624c437fb2996d14c83e90a2b54"
-    },
     "ghcr.io/github/gh-aw-mcpg:v0.3.6": {
       "image": "ghcr.io/github/gh-aw-mcpg:v0.3.6",
       "digest": "sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c",

--- a/pkg/actionpins/data/action_pins.json
+++ b/pkg/actionpins/data/action_pins.json
@@ -385,6 +385,11 @@
       "digest": "sha256:0dd1bd91a41e24a3ccc31b1ec6cb61d36608997fabf91f2d643b64e3fc33180a",
       "pinned_image": "ghcr.io/github/gh-aw-mcpg:v0.3.23@sha256:0dd1bd91a41e24a3ccc31b1ec6cb61d36608997fabf91f2d643b64e3fc33180a"
     },
+    "ghcr.io/github/gh-aw-mcpg:v0.3.24": {
+      "image": "ghcr.io/github/gh-aw-mcpg:v0.3.24",
+      "digest": "sha256:72cc921901afa1d67b6fee568f110c6b84436624c437fb2996d14c83e90a2b54",
+      "pinned_image": "ghcr.io/github/gh-aw-mcpg:v0.3.24@sha256:72cc921901afa1d67b6fee568f110c6b84436624c437fb2996d14c83e90a2b54"
+    },
     "ghcr.io/github/gh-aw-mcpg:v0.3.6": {
       "image": "ghcr.io/github/gh-aw-mcpg:v0.3.6",
       "digest": "sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c",

--- a/pkg/cli/commands_compile_workflow_test.go
+++ b/pkg/cli/commands_compile_workflow_test.go
@@ -156,7 +156,7 @@ This workflow has invalid frontmatter.
 			verbose:        false,
 			engineOverride: "",
 			expectError:    true,
-			errorContains:  "no such file",
+			errorContains:  "failed to read file",
 		},
 		{
 			name: "compilation with invalid engine override",

--- a/pkg/cli/compile_command_test.go
+++ b/pkg/cli/compile_command_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,6 +18,15 @@ import (
 
 	"github.com/github/gh-aw/pkg/workflow"
 )
+
+// absoluteTestPath returns a path that filepath.IsAbs reports as absolute on
+// the current OS.
+func absoluteTestPath() string {
+	if runtime.GOOS == "windows" {
+		return `C:\absolute\path`
+	}
+	return "/absolute/path"
+}
 
 // TestCompileConfig tests the CompileConfig structure
 func TestCompileConfig(t *testing.T) {
@@ -319,7 +329,7 @@ func TestCompileWorkflows_WorkflowDirValidation(t *testing.T) {
 	}{
 		{
 			name:        "absolute path not allowed",
-			workflowDir: "/absolute/path",
+			workflowDir: absoluteTestPath(),
 			expectError: true,
 			errorMsg:    "must be a relative path",
 		},

--- a/pkg/cli/compile_integration_test.go
+++ b/pkg/cli/compile_integration_test.go
@@ -230,6 +230,9 @@ Please check the repository for any open issues and create a summary.
 }
 
 func TestCompileWithIncludeWithEmptyFrontmatterUnderPty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY-based test is not supported on Windows")
+	}
 	setup := setupIntegrationTest(t)
 	defer setup.cleanup()
 


### PR DESCRIPTION
Splits out the generic CI fixes from #37863 so they can land independently of that PR's behavior change.

## What's fixed

### `test` job — `TestGetContainerPin_DefaultMCPImagesArePinned`
Adds the `ghcr.io/github/gh-aw-mcpg:v0.3.24` entry (with verified digest from GHCR) to `pkg/actionpins/data/action_pins.json`. The constant `DefaultMCPGatewayVersion` was bumped to `v0.3.24` in #37708 but the embedded pin entry was missed, so the default-image-is-pinned test has been failing on `main` since.

### `Windows Integration: compile` job (CWI workflow)
- `compilation_with_nonexistent_file`: relax the expected substring from `no such file` (POSIX-only) to `failed to read file`, which is what the engine itself emits on all platforms.
- `absolute_path_not_allowed`: pick an OS-appropriate absolute path so `filepath.IsAbs` returns true on Windows (`C:\\absolute\\path`).
- `TestCompileWithIncludeWithEmptyFrontmatterUnderPty`: skip on Windows where `creack/pty` returns 'unsupported'.

### `Windows Integration: version` job (CWI workflow)
- `TestVersionIsSetDuringBuild`: build the throwaway test binary inside `t.TempDir()` with the correct `.exe` suffix on Windows, instead of hardcoding `/tmp/gh-aw-test-version` which doesn't exist as an executable path on Windows runners.

## Verification

```
go test ./pkg/actionpins -run TestGetContainerPin          # PASS
go test -tags=integration -run 'TestCompileWorkflow$|TestCompileWorkflows_WorkflowDirValidation|TestCompileWithIncludeWithEmptyFrontmatterUnderPty' ./pkg/cli/...   # PASS
go test -tags=integration -run TestVersionIsSetDuringBuild ./cmd/gh-aw/...   # PASS
```

These same fixes are also present in #37863 and will continue to land there if this PR merges first.