### PR TITLE
fix: support max field on custom safe-jobs

### DIFF
--- a/actions/setup/js/safe_output_type_validator.test.cjs
+++ b/actions/setup/js/safe_output_type_validator.test.cjs
@@ -740,6 +740,24 @@ describe("safe_output_type_validator", () => {
 
       expect(max).toBe(1);
     });
+
+    it("should return configured max for custom safe-job type", async () => {
+      const { getMaxAllowedForType } = await import("./safe_output_type_validator.cjs");
+
+      // Simulates a custom safe-job entry as written by safe_outputs_config_generation.go
+      const max = getMaxAllowedForType("emit_finding", { emit_finding: { max: 25, description: "Emit a finding" } });
+
+      expect(max).toBe(25);
+    });
+
+    it("should return 1 for custom safe-job type with no max in config", async () => {
+      const { getMaxAllowedForType } = await import("./safe_output_type_validator.cjs");
+
+      // Custom safe-job without max: field — should fall through to default of 1
+      const max = getMaxAllowedForType("emit_finding", { emit_finding: { description: "Emit a finding" } });
+
+      expect(max).toBe(1);
+    });
   });
 
   describe("hasValidationConfig", () => {

--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -10087,6 +10087,11 @@
                   "type": "string",
                   "description": "Output configuration for the safe job"
                 },
+                "max": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Maximum number of times this output type may be emitted per run (default: 1). Increase for workflows that emit multiple findings, comments, or other items from a single agent run."
+                },
                 "inputs": {
                   "type": "object",
                   "description": "Input parameters for the safe job (workflow_dispatch syntax) - REQUIRED: at least one input must be defined",

--- a/pkg/workflow/safe_jobs.go
+++ b/pkg/workflow/safe_jobs.go
@@ -150,15 +150,25 @@ func (c *Compiler) parseSafeJobsConfig(jobsMap map[string]any) map[string]*SafeJ
 
 		// Parse max (optional; controls how many times this output type may be emitted per run)
 		if maxVal, exists := jobConfig["max"]; exists {
+			maxInt := 0
 			switch v := maxVal.(type) {
 			case int:
-				if v > 0 {
-					safeJob.Max = v
-				}
+				maxInt = v
+			case int64:
+				maxInt = int(v)
+			case uint64:
+				maxInt = int(v)
 			case float64:
-				if int(v) > 0 {
-					safeJob.Max = int(v)
+				if v != float64(int(v)) {
+					safeJobsLog.Printf("Warning: ignoring non-integer max for safe-job %q: %v", jobName, v)
+				} else {
+					maxInt = int(v)
 				}
+			default:
+				safeJobsLog.Printf("Warning: ignoring non-numeric max for safe-job %q: %T", jobName, maxVal)
+			}
+			if maxInt > 0 {
+				safeJob.Max = maxInt
 			}
 		}
 

--- a/pkg/workflow/safe_jobs.go
+++ b/pkg/workflow/safe_jobs.go
@@ -29,6 +29,7 @@ type SafeJobConfig struct {
 	Inputs      map[string]*InputDefinition `yaml:"inputs,omitempty"`
 	GitHubToken string                      `yaml:"github-token,omitempty"`
 	Output      string                      `yaml:"output,omitempty"`
+	Max         int                         `yaml:"max,omitempty"` // Maximum number of times this output type may be emitted per run (default: 1)
 }
 
 // parseSafeJobsConfig parses safe-jobs configuration from a jobs map.
@@ -147,7 +148,21 @@ func (c *Compiler) parseSafeJobsConfig(jobsMap map[string]any) map[string]*SafeJ
 			}
 		}
 
-		safeJobsLog.Printf("Parsed safe-job configuration: name=%s, has_steps=%v, has_inputs=%v", jobName, len(safeJob.Steps) > 0, len(safeJob.Inputs) > 0)
+		// Parse max (optional; controls how many times this output type may be emitted per run)
+		if maxVal, exists := jobConfig["max"]; exists {
+			switch v := maxVal.(type) {
+			case int:
+				if v > 0 {
+					safeJob.Max = v
+				}
+			case float64:
+				if int(v) > 0 {
+					safeJob.Max = int(v)
+				}
+			}
+		}
+
+		safeJobsLog.Printf("Parsed safe-job configuration: name=%s, has_steps=%v, has_inputs=%v, max=%d", jobName, len(safeJob.Steps) > 0, len(safeJob.Inputs) > 0, safeJob.Max)
 		result[jobName] = safeJob
 	}
 

--- a/pkg/workflow/safe_jobs_test.go
+++ b/pkg/workflow/safe_jobs_test.go
@@ -148,6 +148,82 @@ func TestParseSafeJobsConfig(t *testing.T) {
 	}
 }
 
