### PR TITLE
feat: add runner.topology arc-dind support for ARC/DinD rootless execution

### DIFF
--- a/pkg/parser/schemas/main_workflow_schema.json
+++ b/pkg/parser/schemas/main_workflow_schema.json
@@ -2663,6 +2663,18 @@
         }
       ]
     },
+    "runner": {
+      "type": "object",
+      "description": "Runner topology configuration. Tells gh-aw and AWF what kind of runner environment the workflow targets, so they can activate topology-specific behaviors automatically (split-filesystem handling, network isolation, sysroot images, tool cache redirection). The runner.topology key is the single stable contract between gh-aw and AWF for runner environment detection.",
+      "additionalProperties": false,
+      "properties": {
+        "topology": {
+          "type": "string",
+          "description": "Runner execution topology. When set to 'arc-dind', gh-aw emits the topology in the AWF config, redirects the tool cache to a shared volume, and validates that no generated steps require root. AWF then activates split-filesystem handling, network isolation, sysroot image staging, and DinD pre-staging automatically.",
+          "enum": ["arc-dind"]
+        }
+      }
+    },
     "timeout-minutes": {
       "$ref": "#/$defs/templatable_integer",
       "description": "Workflow timeout in minutes (GitHub Actions standard field). Defaults to 20 minutes for agentic workflows. Has sensible defaults and can typically be omitted. Custom runners support longer timeouts beyond the GitHub-hosted runner limit. Supports GitHub Actions expressions (e.g. '${{ inputs.timeout }}') for reusable workflow_call workflows.",

--- a/pkg/workflow/awf_config.go
+++ b/pkg/workflow/awf_config.go
@@ -147,6 +147,11 @@ type AWFConfigFile struct {
 	// Schema is the JSON schema reference for IDE auto-complete support.
 	Schema string `json:"$schema,omitempty"`
 
+	// Runner contains runner topology metadata that AWF uses to activate
+	// topology-specific behaviors (split-filesystem handling, network isolation,
+	// tool cache redirection, sysroot image selection).
+	Runner *AWFRunnerConfig `json:"runner,omitempty"`
+
 	// Network contains network egress control configuration.
 	Network *AWFNetworkConfig `json:"network,omitempty"`
 
@@ -162,6 +167,18 @@ type AWFConfigFile struct {
 	// Chroot contains chroot execution overrides for split-filesystem ARC/DinD runners.
 	// This field is not populated at compile time; it is injected at runtime when DinD topology is detected.
 	Chroot *AWFChrootConfig `json:"chroot,omitempty"`
+}
+
+// AWFRunnerConfig is the "runner" section of the AWF config file.
+// It provides a single stable contract between gh-aw and AWF for runner topology
+// detection, letting AWF resolve all internal details (network isolation, sysroot
+// image, path-prefix probes, tool cache validation) from this signal.
+type AWFRunnerConfig struct {
+	// Topology identifies the runner execution topology.
+	// Currently supported values: "arc-dind" (ARC with Docker-in-Docker sidecar).
+	// When set to "arc-dind", AWF activates split-filesystem handling, network
+	// isolation, sysroot image staging, and DinD pre-staging automatically.
+	Topology string `json:"topology,omitempty"`
 }
 
 // AWFNetworkConfig is the "network" section of the AWF config file.
@@ -341,6 +358,12 @@ func BuildAWFConfigJSON(config AWFCommandConfig) (string, error) {
 
 	awfConfig := AWFConfigFile{
 		Schema: buildAWFConfigSchemaURL(firewallConfig),
+	}
+
+	// ── Runner section ──────────────────────────────────────────────────────
+	if topology := getRunnerTopology(config.WorkflowData); topology != "" {
+		awfConfig.Runner = &AWFRunnerConfig{Topology: topology}
+		awfConfigLog.Printf("Runner section: topology=%s", topology)
 	}
 
 	// ── Network section ──────────────────────────────────────────────────────
@@ -663,4 +686,18 @@ func extractModelFallback(workflowData *WorkflowData) *AWFModelFallbackConfig {
 	return &AWFModelFallbackConfig{
 		Enabled: mf,
 	}
+}
+
+// getRunnerTopology extracts the runner topology string from WorkflowData.
+// Returns an empty string when no topology is configured.
+func getRunnerTopology(workflowData *WorkflowData) string {
+	if workflowData == nil || workflowData.RunnerConfig == nil {
+		return ""
+	}
+	return workflowData.RunnerConfig.Topology
+}
+
+// isArcDindTopology returns true when the workflow targets ARC/DinD runners.
+func isArcDindTopology(workflowData *WorkflowData) bool {
+	return getRunnerTopology(workflowData) == RunnerTopologyArcDind
 }

--- a/pkg/workflow/awf_config_test.go
+++ b/pkg/workflow/awf_config_test.go
@@ -127,6 +127,43 @@ func TestBuildAWFConfigJSON(t *testing.T) {
 		assert.Contains(t, jsonStr, `"topologyAttach":["awmg-mcpg"]`, "should attach MCP gateway container to awf-net")
 	})
 
+	t.Run("runner topology arc-dind emits runner section", func(t *testing.T) {
+		config := AWFCommandConfig{
+			EngineName:     "copilot",
+			AllowedDomains: "github.com",
+			WorkflowData: &WorkflowData{
+				EngineConfig: &EngineConfig{ID: "copilot"},
+				NetworkPermissions: &NetworkPermissions{
+					Firewall: &FirewallConfig{Enabled: true},
+				},
+				RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+			},
+		}
+
+		jsonStr, err := BuildAWFConfigJSON(config)
+		require.NoError(t, err, "BuildAWFConfigJSON should not return an error")
+
+		assert.Contains(t, jsonStr, `"runner":{"topology":"arc-dind"}`, "should emit runner topology")
+	})
+
+	t.Run("runner section omitted when no topology set", func(t *testing.T) {
+		config := AWFCommandConfig{
+			EngineName:     "copilot",
+			AllowedDomains: "github.com",
+			WorkflowData: &WorkflowData{
+				EngineConfig: &EngineConfig{ID: "copilot"},
+				NetworkPermissions: &NetworkPermissions{
+					Firewall: &FirewallConfig{Enabled: true},
+				},
+			},
+		}
+
+		jsonStr, err := BuildAWFConfigJSON(config)
+		require.NoError(t, err, "BuildAWFConfigJSON should not return an error")
+
+		assert.NotContains(t, jsonStr, `"runner"`, "should not emit runner section when not configured")
+	})
+
 	t.Run("openai API target is included in apiProxy targets", func(t *testing.T) {
 		config := AWFCommandConfig{
 			EngineName:     "codex",

--- a/pkg/workflow/compiler.go
+++ b/pkg/workflow/compiler.go
@@ -85,6 +85,14 @@ func (c *Compiler) CompileWorkflow(markdownPath string) error {
 //   - validatePermissions: permissions parsing, MCP tool constraints, workflow_run security
 //   - validateToolConfiguration: safe-outputs, GitHub tools, dispatches, and resources
 func (c *Compiler) validateWorkflowData(workflowData *WorkflowData, markdownPath string) error {
+	if err := validateRunnerConfig(workflowData.RunnerConfig); err != nil {
+		return formatCompilerError(markdownPath, "error", err.Error(), err)
+	}
+
+	if err := validateArcDindRootless(workflowData); err != nil {
+		return formatCompilerError(markdownPath, "error", err.Error(), err)
+	}
+
 	if err := c.validateExpressions(workflowData, markdownPath); err != nil {
 		return err
 	}

--- a/pkg/workflow/compiler_types.go
+++ b/pkg/workflow/compiler_types.go
@@ -552,6 +552,7 @@ type WorkflowData struct {
 	NeedsTextOutput                bool                            // whether the workflow uses ${{ needs.task.outputs.text }}
 	NetworkPermissions             *NetworkPermissions             // parsed network permissions
 	SandboxConfig                  *SandboxConfig                  // parsed sandbox configuration (AWF or SRT)
+	RunnerConfig                   *RunnerConfig                   // parsed runner topology configuration (e.g., arc-dind)
 	SafeOutputs                    *SafeOutputsConfig              // output configuration for automatic output routes
 	MCPScripts                     *MCPScriptsConfig               // mcp-scripts configuration for custom MCP tools
 	LabelNames                     []string                        // label names that must match for pull_request_target labeled events (on.labels)

--- a/pkg/workflow/compiler_yaml_main_job.go
+++ b/pkg/workflow/compiler_yaml_main_job.go
@@ -243,6 +243,15 @@ func (c *Compiler) generateRuntimeAndWorkspaceSetupSteps(yaml *strings.Builder, 
 	yaml.WriteString("      - name: Create gh-aw temp directory\n")
 	yaml.WriteString("        run: bash \"${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh\"\n")
 
+	// Redirect tool cache for ARC/DinD runners.
+	// On ARC, the standard RUNNER_TOOL_CACHE=/opt/hostedtoolcache is invisible to the DinD
+	// daemon's filesystem. Redirecting to /tmp/gh-aw/tool-cache (a shared emptyDir volume)
+	// ensures setup-* actions install to a path visible to both runner and DinD containers.
+	if isArcDindTopology(data) {
+		yaml.WriteString("      - name: Redirect tool cache for ARC/DinD\n")
+		yaml.WriteString("        run: echo \"RUNNER_TOOL_CACHE=/tmp/gh-aw/tool-cache\" >> \"$GITHUB_ENV\"\n")
+	}
+
 	// Configure gh CLI for GitHub Enterprise hosts (*.ghe.com / GHES).
 	// This step runs configure_gh_for_ghe.sh which:
 	//   1. Detects the GitHub host from GITHUB_SERVER_URL

--- a/pkg/workflow/frontmatter_types.go
+++ b/pkg/workflow/frontmatter_types.go
@@ -6,6 +6,19 @@ import (
 
 var frontmatterTypesLog = logger.New("workflow:frontmatter_types")
 
+// RunnerTopologyArcDind is the topology value for ARC runners with Docker-in-Docker sidecars.
+const RunnerTopologyArcDind = "arc-dind"
+
+// RunnerConfig represents runner topology configuration from the workflow frontmatter.
+// The topology field is the single stable contract between gh-aw and AWF for runner
+// environment detection — AWF resolves all internal details (network isolation, sysroot
+// image, path-prefix probes, tool cache validation) from this signal.
+type RunnerConfig struct {
+	// Topology identifies the runner execution topology.
+	// Supported values: "arc-dind" (ARC with Docker-in-Docker sidecar).
+	Topology string `json:"topology,omitempty" yaml:"topology,omitempty"`
+}
+
 // RuntimeConfig represents the configuration for a single runtime
 type RuntimeConfig struct {
 	Version           string `json:"version,omitempty"`             // Version of the runtime (e.g., "20" for Node, "3.11" for Python)
@@ -330,6 +343,7 @@ type FrontmatterConfig struct {
 	// Network and sandbox configuration
 	Network *NetworkPermissions `json:"network,omitempty"`
 	Sandbox *SandboxConfig      `json:"sandbox,omitempty"`
+	Runner  *RunnerConfig       `json:"runner,omitempty"`
 
 	// Feature flags and other settings
 	Features map[string]any    `json:"features,omitempty"` // Dynamic feature flags

--- a/pkg/workflow/runner_config.go
+++ b/pkg/workflow/runner_config.go
@@ -1,0 +1,53 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/github/gh-aw/pkg/logger"
+)
+
+var runnerConfigLog = logger.New("workflow:runner_config")
+
+// extractRunnerConfig extracts runner topology configuration from frontmatter.
+// Returns nil when no runner configuration is present.
+func extractRunnerConfig(frontmatter map[string]any) *RunnerConfig {
+	runner, exists := frontmatter["runner"]
+	if !exists {
+		return nil
+	}
+
+	runnerObj, ok := runner.(map[string]any)
+	if !ok {
+		runnerConfigLog.Printf("runner field has unexpected type %T, expected object", runner)
+		return nil
+	}
+
+	config := &RunnerConfig{}
+	if topology, ok := runnerObj["topology"].(string); ok {
+		config.Topology = topology
+		runnerConfigLog.Printf("Runner topology: %s", topology)
+	}
+
+	if config.Topology == "" {
+		return nil
+	}
+
+	return config
+}
+
+// validateRunnerConfig validates the runner topology configuration.
+// It returns an error if the topology value is not recognized.
+func validateRunnerConfig(config *RunnerConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	switch config.Topology {
+	case RunnerTopologyArcDind:
+		return nil
+	case "":
+		return nil
+	default:
+		return fmt.Errorf("unsupported runner.topology value %q; supported values: %q", config.Topology, RunnerTopologyArcDind)
+	}
+}

--- a/pkg/workflow/runner_config_test.go
+++ b/pkg/workflow/runner_config_test.go
@@ -1,0 +1,92 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractRunnerConfig(t *testing.T) {
+	t.Run("nil when runner not present", func(t *testing.T) {
+		fm := map[string]any{"name": "test"}
+		assert.Nil(t, extractRunnerConfig(fm))
+	})
+
+	t.Run("nil when runner is not an object", func(t *testing.T) {
+		fm := map[string]any{"runner": "arc-dind"}
+		assert.Nil(t, extractRunnerConfig(fm))
+	})
+
+	t.Run("nil when topology is empty", func(t *testing.T) {
+		fm := map[string]any{"runner": map[string]any{}}
+		assert.Nil(t, extractRunnerConfig(fm))
+	})
+
+	t.Run("extracts arc-dind topology", func(t *testing.T) {
+		fm := map[string]any{
+			"runner": map[string]any{
+				"topology": "arc-dind",
+			},
+		}
+		cfg := extractRunnerConfig(fm)
+		require.NotNil(t, cfg)
+		assert.Equal(t, RunnerTopologyArcDind, cfg.Topology)
+	})
+}
+
+func TestValidateRunnerConfig(t *testing.T) {
+	t.Run("nil config is valid", func(t *testing.T) {
+		assert.NoError(t, validateRunnerConfig(nil))
+	})
+
+	t.Run("arc-dind is valid", func(t *testing.T) {
+		assert.NoError(t, validateRunnerConfig(&RunnerConfig{Topology: RunnerTopologyArcDind}))
+	})
+
+	t.Run("empty topology is valid", func(t *testing.T) {
+		assert.NoError(t, validateRunnerConfig(&RunnerConfig{}))
+	})
+
+	t.Run("unsupported topology returns error", func(t *testing.T) {
+		err := validateRunnerConfig(&RunnerConfig{Topology: "unknown"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported runner.topology")
+		assert.Contains(t, err.Error(), "unknown")
+	})
+}
+
+func TestIsArcDindTopology(t *testing.T) {
+	t.Run("false when nil workflow data", func(t *testing.T) {
+		assert.False(t, isArcDindTopology(nil))
+	})
+
+	t.Run("false when nil runner config", func(t *testing.T) {
+		assert.False(t, isArcDindTopology(&WorkflowData{}))
+	})
+
+	t.Run("false when topology is empty", func(t *testing.T) {
+		assert.False(t, isArcDindTopology(&WorkflowData{
+			RunnerConfig: &RunnerConfig{},
+		}))
+	})
+
+	t.Run("true when topology is arc-dind", func(t *testing.T) {
+		assert.True(t, isArcDindTopology(&WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+		}))
+	})
+}
+
+func TestGetRunnerTopology(t *testing.T) {
+	t.Run("empty when nil workflow data", func(t *testing.T) {
+		assert.Empty(t, getRunnerTopology(nil))
+	})
+
+	t.Run("returns topology when set", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: "arc-dind"},
+		}
+		assert.Equal(t, "arc-dind", getRunnerTopology(wd))
+	})
+}

--- a/pkg/workflow/runner_topology_validation.go
+++ b/pkg/workflow/runner_topology_validation.go
@@ -1,0 +1,104 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/github/gh-aw/pkg/logger"
+)
+
+var runnerTopologyValidationLog = logger.New("workflow:runner_topology_validation")
+
+// validateArcDindRootless checks that no generated step content uses sudo or other
+// root-requiring operations when the workflow targets ARC/DinD topology.
+// On ARC, the runner container does not have root access, so anything requiring
+// root must already be handled at image build time.
+func validateArcDindRootless(workflowData *WorkflowData) error {
+	if !isArcDindTopology(workflowData) {
+		return nil
+	}
+	runnerTopologyValidationLog.Print("Validating rootless execution for arc-dind topology")
+
+	// Check custom steps, pre-steps, pre-agent-steps, and post-steps for sudo usage.
+	checks := []struct {
+		name    string
+		content string
+	}{
+		{"steps", workflowData.CustomSteps},
+		{"pre-steps", workflowData.PreSteps},
+		{"pre-agent-steps", workflowData.PreAgentSteps},
+		{"post-steps", workflowData.PostSteps},
+	}
+
+	for _, check := range checks {
+		if check.content == "" {
+			continue
+		}
+		if violations := findRootRequiringPatterns(check.content); len(violations) > 0 {
+			return fmt.Errorf(
+				"runner.topology is arc-dind but %s contain root-requiring operations (%s); "+
+					"ARC runners do not have root access — remove sudo and privileged commands, "+
+					"or use a pre-built sysroot image for system packages",
+				check.name, strings.Join(violations, ", "),
+			)
+		}
+	}
+
+	return nil
+}
+
+// findRootRequiringPatterns scans step content for patterns that require root privileges.
+// Returns a deduplicated list of violation descriptions found.
+func findRootRequiringPatterns(content string) []string {
+	var violations []string
+	seen := map[string]bool{}
+
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Skip comments and empty lines
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Skip YAML keys (e.g. "name:", "run:", "if:")
+		if !strings.Contains(trimmed, "sudo") && !strings.Contains(trimmed, "apt-get") && !strings.Contains(trimmed, "apt ") {
+			continue
+		}
+
+		if containsSudoCommand(trimmed) && !seen["sudo"] {
+			seen["sudo"] = true
+			violations = append(violations, "sudo")
+		}
+		if containsAptGetInstall(trimmed) && !seen["apt-get install"] {
+			seen["apt-get install"] = true
+			violations = append(violations, "apt-get install")
+		}
+	}
+
+	return violations
+}
+
+// containsSudoCommand checks if a line contains a sudo invocation.
+// Matches "sudo " at word boundaries but not inside comments or strings mentioning sudo.
+func containsSudoCommand(line string) bool {
+	// Look for sudo as a command (not in a YAML key or comment)
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	// Check for sudo at start of a command or after common shell operators
+	for _, prefix := range []string{"sudo ", "sudo\t"} {
+		if strings.Contains(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAptGetInstall checks if a line contains apt-get install.
+func containsAptGetInstall(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	return strings.Contains(trimmed, "apt-get install") || strings.Contains(trimmed, "apt install")
+}

--- a/pkg/workflow/runner_topology_validation_test.go
+++ b/pkg/workflow/runner_topology_validation_test.go
@@ -1,0 +1,107 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateArcDindRootless(t *testing.T) {
+	t.Run("no error when topology is not arc-dind", func(t *testing.T) {
+		wd := &WorkflowData{
+			CustomSteps: "      - run: sudo apt-get install -y gcc\n",
+		}
+		assert.NoError(t, validateArcDindRootless(wd))
+	})
+
+	t.Run("no error when no steps use sudo", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+			CustomSteps:  "      - run: echo hello\n",
+		}
+		assert.NoError(t, validateArcDindRootless(wd))
+	})
+
+	t.Run("error when custom steps use sudo", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+			CustomSteps:  "      - run: sudo apt-get install -y gcc\n",
+		}
+		err := validateArcDindRootless(wd)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "arc-dind")
+		assert.Contains(t, err.Error(), "sudo")
+	})
+
+	t.Run("error when pre-steps use apt-get install", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+			PreSteps:     "      - run: apt-get install -y build-essential\n",
+		}
+		err := validateArcDindRootless(wd)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "apt-get install")
+		assert.Contains(t, err.Error(), "pre-steps")
+	})
+
+	t.Run("error when post-steps use sudo", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+			PostSteps:    "      - run: sudo rm -rf /tmp/cache\n",
+		}
+		err := validateArcDindRootless(wd)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "post-steps")
+	})
+
+	t.Run("no error when steps are empty", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+		}
+		assert.NoError(t, validateArcDindRootless(wd))
+	})
+
+	t.Run("ignores comments containing sudo", func(t *testing.T) {
+		wd := &WorkflowData{
+			RunnerConfig: &RunnerConfig{Topology: RunnerTopologyArcDind},
+			CustomSteps:  "      - run: |\n          # don't use sudo here\n          echo hello\n",
+		}
+		assert.NoError(t, validateArcDindRootless(wd))
+	})
+}
+
+func TestFindRootRequiringPatterns(t *testing.T) {
+	t.Run("empty for clean content", func(t *testing.T) {
+		assert.Empty(t, findRootRequiringPatterns("echo hello\nls -la\n"))
+	})
+
+	t.Run("detects sudo", func(t *testing.T) {
+		violations := findRootRequiringPatterns("sudo apt-get update\nsudo apt-get install gcc\n")
+		assert.Contains(t, violations, "sudo")
+	})
+
+	t.Run("detects apt-get install", func(t *testing.T) {
+		violations := findRootRequiringPatterns("apt-get install -y gcc\n")
+		assert.Contains(t, violations, "apt-get install")
+	})
+
+	t.Run("detects apt install", func(t *testing.T) {
+		violations := findRootRequiringPatterns("apt install -y gcc\n")
+		assert.Contains(t, violations, "apt-get install")
+	})
+
+	t.Run("skips comments", func(t *testing.T) {
+		assert.Empty(t, findRootRequiringPatterns("# sudo apt-get install gcc\n"))
+	})
+
+	t.Run("deduplicates violations", func(t *testing.T) {
+		violations := findRootRequiringPatterns("sudo ls\nsudo rm\n")
+		count := 0
+		for _, v := range violations {
+			if v == "sudo" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count)
+	})
+}

