### PR TITLE
Skip copilot-requests tip for individual (non-org) repository owners

### DIFF
--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -107,6 +107,7 @@ type Compiler struct {
 	requireDocker           bool                     // If true, fail validation when Docker is not available instead of silently skipping
 	ghesCompatFromCLI       bool                     // If true, GHES compat was requested via --ghes CLI flag (takes precedence over aw.json)
 	ghesArtifactCompat      bool                     // If true, emit GHES-compatible v3.x pins for artifact actions instead of the latest v7/v8
+	ownerTypeCache          map[string]string        // Cached GitHub owner type ("User"/"Organization"/"") keyed by owner login
 }
 
 // NewCompiler creates a new workflow compiler with functional options.

--- a/pkg/workflow/permissions_compiler_validator.go
+++ b/pkg/workflow/permissions_compiler_validator.go
@@ -180,13 +180,9 @@ Ensure proper audience validation and trust policies are configured.`
 // type cannot be determined, preserving prior behavior.
 func (c *Compiler) repositoryOwnerIsIndividualUser() bool {
 	slug := c.repositorySlug
-	if slug == "" || strings.Count(slug, "/") != 1 {
+	owner, repo, ok := strings.Cut(slug, "/")
+	if !ok || owner == "" || repo == "" {
 		workflowLog.Printf("Skipping owner-type check: slug %q is not in owner/repo format", slug)
-		return false
-	}
-	owner, _, _ := strings.Cut(slug, "/")
-	if owner == "" {
-		workflowLog.Printf("Skipping owner-type check: slug %q has empty owner", slug)
 		return false
 	}
 

--- a/pkg/workflow/permissions_compiler_validator.go
+++ b/pkg/workflow/permissions_compiler_validator.go
@@ -40,6 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // validatePermissions validates all permission-related configuration: dangerous
@@ -161,12 +162,51 @@ Ensure proper audience validation and trust policies are configured.`
 		fmt.Fprintln(os.Stderr, formatCompilerMessage(markdownPath, "warning", warningMsg))
 		c.IncrementWarningCount()
 	}
-	if shouldEmitCopilotRequestsEnableTip(workflowData, workflowPermissions) {
+	if shouldEmitCopilotRequestsEnableTip(workflowData, workflowPermissions) && !c.repositoryOwnerIsIndividualUser() {
 		tipMsg := `Tip: set permissions.copilot-requests: write to use GitHub Actions token-based inference with the Copilot engine instead of a personal access token (COPILOT_GITHUB_TOKEN). This option requires that your organization has centralized Copilot billing enabled and may not be available in all organizations — see https://github.github.com/gh-aw/reference/billing/ for details.`
 		fmt.Fprintln(os.Stderr, formatCompilerMessage(markdownPath, "info", tipMsg))
 	}
 
 	return workflowPermissions, nil
+}
+
+// repositoryOwnerIsIndividualUser reports whether the repository owner is confirmed
+// to be an individual user account (as opposed to an organization).
+//
+// It returns true only when the GitHub API confirms the owner type is "User". It
+// returns false when the owner is an organization, when no repository slug is set, or
+// when the API call fails (e.g. no authentication, network error). This fail-safe
+// default ensures the copilot-requests tip continues to be shown whenever the owner
+// type cannot be determined, preserving prior behavior.
+func (c *Compiler) repositoryOwnerIsIndividualUser() bool {
+	slug := c.repositorySlug
+	if slug == "" || strings.Count(slug, "/") != 1 {
+		workflowLog.Printf("Skipping owner-type check: slug %q is not in owner/repo format", slug)
+		return false
+	}
+	owner, _, _ := strings.Cut(slug, "/")
+	if owner == "" {
+		workflowLog.Printf("Skipping owner-type check: slug %q has empty owner", slug)
+		return false
+	}
+
+	if c.ownerTypeCache == nil {
+		c.ownerTypeCache = make(map[string]string)
+	}
+	ownerType, cached := c.ownerTypeCache[owner]
+	if !cached {
+		workflowLog.Printf("Checking owner type for: %s", owner)
+		output, err := RunGH("Checking repository owner type...", "api", "/users/"+owner, "--jq", ".type")
+		if err != nil {
+			workflowLog.Printf("Could not determine owner type for %q: %v", owner, err)
+			c.ownerTypeCache[owner] = ""
+			return false
+		}
+		ownerType = strings.TrimSpace(string(output))
+		c.ownerTypeCache[owner] = ownerType
+		workflowLog.Printf("Owner type for %q: %s", owner, ownerType)
+	}
+	return ownerType == "User"
 }
 
 func shouldEmitCopilotRequestsEnableTip(workflowData *WorkflowData, workflowPermissions *Permissions) bool {


### PR DESCRIPTION
## Skip `copilot-requests` tip for individual (non-org) repository owners

### Summary

The `copilot-requests: write` permission tip advises users to enable GitHub Actions token-based Copilot inference instead of a personal access token. That feature requires **centralized Copilot billing**, which is only available to GitHub **organizations** — individual user accounts cannot use it. Previously the tip was always emitted whenever a workflow met the eligibility conditions, generating confusing noise for personal-repo owners who can never act on it.

This PR suppresses the tip whenever the repository owner is confirmed to be an individual `User` account via the GitHub API, while preserving the prior behaviour (tip shown) in every case where the owner type cannot be determined.

---

### Changes

#### `pkg/workflow/compiler_types.go`
- Added `ownerTypeCache map[string]string` field to the `Compiler` struct.  
  Caches GitHub API owner-type results (e.g. `"User"`, `"Organization"`, `""`) keyed by owner login to avoid redundant API round-trips within a single compilation.

#### `pkg/workflow/permissions_compiler_validator.go`
- Added `repositoryOwnerIsIndividualUser() bool` method on `Compiler`.  
  - Parses `c.repositorySlug` into `owner/repo` components; returns `false` if the slug is absent or malformed.  
  - Calls `gh api /users/{owner} --jq .type` and writes the result into `ownerTypeCache`.  
  - Returns `true` only when the API confirms the type is `"User"`.  
  - **Fails safe**: returns `false` (tip shown) on any API error, authentication failure, or network issue, preserving the previous default behaviour for ambiguous cases.
- Guarded the `copilot-requests: write` tip emission with `!c.repositoryOwnerIsIndividualUser()`, so the tip is suppressed only for confirmed individual owners.

---

### Motivation / Design decisions

| Concern | Decision |
|---|---|
| Org owners must still see the tip | `false` is returned for `Organization` type → tip is shown as before |
| Unauthenticated / air-gapped environments | API failure returns `false` → tip shown; no regression |
| Repeated compilations | `ownerTypeCache` prevents multiple API calls for the same owner within one session |
| Malformed or missing slug | Early-return `false` → tip shown; no panic |

The fail-safe default (`false` → show tip) means this change is strictly a noise-reduction improvement for individual users with zero regression risk for org users or offline environments.

---

### Commits

| SHA | Message |
|---|---|
| `dda145e` | Skip copilot-requests tip for individual (non-org) repository owners |
| `14aaa71` | Potential fix for pull request finding |

---

### Risk

**Low.** The change is additive: a new cached API call gates an informational tip. No permissions are altered, no compilation output changes for org-owned repos, and all error paths preserve the prior behaviour.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27728583727) for issue #39923 · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 27728583727, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27728583727 -->