### PR TITLE
fix: enhance slide loading and error handling in WorkflowHero

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -27,6 +27,9 @@
         "@types/primer__octicons": "^19.21.0",
         "http-server": "^14.1.1",
         "starlight-github-alerts": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -846,9 +849,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -864,9 +864,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -884,9 +881,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -902,9 +896,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -922,9 +913,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -941,9 +929,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -957,9 +942,6 @@
       "version": "1.2.4",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -976,9 +958,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1002,9 +981,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1026,9 +1002,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1052,9 +1025,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1076,9 +1046,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1102,9 +1069,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1124,9 +1088,6 @@
       "version": "0.34.5",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1380,9 +1341,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,9 +1360,6 @@
       "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1426,9 +1381,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1447,9 +1399,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,9 +1416,6 @@
       "version": "1.0.0",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1761,9 +1707,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1776,9 +1719,6 @@
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1793,9 +1733,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1808,9 +1745,6 @@
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1825,9 +1759,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1840,9 +1771,6 @@
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1857,9 +1785,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1872,9 +1797,6 @@
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1889,9 +1811,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1823,6 @@
       "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1921,9 +1837,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1935,9 +1848,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1948,9 +1858,6 @@
       "version": "4.59.0",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6721,9 +6628,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6737,9 +6641,6 @@
       "version": "0.34.5",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "start": "astro dev",
     "prebuild": "npm run generate-agent-factory && npm run generate-model-tables && npm run build:slides",
     "build": "rm -rf dist && astro build",
-    "build:slides": "mkdir -p public/slides && cp slides/github-agentic-workflows.pdf public/slides/github-agentic-workflows.pdf",
+    "build:slides": "head -c 5 slides/github-agentic-workflows.pdf | grep -q '%PDF-' && mkdir -p public/slides && cp slides/github-agentic-workflows.pdf public/slides/github-agentic-workflows.pdf || (echo 'slides/github-agentic-workflows.pdf is not a real PDF. Did checkout skip Git LFS?' >&2; exit 1)",
     "preview": "astro preview",
     "astro": "astro",
     "validate-links": "astro build",

--- a/docs/src/components/WorkflowHero.astro
+++ b/docs/src/components/WorkflowHero.astro
@@ -32,12 +32,25 @@ const deck = {
     const root = document.querySelector('[data-slide-hero]');
     if (!root) throw new Error('Slide hero root not found');
 
+    /** @type {HTMLElement | null} */
+    let heroRoot = null;
+
     function mountIntoHero() {
       const hero = document.querySelector('.hero');
-      if (!hero || root.parentElement === hero) return;
+      if (!hero) return;
+
+      heroRoot = hero;
+      hero.dataset.workflowHeroMounted = 'true';
+      if (root.parentElement === hero) return;
 
       hero.append(root);
       root.classList.add('workflow-hero--mounted');
+    }
+
+    function unmountFromHero() {
+      stopCarousel();
+      root.remove();
+      heroRoot?.removeAttribute('data-workflow-hero-mounted');
     }
 
     mountIntoHero();
@@ -131,7 +144,7 @@ const deck = {
         startCarousel();
       } catch (error) {
         console.error('Failed to load PDF slides', error);
-        if (loading) loading.textContent = 'Unable to load slides';
+        unmountFromHero();
       }
     }
 
