### PR TITLE
test: fix env-dependent and parallel-process test failures

### DIFF
--- a/actions/setup/js/create_pull_request.test.cjs
+++ b/actions/setup/js/create_pull_request.test.cjs
@@ -14,22 +14,31 @@ const { getBundlePathForBranch, getBundlePathForBranchInRepo } = require("./gene
 // The privileged handler derives patch/bundle paths from `branch` (and `repo`)
 // via resolveTransportPaths, so tests must write transport files at the
 // canonical derived location and let the handler discover them.
+//
+// `/tmp/gh-aw` is a process-global path shared by every test file. Vitest runs
+// test files in parallel processes, so a cleanup that globbed the whole
+// directory would delete another file's in-flight transport files mid-test.
+// Track only the paths this file created and delete just those.
+const createdTransportPaths = new Set();
 function canonicalPatchPath(branch, repo) {
   fs.mkdirSync("/tmp/gh-aw", { recursive: true });
-  return repo ? getPatchPathForBranchInRepo(branch, repo) : getPatchPathForBranch(branch);
+  const p = repo ? getPatchPathForBranchInRepo(branch, repo) : getPatchPathForBranch(branch);
+  createdTransportPaths.add(p);
+  return p;
 }
 function canonicalBundlePath(branch, repo) {
   fs.mkdirSync("/tmp/gh-aw", { recursive: true });
-  return repo ? getBundlePathForBranchInRepo(branch, repo) : getBundlePathForBranch(branch);
+  const p = repo ? getBundlePathForBranchInRepo(branch, repo) : getBundlePathForBranch(branch);
+  createdTransportPaths.add(p);
+  return p;
 }
 function cleanupCanonicalTransports() {
-  try {
-    for (const f of fs.readdirSync("/tmp/gh-aw")) {
-      if (/^aw-.*\.(patch|bundle)$/.test(f)) {
-        fs.rmSync(`/tmp/gh-aw/${f}`, { force: true });
-      }
-    }
-  } catch {}
+  for (const p of createdTransportPaths) {
+    try {
+      fs.rmSync(p, { force: true });
+    } catch {}
+  }
+  createdTransportPaths.clear();
 }
 
 beforeEach(() => {

--- a/actions/setup/js/handle_noop_message.test.cjs
+++ b/actions/setup/js/handle_noop_message.test.cjs
@@ -20,6 +20,12 @@ describe("handle_noop_message", () => {
     // Create temp directory for test files
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "handle-noop-test-"));
 
+    // getPromptPath() throws unless GH_AW_PROMPTS_DIR or RUNNER_TEMP is set.
+    // On CI RUNNER_TEMP is ambient, but it is not set in local dev, so set the
+    // prompts dir explicitly to make the suite environment-independent. The
+    // actual path is irrelevant because fs.readFileSync is mocked below.
+    process.env.GH_AW_PROMPTS_DIR = tempDir;
+
     // Mock fs.readFileSync to return template content
     originalReadFileSync = fs.readFileSync;
     fs.readFileSync = vi.fn((filePath, encoding) => {

--- a/actions/setup/js/push_to_pull_request_branch.test.cjs
+++ b/actions/setup/js/push_to_pull_request_branch.test.cjs
@@ -9,22 +9,31 @@ const { getBundlePathForBranch, getBundlePathForBranchInRepo } = require("./gene
 // The privileged handler derives patch/bundle paths from `branch` (and `repo`)
 // via resolveTransportPaths, so tests must write transport files at the
 // canonical derived location and let the handler discover them.
+//
+// `/tmp/gh-aw` is a process-global path shared by every test file. Vitest runs
+// test files in parallel processes, so a cleanup that globbed the whole
+// directory would delete another file's in-flight transport files mid-test.
+// Track only the paths this file created and delete just those.
+const createdTransportPaths = new Set();
 function canonicalPatchPath(branch, repo) {
   fs.mkdirSync("/tmp/gh-aw", { recursive: true });
-  return repo ? getPatchPathForBranchInRepo(branch, repo) : getPatchPathForBranch(branch);
+  const p = repo ? getPatchPathForBranchInRepo(branch, repo) : getPatchPathForBranch(branch);
+  createdTransportPaths.add(p);
+  return p;
 }
 function canonicalBundlePath(branch, repo) {
   fs.mkdirSync("/tmp/gh-aw", { recursive: true });
-  return repo ? getBundlePathForBranchInRepo(branch, repo) : getBundlePathForBranch(branch);
+  const p = repo ? getBundlePathForBranchInRepo(branch, repo) : getBundlePathForBranch(branch);
+  createdTransportPaths.add(p);
+  return p;
 }
 function cleanupCanonicalTransports() {
-  try {
-    for (const f of fs.readdirSync("/tmp/gh-aw")) {
-      if (/^aw-.*\.(patch|bundle)$/.test(f)) {
-        fs.rmSync(`/tmp/gh-aw/${f}`, { force: true });
-      }
-    }
-  } catch {}
+  for (const p of createdTransportPaths) {
+    try {
+      fs.rmSync(p, { force: true });
+    } catch {}
+  }
+  createdTransportPaths.clear();
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## test: fix env-dependent and parallel-process test failures

### What

Fixes two independent, local-only test reliability problems in the JavaScript action test suite. Neither change touches production code.

**1 — Transport-file race between parallel Vitest workers**

`create_pull_request.test.cjs` and `push_to_pull_request_branch.test.cjs` share the process-global `/tmp/gh-aw` directory. Their `beforeEach` cleanup previously globbed and deleted *every* `aw-*.patch` / `aw-*.bundle` file in that directory. When Vitest runs test files as parallel worker processes, one file's cleanup could delete transport files that a sibling file had just written, causing mid-test failures.

Fix: introduce a module-level `createdTransportPaths` `Set` in each affected test file. Helper functions (`canonicalPatchPath`, `canonicalBundlePath`) register each path they create into that set; `cleanupCanonicalTransports` deletes only those paths. No other file's in-flight files are touched.

**2 — `handle_noop_message.test.cjs` depended on an ambient `RUNNER_TEMP`**

`getPromptPath()` throws unless `GH_AW_PROMPTS_DIR` or `RUNNER_TEMP` is set. `RUNNER_TEMP` is always present on GitHub-hosted runners but absent in most local dev environments, causing all tests in the file to throw before reaching any assertion.

Fix: add `process.env.GH_AW_PROMPTS_DIR = tempDir` to the `beforeEach` setup. Because `fs.readFileSync` is already mocked, the path value itself is irrelevant.

### Why

Both failures are test-infrastructure bugs:
- The race made parallel local runs non-deterministic and silently broken for developers.
- The missing env var made `handle_noop_message` tests completely unusable outside CI, reducing local developer confidence in the test suite.

### Files changed

| File | Change |
|---|---|
| `actions/setup/js/create_pull_request.test.cjs` | Replace global `/tmp/gh-aw` scan cleanup with `createdTransportPaths` Set |
| `actions/setup/js/push_to_pull_request_branch.test.cjs` | Same transport-path tracking fix |
| `actions/setup/js/handle_noop_message.test.cjs` | Set `GH_AW_PROMPTS_DIR` in `beforeEach` to remove `RUNNER_TEMP` dependency |

### Risk

Low. All changes are confined to test files. No production logic, exported interfaces, or CI configuration is modified. The fixes make tests *more* isolated, not less.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27584400944) for issue #39467 · 98.1 AIC · ⌖ 12.7 AIC · ⊞ 19.9K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27584400944, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27584400944 -->