### PR TITLE
fix(aw-dashboard): use detached spawn to prevent gh-aw hang on inherited handles

### DIFF
--- a/.github/extensions/agentic-workflows-dashboard/dashboard-cli.mjs
+++ b/.github/extensions/agentic-workflows-dashboard/dashboard-cli.mjs
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 import { join } from "node:path";
@@ -9,7 +9,54 @@ function combineOutput(stdout, stderr) {
   return [stdout, stderr].filter(Boolean).join("\n").trim();
 }
 
-function execp(bin, args, cwd, { combineIO = false, execFileFn = execFile, env = process.env } = {}) {
+/**
+ * Wraps spawn() with the same callback signature as execFile(), but uses
+ * stdio: ['ignore', 'pipe', 'pipe'] so the child process never blocks waiting
+ * for stdin. This is important in environments where the parent process holds
+ * a special stdin handle (e.g. Copilot CLI) that causes the child to hang.
+ */
+function spawnExecFile(file, args, options, callback) {
+  const { env, cwd, maxBuffer = 10 * 1024 * 1024 } = options ?? {};
+  // detached: true prevents the child from inheriting the parent's special
+  // handles (e.g. Copilot CLI named pipes) that would otherwise cause gh-aw
+  // to block indefinitely waiting on an inherited pipe it never owns.
+  const proc = spawn(file, args, { env, cwd, stdio: ["ignore", "pipe", "pipe"], detached: true });
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  let stdoutLen = 0;
+  let stderrLen = 0;
+  let overflowed = false;
+
+  proc.stdout.on("data", chunk => {
+    stdoutLen += chunk.length;
+    if (stdoutLen > maxBuffer) { overflowed = true; return; }
+    stdoutChunks.push(chunk);
+  });
+  proc.stderr.on("data", chunk => {
+    stderrLen += chunk.length;
+    if (stderrLen > maxBuffer) { overflowed = true; return; }
+    stderrChunks.push(chunk);
+  });
+
+  proc.on("error", err => callback(err, "", ""));
+  proc.on("close", code => {
+    const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+    const stderr = Buffer.concat(stderrChunks).toString("utf8");
+    if (overflowed) {
+      const err = new Error("stdout/stderr maxBuffer exceeded");
+      err.code = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+      callback(err, stdout, stderr);
+    } else if (code !== 0) {
+      const err = new Error(`Command failed with exit code ${code}`);
+      err.code = code;
+      callback(err, stdout, stderr);
+    } else {
+      callback(null, stdout, stderr);
+    }
+  });
+}
+
+function execp(bin, args, cwd, { combineIO = false, execFileFn = spawnExecFile, env = process.env } = {}) {
   return new Promise((resolve, reject) => {
     execFileFn(
       bin,
@@ -50,7 +97,7 @@ async function findDevBinary(cwd, accessFn = access, platform = process.platform
   }
 }
 
-export function createGhAwRunner({ getWorkspacePath, accessFn = access, execFileFn = execFile, platform = process.platform, env = process.env }) {
+export function createGhAwRunner({ getWorkspacePath, accessFn = access, execFileFn = spawnExecFile, platform = process.platform, env = process.env }) {
   async function runExec(bin, args, cwd, options) {
     return execp(bin, args, cwd, { ...options, execFileFn, env });
   }
@@ -75,7 +122,7 @@ export function createGhAwRunnerWithStatus(options) {
     if (devBin) {
       const output = await execp(devBin, ["version"], cwd, {
         combineIO: true,
-        execFileFn: options.execFileFn ?? execFile,
+        execFileFn: options.execFileFn ?? spawnExecFile,
         env: options.env ?? process.env,
       });
       return {
@@ -90,7 +137,7 @@ export function createGhAwRunnerWithStatus(options) {
     try {
       const output = await execp("gh", ["aw", "version"], cwd, {
         combineIO: true,
-        execFileFn: options.execFileFn ?? execFile,
+        execFileFn: options.execFileFn ?? spawnExecFile,
         env: options.env ?? process.env,
       });
       return {

--- a/.github/extensions/agentic-workflows-dashboard/package-lock.json
+++ b/.github/extensions/agentic-workflows-dashboard/package-lock.json
@@ -175,9 +175,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -195,9 +192,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -215,9 +209,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -235,9 +226,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -255,9 +243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -275,9 +260,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -784,9 +763,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -808,9 +784,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -832,9 +805,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
### Summary

Fixes a hang in the `aw-dashboard` extension when `gh-aw` is invoked from the Copilot CLI (or any environment where the parent process holds a special stdin handle such as a named pipe). Child processes spawned with `execFile` inherited that handle and blocked indefinitely waiting for input they never received.

### Root cause

When the parent process holds a special stdin handle (e.g. Copilot CLI named pipe), `execFile`-spawned children inherit it. The child blocks waiting on the inherited pipe, causing the entire dashboard to hang.

### Changes

**`.github/extensions/agentic-workflows-dashboard/dashboard-cli.mjs`**

- Replaces `execFile` import with `spawn` from `node:child_process`.
- Introduces `spawnExecFile(file, args, options, callback)` — a drop-in wrapper around `spawn()` that:
  - Uses `stdio: ['ignore', 'pipe', 'pipe']` to explicitly ignore stdin.
  - Uses `detached: true` to prevent inheritance of the parent's special handles.
  - Accumulates stdout/stderr chunks with a configurable `maxBuffer` (default 10 MB).
  - Surfaces `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` on overflow and propagates non-zero exit codes.
  - Preserves the `execFile` callback signature for full backward compatibility with injected test mocks.
- Updates all four `execFileFn` default sites (`execp`, `createGhAwRunner`, and both fallbacks in `createGhAwRunnerWithStatus`) to use `spawnExecFile` instead of `execFile`.

### Backward compatibility

The `execFileFn` injection point is retained at every call site. Existing tests that supply a mock `execFileFn` are unaffected.

### Testing

Verify that the dashboard no longer hangs when run from the Copilot CLI. Existing unit tests that mock `execFileFn` continue to pass without modification.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/28391343184) for #42311 · 50.5 AIC · ⌖ 7.57 AIC · ⊞ 4.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.65, model: claude-sonnet-4.6, id: 28391343184, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/28391343184 -->