### PR TITLE
fix: relocate checkout manifest into safeoutputs/ so containerized safe-outputs MCP can read it

### DIFF
--- a/.changeset/patch-relocate-checkout-manifest-into-safeoutputs.md
+++ b/.changeset/patch-relocate-checkout-manifest-into-safeoutputs.md
@@ -1,0 +1,5 @@
+---
+"gh-aw": patch
+---
+
+Fix `create_pull_request` and `push_to_pull_request_branch` failing with `Repository '<owner>/<repo>' not found in workspace` after the safe-outputs MCP server moved into a container. The checkout manifest is now written to and read from `$RUNNER_TEMP/gh-aw/safeoutputs/checkout-manifest.json` instead of `$RUNNER_TEMP/gh-aw/checkout-manifest.json`, so it lives inside the `safeoutputs/` directory that is bind-mounted into the containerized safe-outputs MCP server. Previously the manifest was a sibling of the mounted directory and therefore invisible inside the container, causing manifest-first checkout resolution to fail.

--- a/actions/setup/js/build_checkout_manifest.cjs
+++ b/actions/setup/js/build_checkout_manifest.cjs
@@ -88,7 +88,10 @@ function buildCheckoutManifest(entries, options = {}) {
   const runGit = options.runGit;
   const runGH = options.runGH;
 
-  const manifestDir = path.join(runnerTemp, "gh-aw");
+  // Write under safeoutputs/ because that subdirectory is the only part of
+  // $RUNNER_TEMP/gh-aw that is bind-mounted into the containerized safe-outputs
+  // MCP server, which is where the manifest is read by findRepoCheckout.
+  const manifestDir = path.join(runnerTemp, "gh-aw", "safeoutputs");
   fs.mkdirSync(manifestDir, { recursive: true });
   const manifestPath = path.join(manifestDir, "checkout-manifest.json");
   const manifest = {};

--- a/actions/setup/js/build_checkout_manifest.test.cjs
+++ b/actions/setup/js/build_checkout_manifest.test.cjs
@@ -121,7 +121,7 @@ describe("build_checkout_manifest.cjs", () => {
       }
     );
 
-    expect(manifestPath).toBe(path.join(runnerTemp, "gh-aw", "checkout-manifest.json"));
+    expect(manifestPath).toBe(path.join(runnerTemp, "gh-aw", "safeoutputs", "checkout-manifest.json"));
     expect(manifest).toEqual({
       "owner/repo": {
         repository: "Owner/Repo",

--- a/actions/setup/js/checkout_manifest.cjs
+++ b/actions/setup/js/checkout_manifest.cjs
@@ -19,9 +19,12 @@ const { getErrorMessage } = require("./error_helpers.cjs");
  * authoritative source for resolving the on-disk checkout path and base branch
  * of cross-repo checkouts without any network access.
  *
- * The default location is $RUNNER_TEMP/gh-aw/checkout-manifest.json. Override
- * with GH_AW_CHECKOUT_MANIFEST when running outside of a GitHub Actions runner
- * (tests, local dev).
+ * The default location is $RUNNER_TEMP/gh-aw/safeoutputs/checkout-manifest.json.
+ * It lives under safeoutputs/ specifically because that subdirectory is the only
+ * part of $RUNNER_TEMP/gh-aw that is bind-mounted into the containerized
+ * safe-outputs MCP server; a sibling file at $RUNNER_TEMP/gh-aw/ would be
+ * invisible inside the container. Override with GH_AW_CHECKOUT_MANIFEST when
+ * running outside of a GitHub Actions runner (tests, local dev).
  */
 
 let cached = null;
@@ -35,7 +38,7 @@ function resolveManifestPath() {
   if (!runnerTemp || runnerTemp.trim() === "") {
     return null;
   }
-  return path.join(runnerTemp, "gh-aw", "checkout-manifest.json");
+  return path.join(runnerTemp, "gh-aw", "safeoutputs", "checkout-manifest.json");
 }
 
 function loadManifest() {

--- a/pkg/workflow/checkout_step_generator.go
+++ b/pkg/workflow/checkout_step_generator.go
@@ -73,8 +73,9 @@ func (cm *CheckoutManager) GenerateAdditionalCheckoutSteps(getActionPin func(str
 // so the safe-outputs MCP server (which runs without credentials) can look up the
 // base branch without making any network calls.
 //
-// The manifest file lives at $RUNNER_TEMP/gh-aw/checkout-manifest.json. The default
-// branch is resolved at runtime via:
+// The manifest file lives at $RUNNER_TEMP/gh-aw/safeoutputs/checkout-manifest.json
+// (under safeoutputs/ so it is bind-mounted into the containerized safe-outputs MCP
+// server). The default branch is resolved at runtime via:
 //  1. `git symbolic-ref --short refs/remotes/origin/HEAD` on the local checkout
 //     (works when actions/checkout left the remote HEAD set, typical for fetch-depth: 0)
 //  2. `gh api repos/<owner>/<repo> --jq .default_branch` as a credentialed fallback


### PR DESCRIPTION
## fix: relocate checkout manifest into `safeoutputs/` so containerized safe-outputs MCP can read it

### Problem

The safe-outputs MCP server runs in a container whose bind-mount covers only `$RUNNER_TEMP/gh-aw/safeoutputs/` (plus the workspace and `/tmp/gh-aw`). The checkout manifest was written one level up at `$RUNNER_TEMP/gh-aw/checkout-manifest.json`, making it invisible inside the container. Manifest-first checkout resolution then fell back to an unreliable git scan and failed with:

```
Repository <owner>/<repo> not found in workspace
```

This broke `create_pull_request` and `push_to_pull_request_branch`.

---

### Solution

Move the manifest write and read path from  
`$RUNNER_TEMP/gh-aw/checkout-manifest.json`  
to  
`$RUNNER_TEMP/gh-aw/safeoutputs/checkout-manifest.json`

so the file lives inside the bind-mounted directory and is visible to the containerized safe-outputs MCP server.

---

### Changes

| File | Type | Description |
|---|---|---|
| `actions/setup/js/build_checkout_manifest.cjs` | modified | Writes `checkout-manifest.json` to `safeoutputs/` subdirectory instead of the parent `gh-aw/` directory. **Core fix.** |
| `actions/setup/js/checkout_manifest.cjs` | modified | Updates the default resolved manifest path constant to `safeoutputs/checkout-manifest.json`; expands JSDoc to explain the bind-mount constraint. **Core fix.** |
| `actions/setup/js/build_checkout_manifest.test.cjs` | modified | Updates path assertion in tests from `gh-aw/checkout-manifest.json` → `gh-aw/safeoutputs/checkout-manifest.json` to match the new write location. |
| `pkg/workflow/checkout_step_generator.go` | modified | Updates a Go comment to reflect the new canonical path and documents why it must live under `safeoutputs/`. |
| `.changeset/patch-relocate-checkout-manifest-into-safeoutputs.md` | added | Patch-level changeset entry recording this fix for release notes. |

**5 files changed, 20 insertions(+), 8 deletions(-)**

---

### Risk

- **Breaking change:** No
- **Highest-impact files:** `build_checkout_manifest.cjs`, `checkout_manifest.cjs` (path change takes effect immediately on next setup run)
- **Rollout note:** Any existing `checkout-manifest.json` at the old path (`$RUNNER_TEMP/gh-aw/`) will be ignored; a fresh manifest will be written at the new path on next `setup` execution. No migration needed.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/27753042876) for issue #40025 · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 27753042876, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/27753042876 -->