### PR TITLE
Fix call-workflow startup_failure: declare payload input in workers

### DIFF
--- a/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
+++ b/.github/workflows/smoke-workflow-call-with-inputs.lock.yml
@@ -61,6 +61,11 @@ name: "Smoke Workflow Call with Inputs"
 on:
   workflow_call:
     inputs:
+      payload:
+        default: ""
+        description: "Serialized agent arguments payload (used internally by Agentic Workflows call-workflow)."
+        required: false
+        type: string
       aw_context:
         default: ""
         description: "Agent caller context (used internally by Agentic Workflows)."

--- a/pkg/workflow/call_workflow_compilation_test.go
+++ b/pkg/workflow/call_workflow_compilation_test.go
@@ -363,6 +363,81 @@ Compile without the optional workflow_call network input.
 	assert.NotContains(t, lockYAML, "GH_AW_WORKFLOW_CALL_NETWORK_ALLOWED:", "engine step env should not reference network_allowed unless opted in")
 }
 
+// TestWorkflowCallCompile_InjectsPayloadInput verifies that every workflow_call worker
+// declares the `payload` input. call-workflow callers always forward a `payload` value,
+// so the callee must declare it or GitHub Actions rejects the run with startup_failure
+// for an undeclared input.
+func TestWorkflowCallCompile_InjectsPayloadInput(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "workflow-call-payload-input")
+	workflowsDir := filepath.Join(tmpDir, ".github", "workflows")
+	require.NoError(t, os.MkdirAll(workflowsDir, 0755))
+
+	workflowMD := `---
+on: workflow_call
+engine: copilot
+permissions:
+  contents: read
+---
+
+# Reusable worker
+
+Compile a worker that should auto-declare the payload input.
+`
+	lockYAML := compileAndReadLock(t, filepath.Join(workflowsDir, "worker.md"), workflowMD)
+
+	var compiled map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(lockYAML), &compiled), "compiled workflow should remain valid YAML")
+	onMap, ok := compiled["on"].(map[string]any)
+	require.True(t, ok, "compiled workflow should include an on map")
+	workflowCallMap, ok := onMap["workflow_call"].(map[string]any)
+	require.True(t, ok, "compiled workflow should include on.workflow_call")
+	inputsMap, ok := workflowCallMap["inputs"].(map[string]any)
+	require.True(t, ok, "compiled workflow should include on.workflow_call.inputs")
+	payloadMap, ok := inputsMap[PayloadInputName].(map[string]any)
+	require.True(t, ok, "compiled workflow should include on.workflow_call.inputs.payload")
+	assert.Equal(t, "string", payloadMap["type"], "payload input should be typed as string")
+	assert.Equal(t, false, payloadMap["required"], "payload input should be optional")
+	assert.Equal(t, payloadInputDescription, payloadMap["description"], "payload description should round-trip as YAML")
+}
+
+// TestWorkflowCallCompile_PreservesUserDeclaredPayloadInput verifies that when a worker
+// already declares a `payload` input, the compiler does not duplicate or override it.
+func TestWorkflowCallCompile_PreservesUserDeclaredPayloadInput(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "workflow-call-payload-preserve")
+	workflowsDir := filepath.Join(tmpDir, ".github", "workflows")
+	require.NoError(t, os.MkdirAll(workflowsDir, 0755))
+
+	workflowMD := `---
+on:
+  workflow_call:
+    inputs:
+      payload:
+        type: string
+        required: true
+        description: User declared payload
+engine: copilot
+permissions:
+  contents: read
+---
+
+# Reusable worker
+
+Compile a worker that already declares the payload input.
+`
+	lockYAML := compileAndReadLock(t, filepath.Join(workflowsDir, "worker.md"), workflowMD)
+
+	var compiled map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(lockYAML), &compiled), "compiled workflow should remain valid YAML")
+	onMap := compiled["on"].(map[string]any)
+	workflowCallMap := onMap["workflow_call"].(map[string]any)
+	inputsMap := workflowCallMap["inputs"].(map[string]any)
+	payloadMap, ok := inputsMap[PayloadInputName].(map[string]any)
+	require.True(t, ok, "compiled workflow should retain the user-declared payload input")
+	assert.Equal(t, "User declared payload", payloadMap["description"], "user-declared payload description should be preserved")
+	assert.Equal(t, true, payloadMap["required"], "user-declared payload required flag should be preserved")
+	assert.Equal(t, 1, strings.Count(lockYAML, "payload:"), "payload input should not be duplicated")
+}
+
 // TestCallWorkflowCompile_WorkflowCallGateway tests compilation when the gateway itself
 // is triggered via workflow_call (cross-repo use case)
 func TestCallWorkflowCompile_WorkflowCallGateway(t *testing.T) {

--- a/pkg/workflow/compiler_aw_context.go
+++ b/pkg/workflow/compiler_aw_context.go
@@ -17,11 +17,20 @@ const AwContextInputName = "aw_context"
 // network allowlist at runtime for reusable workflows.
 const NetworkAllowedInputName = "network_allowed"
 
+// PayloadInputName is the workflow_call input that carries the serialized agent
+// arguments forwarded by call-workflow safe outputs. Callers always pass a
+// `payload` value, so every workflow_call worker must declare this input or
+// GitHub Actions rejects the run with startup_failure for an undeclared input.
+const PayloadInputName = "payload"
+
 // awContextInputDescription is the description for the aw_context workflow_dispatch input.
 // It signals to users that this input is managed internally by the agentic workflow system.
 const awContextInputDescription = "Agent caller context (used internally by Agentic Workflows)."
 
 const networkAllowedInputDescription = "Additional allowed network domains or ecosystem identifiers to union with network.allowed (comma-separated, for example: \"rust\" or \"python,github.com\")."
+
+// payloadInputDescription is the description for the payload workflow_call input.
+const payloadInputDescription = "Serialized agent arguments payload (used internally by Agentic Workflows call-workflow)."
 
 // injectAwContextIntoOnYAML adds the aw_context input to internal workflow triggers
 // in the given on-section YAML string.
@@ -39,6 +48,9 @@ const networkAllowedInputDescription = "Additional allowed network domains or ec
 func injectAwContextIntoOnYAML(onSection string) string {
 	updated := injectInputIntoTrigger(onSection, "workflow_dispatch", AwContextInputName, buildAwContextInputLines)
 	updated = injectInputIntoTrigger(updated, "workflow_call", AwContextInputName, buildAwContextInputLines)
+	// call-workflow callers always forward a `payload` input, so every workflow_call
+	// worker must declare it to avoid a startup_failure for an undeclared input.
+	updated = injectInputIntoTrigger(updated, "workflow_call", PayloadInputName, buildPayloadInputLines)
 	return updated
 }
 
@@ -162,6 +174,18 @@ func buildNetworkAllowedInputLines(wdIndent int) []string {
 		inputIndent + NetworkAllowedInputName + ":",
 		propIndent + "default: \"\"",
 		propIndent + "description: " + strconv.Quote(networkAllowedInputDescription),
+		propIndent + "required: false",
+		propIndent + "type: string",
+	}
+}
+
+func buildPayloadInputLines(wdIndent int) []string {
+	inputIndent := strings.Repeat(" ", wdIndent+4)
+	propIndent := strings.Repeat(" ", wdIndent+6)
+	return []string{
+		inputIndent + PayloadInputName + ":",
+		propIndent + "default: \"\"",
+		propIndent + "description: " + strconv.Quote(payloadInputDescription),
 		propIndent + "required: false",
 		propIndent + "type: string",
 	}


### PR DESCRIPTION
## Summary

`call-workflow` safe-output workflows fail at startup with `startup_failure` (no jobs run) because the compiler emits a `payload` key in the caller's `with:` block but does not declare a corresponding `payload` input in the callee's `workflow_call.inputs`. GitHub Actions rejects `workflow_call` jobs that pass undeclared inputs.

Fixes #40089.

## Root cause

The compiler always forwards the canonical payload transport in the caller job:

```yaml
with:
  payload: ${{ needs.safe_outputs.outputs.call_workflow_payload }}   # always emitted
```

But it only auto-injected `aw_context` (not `payload`) into each worker's `workflow_call.inputs`, so Actions refused to start the run.

## Fix

Auto-inject a `payload` input into every `workflow_call` worker, mirroring the existing `aw_context` injection:

```yaml
on:
  workflow_call:
    inputs:
      payload:
        default: ""
        description: "Serialized agent arguments payload (used internally by Agentic Workflows call-workflow)."
        required: false
        type: string
```

This matches the documented contract that "Workers always receive this `payload` input." The injection reuses the existing idempotent helper, so worker workflows that already declare a `payload` input are preserved unchanged.

## Changes

- `pkg/workflow/compiler_aw_context.go`: added `PayloadInputName` constant, `payloadInputDescription`, `buildPayloadInputLines`, and the `workflow_call` injection call.
- `pkg/workflow/call_workflow_compilation_test.go`: tests for payload injection and preservation of a user-declared `payload`.
- `.github/workflows/smoke-workflow-call-with-inputs.lock.yml`: recompiled to include the new input.

## Testing

- New tests `TestWorkflowCallCompile_InjectsPayloadInput` and `TestWorkflowCallCompile_PreservesUserDeclaredPayloadInput` pass.
- Full `pkg/workflow` test suite passes; `make fmt` and `make recompile` run clean (250/250 workflows compiled).