### PR TITLE
fix(arc-dind): mount workspace correctly and unify artifact roots

### DIFF
--- a/pkg/workflow/arc_dind_artifacts.go
+++ b/pkg/workflow/arc_dind_artifacts.go
@@ -1,0 +1,48 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/github/gh-aw/pkg/constants"
+)
+
+// rewriteTmpGhAwPathsForArcDind rewrites artifact paths that use /tmp/gh-aw/ to
+// use ${{ runner.temp }}/gh-aw/ instead, so all paths share a single root for the
+// artifact upload. This prevents upload-artifact from computing "/" as the common
+// ancestor (which happens when paths span both /tmp/gh-aw/ and the runner.temp tree),
+// causing a nested directory layout that breaks downstream artifact downloads.
+func rewriteTmpGhAwPathsForArcDind(paths []string) []string {
+	result := make([]string, len(paths))
+	for i, p := range paths {
+		if strings.HasPrefix(p, constants.TmpGhAwDirSlash) {
+			// /tmp/gh-aw/foo → ${{ runner.temp }}/gh-aw/foo
+			result[i] = constants.GhAwRootDir + "/" + strings.TrimPrefix(p, constants.TmpGhAwDirSlash)
+		} else if p == constants.TmpGhAwDir {
+			result[i] = constants.GhAwRootDir
+		} else {
+			result[i] = p
+		}
+	}
+	return result
+}
+
+// generateArcDindArtifactConsolidationStep emits a workflow step that copies files
+// from /tmp/gh-aw/ to ${{ runner.temp }}/gh-aw/ so the artifact upload has a single
+// root directory. On ARC/DinD, agent output files (agent_output.json, safe_outputs.ndjson,
+// aw-prompts/, patches, MCP logs) are written to /tmp/gh-aw/ during execution, but
+// firewall logs are under ${{ runner.temp }}/gh-aw/. This step consolidates them.
+func (c *Compiler) generateArcDindArtifactConsolidationStep(yaml *strings.Builder) {
+	yaml.WriteString("      - name: Consolidate artifacts for ARC/DinD\n")
+	yaml.WriteString("        if: always()\n")
+	yaml.WriteString("        shell: bash\n")
+	yaml.WriteString("        run: |\n")
+	// Use rsync-like cp to merge /tmp/gh-aw/ into ${RUNNER_TEMP}/gh-aw/ without
+	// clobbering existing files (firewall logs already there). The -a flag preserves
+	// permissions/timestamps, --no-clobber skips existing files.
+	yaml.WriteString("          # Consolidate /tmp/gh-aw/ into ${RUNNER_TEMP}/gh-aw/ for single-root artifact upload\n")
+	yaml.WriteString("          if [ -d /tmp/gh-aw ]; then\n")
+	fmt.Fprintf(yaml, "            cp -a --no-clobber /tmp/gh-aw/. \"${RUNNER_TEMP}/gh-aw/\" 2>/dev/null || \\\n")
+	fmt.Fprintf(yaml, "              cp -a /tmp/gh-aw/. \"${RUNNER_TEMP}/gh-aw/\" 2>/dev/null || true\n")
+	yaml.WriteString("          fi\n")
+}

