### PR TITLE
docs: document --force-public-repos flag for proxy subcommand

### DIFF
--- a/docs/src/content/docs/reference/mcp-gateway.md
+++ b/docs/src/content/docs/reference/mcp-gateway.md
@@ -562,7 +562,9 @@ The gateway MUST NOT fail to start if the OpenTelemetry collector endpoint is un
 
 When `forcePublicRepos` is `true` (the default), the gateway overrides the compiled allow-only policy to `repos="public"` at startup if it detects the workflow is running in a public repository. This prevents agents from accumulating private-data secrecy tags in the first place — even when the compiled config grants broader access.
 
-**Detection mechanism**: The gateway reads `GITHUB_REPOSITORY` and calls `GET /repos/{owner}/{repo}` at startup to determine repository visibility. If the repository is public and `forcePublicRepos` is `true`, the override is applied — subject to the availability of `GITHUB_REPOSITORY`, the GitHub token, and a successful API response (see Precedence rules below).
+**Applies to both modes**: This runtime check applies to both the MCP gateway (unified/routed mode, via `gateway.forcePublicRepos` config) and the CLI proxy (`awmg proxy`, via the `--force-public-repos` flag). In proxy mode, the override modifies the `--policy` JSON before passing it to the WASM guard.
+
+**Detection mechanism**: The gateway/proxy reads `GITHUB_REPOSITORY` and calls `GET /repos/{owner}/{repo}` at startup to determine repository visibility. If the repository is public and `forcePublicRepos` is `true`, the override is applied — subject to the availability of `GITHUB_REPOSITORY`, the GitHub token, and a successful API response (see Precedence rules below).
 
 **Scope of the override**: Only the allow-only policy is affected. Guard policies, tool permissions, and other configuration are unchanged.
 
@@ -571,11 +573,13 @@ When `forcePublicRepos` is `true` (the default), the gateway overrides the compi
 - Runtime detection of a public repo with `forcePublicRepos: true` **adds** the public restriction; it does not relax any existing constraint.
 - `forcePublicRepos: false` disables the runtime override entirely — the compiled allow-only policy is used as-is.
 - This override is **skipped** when `GITHUB_REPOSITORY` or the GitHub token is unavailable.
-- API errors during visibility detection result in a non-fatal warning; the gateway falls back to the compiled policy.
+- API errors during visibility detection result in a non-fatal warning; the gateway/proxy falls back to the compiled policy.
 
-**Opt-out**: Workflow authors who intentionally allow private→public data flows set `private-to-public-flows: allow` in frontmatter (Section 10.9). The compiler translates this to `forcePublicRepos: false` in the generated gateway config. See Section 10.8 and 10.9 for the write-sink guard policy interaction.
+**Opt-out**: Workflow authors who intentionally allow private→public data flows set `private-to-public-flows: allow` in frontmatter (Section 10.9). The compiler translates this to:
+- `gateway.forcePublicRepos: false` in the generated gateway JSON stdin config
+- `--force-public-repos=false` flag when launching the proxy subcommand
 
-**Environment variable override**: `MCP_GATEWAY_FORCE_PUBLIC_REPOS=false` disables the override without requiring a config change.
+**Environment variable override**: `MCP_GATEWAY_FORCE_PUBLIC_REPOS=false` disables the override without requiring a config change. The `--force-public-repos` flag defaults to the value of this environment variable (defaulting to `true` when unset).
 
 **Configuration Example**:
 

--- a/docs/src/content/docs/reference/mcp-gateway.md
+++ b/docs/src/content/docs/reference/mcp-gateway.md
@@ -564,7 +564,7 @@ When `forcePublicRepos` is `true` (the default), the gateway overrides the compi
 
 **Applies to both modes**: This runtime check applies to both the MCP gateway (unified/routed mode, via `gateway.forcePublicRepos` config) and the CLI proxy (`awmg proxy`, via the `--force-public-repos` flag). In proxy mode, the override modifies the `--policy` JSON before passing it to the WASM guard.
 
