### PR TITLE
Update MCP server command and arguments

### DIFF
--- a/.github/mcp.json
+++ b/.github/mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "github-agentic-workflows": {
       "type": "local",
-      "command": "gh",
-      "args": ["aw", "mcp-server"],
+      "command": "./gh-aw",
+      "args": ["mcp-server"],
       "tools": ["compile", "audit", "logs", "inspect", "status", "audit-diff"]
     }
   }


### PR DESCRIPTION
## Summary

Updates the MCP server configuration in `.github/mcp.json` to invoke the local `gh-aw` binary directly (`./gh-aw mcp-server`) instead of going through the installed `gh aw` extension command (`gh aw mcp-server`). This makes the Copilot MCP server usable without a globally installed `gh aw` extension — useful in development and CI environments where only the local build artifact is available.

## Changes

| File | Change |
|---|---|
| `.github/mcp.json` | `command` changed from `gh`, `args` from `["aw", "mcp-server"]` → `command: ./gh-aw`, `args: ["mcp-server"]` |

**Before:**
```json
"command": "gh",
"args": ["aw", "mcp-server"]
```

**After:**
```json
"command": "./gh-aw",
"args": ["mcp-server"]
```

## Motivation

Using `gh aw mcp-server` requires the extension to be installed in the user's global `gh` extension registry. By pointing directly at `./gh-aw`, contributors and CI agents can use the MCP server immediately after building the binary, with no installation step required.

## Impact

- **Scope:** Config-only change — no source code, tests, or generated files touched.
- **Breaking:** No. Existing users with `gh aw` installed will still work; they just need to run from the repo root where `./gh-aw` exists.
- **Environment assumption:** Consumers of `.github/mcp.json` (Copilot, editors, tooling) must be invoked from the repository root so that `./gh-aw` resolves correctly.

## Testing

- No automated tests required for a config-file-only change.
- Manual verification: open the repo in an MCP-aware client (e.g. VS Code with Copilot), confirm the `github-agentic-workflows` server starts and exposes the expected tools (`compile`, `audit`, `logs`, `inspect`, `status`, `audit-diff`).

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27710975372) for issue #39866 · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 27710975372, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27710975372 -->