@@ -247,7 +260,7 @@ const deck = {
   }
 
   @media (min-width: 50rem) {
-    :global(.hero) {
+    :global(.hero[data-workflow-hero-mounted='true']) {
       grid-template-columns: minmax(0, 7fr) minmax(0, 13fr);
       align-items: center;
       gap: 1.5rem;

--- a/docs/src/components/WorkflowHero.astro
+++ b/docs/src/components/WorkflowHero.astro
@@ -47,11 +47,13 @@ const deck = {
       root.classList.add('workflow-hero--mounted');
     }
 
-    function unmountFromHero() {
-      stopCarousel();
-      root.remove();
-      heroRoot?.removeAttribute('data-workflow-hero-mounted');
-    }
+function unmountFromHero() {
+  stopCarousel();
+  pdfDocument = null;
+  renderVersion += 1;
+  root.remove();
+  heroRoot?.removeAttribute('data-workflow-hero-mounted');
+}
 
     mountIntoHero();
 

--- a/docs/tests/slide-preview.spec.ts
+++ b/docs/tests/slide-preview.spec.ts
@@ -122,9 +122,11 @@ test.describe('Slide Preview on Homepage', () => {
     // Wait a bit for the error to be displayed
     await page.waitForTimeout(2000);
 
-    // Verify error message is displayed
-    const loading = page.locator('[data-slide-loading]');
-    const errorText = await loading.textContent();
-    expect(errorText).toContain('Unable to load slides');
+    // Verify the slide preview is removed so the default hero layout remains.
+    const slideHero = page.locator('[data-slide-hero]');
+    await expect(slideHero).toHaveCount(0);
+
+    const hero = page.locator('.hero');
+    await expect(hero).not.toHaveAttribute('data-workflow-hero-mounted', 'true');
   });
 });


### PR DESCRIPTION
## Summary

Fixes PDF slide loading in the docs site by addressing the full chain of failure: CI now fetches real PDF files via Git LFS, the build script validates the file before use, and the `WorkflowHero` component gracefully unmounts itself on load failure instead of showing an inline error string.

---

## Changes

### `.github/workflows/docs.yml` — Enable Git LFS in docs CI checkout
- Adds `lfs: true` to the repository checkout step so that large binary assets (e.g. the PDF slides file) are fully fetched rather than left as Git LFS pointer stubs during the docs build workflow.
- **Impact:** Medium — without this, `build:slides` would receive a pointer file and produce a broken or empty slide preview.

### `docs/package.json` — Add PDF validity guard to `build:slides`
- Extends the `build:slides` script with a pre-flight check that inspects the file header of the slides PDF and exits with an actionable error message if the file is a Git LFS pointer rather than a real PDF.
- Also adds the Node.js `engines` field to declare the required runtime version.
- **Impact:** Medium — makes misconfigured LFS environments fail loudly and clearly at build time rather than silently producing a corrupt output.

### `docs/src/components/WorkflowHero.astro` — Graceful unmount on PDF load failure
- Replaces the inline `"Unable to load slides"` error text with a call to `unmountFromHero()`, which removes the slide widget from the DOM and strips the `data-workflow-hero-mounted` attribute.
- Narrows the responsive grid CSS selector to activate only when `data-workflow-hero-mounted` is present, so the default hero layout is automatically restored whenever slides cannot be loaded.
- **Impact:** High — users no longer see a raw error string embedded in the hero; the page degrades cleanly to its default layout.

### `docs/tests/slide-preview.spec.ts` — Update load-failure test assertions
- Replaces the assertion that checked for the presence of an error text string with assertions that verify the slide hero element is removed from the DOM and the hero element lacks `data-workflow-hero-mounted`.
- Keeps test coverage aligned with the new unmount-on-failure behaviour.
- **Impact:** Low — test-only change; no production behaviour modified.

---

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- Existing Playwright spec (`docs/tests/slide-preview.spec.ts`) updated to cover the new unmount-on-failure path.
- CI docs workflow now exercises the LFS fetch path on every run.
- Manual verification: serve the docs site with a missing or pointer-stub PDF to confirm the hero restores its default layout without visible errors.

---

## Notes

- The commit `11fe8e157 Potential fix for pull request finding` is referenced in the log but has no corresponding file changes in the supplied diff — it likely touches workflow or tooling code outside the analysed chunks.
- No breaking changes; all modifications are additive or replace failing-visible behaviour with failing-silent/graceful behaviour.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27373895331) for issue #38712 · 103.6 AIC · ⌖ 13.2 AIC · ⊞ 19.8K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27373895331, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27373895331 -->