--- a/pkg/workflow/schemas/awf-config.schema.json
+++ b/pkg/workflow/schemas/awf-config.schema.json
@@ -10,6 +10,18 @@
       "type": "string",
       "description": "JSON Schema URL for IDE validation and autocomplete."
     },
+    "runner": {
+      "type": "object",
+      "description": "Runner topology metadata. AWF uses this to activate topology-specific behaviors (split-filesystem handling, network isolation, sysroot image, path-prefix probes, tool cache validation).",
+      "additionalProperties": false,
+      "properties": {
+        "topology": {
+          "type": "string",
+          "description": "Runner execution topology. When set to \"arc-dind\", AWF activates split-filesystem handling, network isolation, sysroot image staging, and DinD pre-staging automatically.",
+          "enum": ["arc-dind"]
+        }
+      }
+    },
     "network": {
       "type": "object",
       "description": "Network egress configuration.",

--- a/pkg/workflow/workflow_builder.go
+++ b/pkg/workflow/workflow_builder.go
@@ -67,6 +67,7 @@ func (c *Compiler) buildInitialWorkflowData(
 		RepositoryImports:     importsResult.RepositoryImports,
 		NetworkPermissions:    engineSetup.networkPermissions,
 		SandboxConfig:         applySandboxDefaults(engineSetup.sandboxConfig, engineSetup.engineConfig),
+		RunnerConfig:          extractRunnerConfig(result.Frontmatter),
 		NeedsTextOutput:       toolsResult.needsTextOutput,
 		ToolsTimeout:          toolsResult.toolsTimeout,
 		ToolsStartupTimeout:   toolsResult.toolsStartupTimeout,


### PR DESCRIPTION
## Motivation

ARC (Actions Runner Controller) with Docker-in-Docker (DinD) rootless runners use a different execution topology than standard GitHub-hosted or self-hosted runners. Workflows targeting these environments need to declare the topology so the compiler can generate the correct job configuration -- for example, adjusting container settings and service wiring that differ under rootless DinD.

## Approach

Introduces a new `runner.topology` frontmatter option (`arc-dind`) and the supporting compilation, validation, and configuration plumbing:

- **Frontmatter & schema**: adds `topology` to the `runner` block in both the main workflow JSON schema and the `awf-config` schema, so authors can write `runner.topology: arc-dind`.
- **Runner config** (`runner_config.go`): new helpers to resolve and apply topology-specific runner configuration during compilation.
- **Topology validation** (`runner_topology_validation.go`): validates that the declared topology is compatible with the rest of the workflow configuration, surfacing clear errors early.
- **Compiler integration**: threads the topology through `compiler_types`, `compiler_yaml_main_job`, and `workflow_builder` so the generated YAML reflects ARC/DinD requirements.
- **Tests**: unit tests for runner config resolution, topology validation, and AWF config parsing cover the new paths.