--- a/pkg/workflow/arc_dind_artifacts.go
+++ b/pkg/workflow/arc_dind_artifacts.go
@@ -42,6 +42,7 @@ func (c *Compiler) generateArcDindArtifactConsolidationStep(yaml *strings.Builde
 	// permissions/timestamps, --no-clobber skips existing files.
 	yaml.WriteString("          # Consolidate /tmp/gh-aw/ into ${RUNNER_TEMP}/gh-aw/ for single-root artifact upload\n")
 	yaml.WriteString("          if [ -d /tmp/gh-aw ]; then\n")
+	yaml.WriteString("            mkdir -p \"${RUNNER_TEMP}/gh-aw\"\n")
 	fmt.Fprintf(yaml, "            cp -a --no-clobber /tmp/gh-aw/. \"${RUNNER_TEMP}/gh-aw/\" 2>/dev/null || \\\n")
 	fmt.Fprintf(yaml, "              cp -a /tmp/gh-aw/. \"${RUNNER_TEMP}/gh-aw/\" 2>/dev/null || true\n")
 	yaml.WriteString("          fi\n")

--- a/pkg/workflow/arc_dind_artifacts_test.go
+++ b/pkg/workflow/arc_dind_artifacts_test.go
@@ -1,0 +1,43 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewriteTmpGhAwPathsForArcDind(t *testing.T) {
+	t.Run("rewrites /tmp/gh-aw/ prefixed paths to runner.temp expression", func(t *testing.T) {
+		input := []string{
+			"/tmp/gh-aw/agent_output.json",
+			"/tmp/gh-aw/safe_outputs.ndjson",
+			"/tmp/gh-aw/aw-prompts/prompt.txt",
+			"/tmp/gh-aw/mcp-logs/",
+			"/tmp/gh-aw/aw-*.patch",
+		}
+		result := rewriteTmpGhAwPathsForArcDind(input)
+		assert.Equal(t, "${{ runner.temp }}/gh-aw/agent_output.json", result[0])
+		assert.Equal(t, "${{ runner.temp }}/gh-aw/safe_outputs.ndjson", result[1])
+		assert.Equal(t, "${{ runner.temp }}/gh-aw/aw-prompts/prompt.txt", result[2])
+		assert.Equal(t, "${{ runner.temp }}/gh-aw/mcp-logs/", result[3])
+		assert.Equal(t, "${{ runner.temp }}/gh-aw/aw-*.patch", result[4])
+	})
+
+	t.Run("preserves paths already using runner.temp expression", func(t *testing.T) {
+		input := []string{
+			"${{ runner.temp }}/gh-aw/sandbox/firewall/logs/",
+			"${{ runner.temp }}/gh-aw/awf-config.json",
+		}
+		result := rewriteTmpGhAwPathsForArcDind(input)
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("preserves unrelated paths", func(t *testing.T) {
+		input := []string{
+			"/some/other/path",
+			"relative/path",
+		}
+		result := rewriteTmpGhAwPathsForArcDind(input)
+		assert.Equal(t, input, result)
+	})
+}

--- a/pkg/workflow/awf_config.go
+++ b/pkg/workflow/awf_config.go
@@ -552,15 +552,14 @@ func BuildAWFConfigJSON(config AWFCommandConfig) (string, error) {
 		container := &AWFContainerConfig{
 			ImageTag: awfImageTag,
 		}
-		// For ARC/DinD topology, set dockerHostPathPrefix in config.
-		// AWF uses this to prefix bind-mount source paths so the DinD daemon can resolve
-		// runner filesystem paths from its separate mount namespace.
-		// The config file is written at runtime, so ${RUNNER_TEMP} can be preserved for
-		// shell expansion before AWF reads the JSON.
-		if isArcDindTopology(config.WorkflowData) {
-			container.DockerHostPathPrefix = awfArcDindRootPathExpr
-			awfConfigLog.Printf("Container section: dockerHostPathPrefix=%s (arc-dind topology)", awfArcDindRootPathExpr)
-		}
+		// NOTE: dockerHostPathPrefix is intentionally NOT set for arc-dind topology.
+		// With sysroot-stage active, the Docker daemon can access all needed paths:
+		//  - Workspace & RUNNER_TEMP: on the shared work volume (/home/runner/_work/)
+		//  - System binaries: provided by the sysroot named volume (not bind mounts)
+		//  - Kernel VFS (/dev, /sys): daemon's own kernel
+		// Setting a prefix would incorrectly translate the workspace mount source to
+		// a non-existent path (e.g. /prefix/home/runner/_work/repo → empty dir),
+		// causing the agent to see an empty workspace. See gh-aw#34896.
 		awfConfig.Container = container
 		if awfImageTag != "" {
 			awfConfigLog.Printf("Container section: image_tag=%s", awfImageTag)

--- a/pkg/workflow/awf_config_test.go
+++ b/pkg/workflow/awf_config_test.go
@@ -132,7 +132,7 @@ func TestBuildAWFConfigJSON(t *testing.T) {
 		assert.Contains(t, jsonStr, `"topologyAttach":["awmg-mcpg"]`, "should attach MCP gateway container to awf-net")
 	})
 
-	t.Run("runner topology arc-dind emits runner section and container.dockerHostPathPrefix", func(t *testing.T) {
+	t.Run("runner topology arc-dind emits runner section without dockerHostPathPrefix", func(t *testing.T) {
 		config := AWFCommandConfig{
 			EngineName:     "copilot",
 			AllowedDomains: "github.com",
@@ -149,7 +149,7 @@ func TestBuildAWFConfigJSON(t *testing.T) {
 		require.NoError(t, err, "BuildAWFConfigJSON should not return an error")
 
 		assert.Contains(t, jsonStr, `"runner":{"topology":"arc-dind"}`, "should emit runner topology")
-		assert.Contains(t, jsonStr, `"dockerHostPathPrefix":"${RUNNER_TEMP}/gh-aw"`, "should emit dockerHostPathPrefix for arc-dind")
+		assert.NotContains(t, jsonStr, `"dockerHostPathPrefix"`, "should NOT emit dockerHostPathPrefix for arc-dind (sysroot handles path visibility)")
 		assert.Contains(t, jsonStr, `"proxyLogsDir":"${RUNNER_TEMP}/gh-aw/sandbox/firewall/logs"`, "should emit arc-dind proxyLogsDir")
 		assert.Contains(t, jsonStr, `"auditDir":"${RUNNER_TEMP}/gh-aw/sandbox/firewall/audit"`, "should emit arc-dind auditDir")
 	})

--- a/pkg/workflow/compiler_yaml_main_job.go
+++ b/pkg/workflow/compiler_yaml_main_job.go
@@ -728,6 +728,13 @@ func (c *Compiler) collectArtifactPaths(data *WorkflowData, engine CodingAgentEn
 		}
 	}
 
+	// For ARC/DinD, rewrite all /tmp/gh-aw/ paths to ${{ runner.temp }}/gh-aw/ so
+	// the artifact upload has a single root. A consolidation step (emitted before upload)
+	// copies the files from /tmp/gh-aw/ to the runner.temp location. See gh-aw#34896 Bug B.
+	if isArcDindTopology(data) {
+		paths = rewriteTmpGhAwPathsForArcDind(paths)
+	}
+
 	return paths
 }
 
@@ -839,6 +846,15 @@ func (c *Compiler) generatePostAgentCollectionAndUpload(yaml *strings.Builder, d
 
 	// Add post-steps (if any) after AI execution
 	c.generatePostSteps(yaml, data)
+
+	// For ARC/DinD, consolidate all artifact files under ${{ runner.temp }}/gh-aw/
+	// before upload. Without this, upload-artifact receives paths from two roots
+	// (/tmp/gh-aw/ and ${{ runner.temp }}/gh-aw/), computes "/" as the common ancestor,
+	// and creates a nested directory layout that breaks downstream artifact downloads.
+	// See gh-aw#34896 Bug B.
+	if isArcDindTopology(data) {
+		c.generateArcDindArtifactConsolidationStep(yaml)
+	}
 
 	// Generate single unified artifact upload with all collected paths.
 	// In workflow_call context, apply the per-invocation prefix to avoid name clashes.


### PR DESCRIPTION
### Summary

Fixes two ARC/DinD runtime bugs (gh-aw#34896) that caused the agent to see an empty workspace and artifact downloads to fail.

### Changes

#### Bug A — Empty workspace (`dockerHostPathPrefix` removed)

`BuildAWFConfigJSON` previously set `container.DockerHostPathPrefix = awfArcDindRootPathExpr` for the `arc-dind` topology so the DinD daemon could resolve runner paths. With the sysroot-stage now active, the Docker daemon accesses the workspace through the shared work volume (`/home/runner/_work/`), system binaries through the sysroot named volume, and kernel VFS from the daemon's own kernel. Setting the prefix incorrectly translated the workspace bind-mount source (e.g. `/prefix/home/runner/_work/repo`) to a non-existent path, causing the agent to see an empty workspace.

**`pkg/workflow/awf_config.go`** — removes the `dockerHostPathPrefix` assignment for `arc-dind`; updated comment explains why it must remain unset.

**`pkg/workflow/awf_config_test.go`** — test updated to assert `dockerHostPathPrefix` is absent from the generated config JSON.

#### Bug B — Broken artifact downloads (unified artifact root)

On ARC/DinD, agent output files (`agent_output.json`, `safe_outputs.ndjson`, `aw-prompts/`, patches, MCP logs) are written to `/tmp/gh-aw/` during execution, but firewall logs land under `${{ runner.temp }}/gh-aw/`. When both roots were passed to `upload-artifact`, it computed `/` as the common ancestor and created a nested directory layout that broke downstream artifact downloads.

**`pkg/workflow/arc_dind_artifacts.go`** (new file) — adds two helpers:
- `rewriteTmpGhAwPathsForArcDind(paths)`: rewrites `/tmp/gh-aw/...` artifact paths to `${{ runner.temp }}/gh-aw/...` so `upload-artifact` sees a single root.
- `(*Compiler).generateArcDindArtifactConsolidationStep`: emits a `Consolidate artifacts for ARC/DinD` workflow step (`if: always()`) that copies files from `/tmp/gh-aw/` into `${RUNNER_TEMP}/gh-aw/` using `cp -a --no-clobber` (with fallback), merging agent outputs with firewall logs before upload.

**`pkg/workflow/compiler_yaml_main_job.go`** — integrates both helpers:
- `collectArtifactPaths`: calls `rewriteTmpGhAwPathsForArcDind` on collected paths when the topology is `arc-dind`.
- `generatePostAgentCollectionAndUpload`: emits the consolidation step before the artifact upload step when the topology is `arc-dind`.

**`pkg/workflow/arc_dind_artifacts_test.go`** (new file) — unit tests for `rewriteTmpGhAwPathsForArcDind` covering prefix rewrite, passthrough for existing `runner.temp` paths, and passthrough for unrelated paths.

### Affected topology

`arc-dind` only. Standard hosted-runner and ARC non-DinD topologies are unaffected.

### Testing

- Unit tests added for `rewriteTmpGhAwPathsForArcDind` (3 subtests).
- Existing `BuildAWFConfigJSON` test updated to assert absence of `dockerHostPathPrefix`.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/28671569394) for #43222 · 58.7 AIC · ⌖ 6.94 AIC · ⊞ 4.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.68, model: claude-sonnet-4.6, id: 28671569394, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/28671569394 -->