-**Detection mechanism**: The gateway/proxy reads `GITHUB_REPOSITORY` and calls `GET /repos/{owner}/{repo}` at startup to determine repository visibility. If the repository is public and `forcePublicRepos` is `true`, the override is applied — subject to the availability of `GITHUB_REPOSITORY`, the GitHub token, and a successful API response (see Precedence rules below).
+**Detection mechanism**: The gateway reads `GITHUB_REPOSITORY` and calls `GET /repos/{owner}/{repo}` at startup to determine repository visibility. Proxy mode uses the same check only when the launcher forwards `GITHUB_REPOSITORY` and a GitHub token into the proxy process/container. If the repository is public and `forcePublicRepos` is `true`, the override is applied — subject to those inputs and a successful API response (see Precedence rules below).
 
 **Scope of the override**: Only the allow-only policy is affected. Guard policies, tool permissions, and other configuration are unchanged.
 
@@ -575,9 +575,7 @@ When `forcePublicRepos` is `true` (the default), the gateway overrides the compi
 - This override is **skipped** when `GITHUB_REPOSITORY` or the GitHub token is unavailable.
 - API errors during visibility detection result in a non-fatal warning; the gateway/proxy falls back to the compiled policy.
 
-**Opt-out**: Workflow authors who intentionally allow private→public data flows set `private-to-public-flows: allow` in frontmatter (Section 10.9). The compiler translates this to:
-- `gateway.forcePublicRepos: false` in the generated gateway JSON stdin config
-- `--force-public-repos=false` flag when launching the proxy subcommand
+**Opt-out**: Workflow authors who intentionally allow private→public data flows set `private-to-public-flows: allow` in frontmatter (Section 10.9). The compiler translates this to `gateway.forcePublicRepos: false` in the generated gateway JSON stdin config. For proxy mode, launchers should pass `--force-public-repos=false` when they need equivalent opt-out behavior.
 
 **Environment variable override**: `MCP_GATEWAY_FORCE_PUBLIC_REPOS=false` disables the override without requiring a config change. The `--force-public-repos` flag defaults to the value of this environment variable (defaulting to `true` when unset).
 


### PR DESCRIPTION
### Summary

Extends the `forcePublicRepos` documentation in the MCP gateway reference to cover the `awmg proxy` subcommand's `--force-public-repos` flag.

### Changes

**File**: `docs/src/content/docs/reference/mcp-gateway.md`

- **New "Applies to both modes" paragraph**: Documents that the `forcePublicRepos` runtime check covers both the MCP gateway (unified/routed mode, `gateway.forcePublicRepos` config) and the CLI proxy (`awmg proxy`, `--force-public-repos` flag). Clarifies that in proxy mode the override modifies `--policy` JSON before it reaches the WASM guard.
- **Detection mechanism**: Adds proxy-mode prerequisite — the check runs only when the launcher forwards `GITHUB_REPOSITORY` and a GitHub token into the proxy process/container.
- **Precedence bullet**: Broadens "the gateway falls back" to "the gateway/proxy falls back" to cover both modes.
- **Opt-out section**: Tightens the config key path to `gateway.forcePublicRepos: false` in the generated gateway JSON stdin config; adds proxy opt-out guidance (`--force-public-repos=false`).
- **Environment variable override**: Documents that `--force-public-repos` inherits from `MCP_GATEWAY_FORCE_PUBLIC_REPOS` (defaulting to `true` when unset).

### Type

`docs` — no code or generated file changes.

### Affected components

| Component | Change |
|---|---|
| `awmg proxy` | Now documented alongside gateway for `forcePublicRepos` behaviour |
| `gateway.forcePublicRepos` | Config key path clarified in opt-out guidance |
| `--force-public-repos` flag | Default value and env-var inheritance documented |

### Reviewer notes

- Pure documentation patch; no behaviour change.
- Proxy mode prerequisite (launcher must inject `GITHUB_REPOSITORY` + token) is a new, actionable constraint that was previously undocumented.
- No related tests required.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/28962801186) for #44360 · 32.5 AIC · ⌖ 8.91 AIC · ⊞ 4.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.68, model: claude-sonnet-4.6, id: 28962801186, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/28962801186 -->