+func TestParseSafeJobsConfigMax(t *testing.T) {
+	c := NewCompiler()
+
+	jobsMap := map[string]any{
+		"emit-finding": map[string]any{
+			"description": "Emit a quality finding",
+			"max":         float64(25), // YAML numbers are float64 when parsed generically
+			"inputs": map[string]any{
+				"message": map[string]any{
+					"description": "The finding message",
+					"required":    true,
+					"type":        "string",
+				},
+			},
+		},
+		"single-output": map[string]any{
+			"description": "Default max (no max field)",
+			"inputs": map[string]any{
+				"body": map[string]any{
+					"type": "string",
+				},
+			},
+		},
+	}
+
+	result := c.parseSafeJobsConfig(jobsMap)
+
+	if result == nil {
+		t.Fatal("Expected safe-jobs config to be parsed, got nil")
+	}
+
+	finding := result["emit-finding"]
+	if finding == nil {
+		t.Fatal("Expected 'emit-finding' job to exist")
+	}
+	if finding.Max != 25 {
+		t.Errorf("Expected Max to be 25, got %d", finding.Max)
+	}
+
+	single := result["single-output"]
+	if single == nil {
+		t.Fatal("Expected 'single-output' job to exist")
+	}
+	if single.Max != 0 {
+		t.Errorf("Expected Max to be 0 (unset) when not specified, got %d", single.Max)
+	}
+}
+
+func TestParseSafeJobsConfigMaxInvalidIgnored(t *testing.T) {
+	c := NewCompiler()
+
+	jobsMap := map[string]any{
+		"bad-max": map[string]any{
+			"max": float64(-5), // negative — should be ignored
+			"inputs": map[string]any{
+				"x": map[string]any{"type": "string"},
+			},
+		},
+		"zero-max": map[string]any{
+			"max": float64(0), // zero — should be ignored
+			"inputs": map[string]any{
+				"x": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	result := c.parseSafeJobsConfig(jobsMap)
+
+	if result["bad-max"].Max != 0 {
+		t.Errorf("Expected negative max to be ignored (Max=0), got %d", result["bad-max"].Max)
+	}
+	if result["zero-max"].Max != 0 {
+		t.Errorf("Expected zero max to be ignored (Max=0), got %d", result["zero-max"].Max)
+	}
+}
+
 func TestBuildSafeJobs(t *testing.T) {
 	c := NewCompiler()
 

--- a/pkg/workflow/safe_outputs_config_generation.go
+++ b/pkg/workflow/safe_outputs_config_generation.go
@@ -80,6 +80,9 @@ func generateSafeOutputsConfig(data *WorkflowData) (string, error) {
 			if jobConfig.Output != "" {
 				safeJobConfig["output"] = jobConfig.Output
 			}
+			if jobConfig.Max > 0 {
+				safeJobConfig["max"] = jobConfig.Max
+			}
 			if len(jobConfig.Inputs) > 0 {
 				inputsConfig := make(map[string]any)
 				for inputName, inputDef := range jobConfig.Inputs {

--- a/pkg/workflow/safe_outputs_config_generation_test.go
+++ b/pkg/workflow/safe_outputs_config_generation_test.go
@@ -461,6 +461,46 @@ func TestGenerateSafeOutputsConfigAddLabelsBlocked(t *testing.T) {
 	assert.Equal(t, "triage-needed", blockedSlice[3], "Fourth blocked pattern should match")
 }
 
+// TestGenerateSafeOutputsConfigSafeJobMax tests that the max field is emitted in config.json
+// for custom safe-jobs so the output collector can enforce it.
+func TestGenerateSafeOutputsConfigSafeJobMax(t *testing.T) {
+	data := &WorkflowData{
+		SafeOutputs: &SafeOutputsConfig{
+			Jobs: map[string]*SafeJobConfig{
+				"emit-finding": {
+					Description: "Emit a quality finding",
+					Max:         25,
+					Inputs: map[string]*InputDefinition{
+						"message": {Type: "string", Required: true},
+					},
+				},
+				"single-output": {
+					Description: "Max not set — should be omitted from config",
+					Inputs: map[string]*InputDefinition{
+						"body": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := generateSafeOutputsConfig(data)
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+
+	findingCfg, ok := parsed["emit-finding"].(map[string]any)
+	require.True(t, ok, "emit-finding should be present in config")
+	assert.InDelta(t, float64(25), findingCfg["max"], 0.0001, "max should be 25")
+
+	singleCfg, ok := parsed["single-output"].(map[string]any)
+	require.True(t, ok, "single-output should be present in config")
+	_, hasMax := singleCfg["max"]
+	assert.False(t, hasMax, "max should be absent when not configured (lets runtime default to 1)")
+}
+
 // TestGenerateSafeOutputsConfigCreatePullRequestTargetRepo tests that target-repo
 // and related cross-repo fields are included in config.json for create_pull_request.
 func TestGenerateSafeOutputsConfigCreatePullRequestTargetRepo(t *testing.T) {


### PR DESCRIPTION
Fixes #42249

## Problem

Custom safe-job output types (`safe-outputs.jobs:`) were hard-capped at **1 emission per run**. Any additional calls were silently dropped:

```
Too many items of type 'emit_finding'. Maximum allowed: 1.
```

### Root cause

Three gaps in the stack:

1. `SafeJobConfig` had no `Max` field — no way to configure a higher limit.
2. `parseSafeJobsConfig` never read a `max:` key.
3. `safe_outputs_config_generation.go` never wrote a `max` key into `config.json` for custom safe-jobs.

At runtime `getMaxAllowedForType` in `safe_output_type_validator.cjs` falls back to `typeConfig?.defaultMax ?? 1`. Since custom types aren't in the built-in validation config, `typeConfig` is always `undefined`, making the effective limit **1** with no way to override it.

## Fix

Three coordinated changes:

| File | Change |
|---|---|
| `pkg/workflow/safe_jobs.go` | Add `Max int` field to `SafeJobConfig` (`yaml:"max,omitempty"`) |
| `pkg/workflow/safe_jobs.go` | Parse the `max:` key in `parseSafeJobsConfig` |
| `pkg/workflow/safe_outputs_config_generation.go` | Emit `"max": N` in the safe-job config block when `Max > 0` |

## Usage

```yaml
safe-outputs:
  jobs:
    emit-finding:
      max: 25          # allow up to 25 findings per run
      description: "Emit a PR quality finding as a check-run annotation"
      runs-on: ubuntu-latest
      ...
```

Without `max:` the default of 1 is preserved (no behaviour change for existing workflows).