### PR TITLE
fix: emit sbx credential refresh step before agent execution

### DIFF
--- a/pkg/workflow/compiler_yaml_ai_execution.go
+++ b/pkg/workflow/compiler_yaml_ai_execution.go
@@ -426,6 +426,17 @@ func (c *Compiler) generateAgentRunSteps(yaml *strings.Builder, data *WorkflowDa
 	// connects to via host.docker.internal:18443.
 	c.generateStartCliProxyStep(yaml, data)
 
+	// Refresh sbx credentials immediately before AWF execution. Docker Hub OAuth
+	// tokens obtained during the daemon-setup step can expire between workflow steps,
+	// causing "user is not authenticated to Docker" errors when AWF calls `sbx create`.
+	if isDockerSbxRuntime(data) {
+		refreshStep := generateDockerSbxCredentialRefreshStep()
+		for _, line := range refreshStep {
+			yaml.WriteString(line)
+			yaml.WriteString("\n")
+		}
+	}
+
 	// Add AI execution step using the agentic engine
 	compilerYamlLog.Printf("Generating engine execution steps for %s", engine.GetID())
 	c.generateEngineExecutionSteps(yaml, data, engine, logFileFull)

--- a/pkg/workflow/docker_sbx_install.go
+++ b/pkg/workflow/docker_sbx_install.go
@@ -131,6 +131,25 @@ func generateDockerSbxAuthAndDaemonStep() GitHubActionStep {
 	})
 }
 
+// generateDockerSbxCredentialRefreshStep creates a step that re-authenticates the
+// sbx daemon with Docker Hub immediately before AWF runs the agent. OAuth tokens
+// obtained by `sbx login` during the daemon-setup step can expire or be invalidated
+// by the policy-reset cycle, so a fresh login right before execution prevents
+// "user is not authenticated to Docker" errors when AWF calls `sbx create`.
+func generateDockerSbxCredentialRefreshStep() GitHubActionStep {
+	return GitHubActionStep([]string{
+		"      - name: Refresh sbx credentials",
+		"        env:",
+		"          DOCKER_PAT_VAL: ${{ secrets.DOCKER_PAT }}",
+		"          DOCKER_USERNAME_VAL: ${{ secrets.DOCKER_USERNAME }}",
+		"        run: |",
+		`          # Re-authenticate sbx immediately before AWF runs.`,
+		`          # Docker Hub OAuth tokens from sbx login can expire between steps.`,
+		`          printf '%s' "$DOCKER_PAT_VAL" | sbx login --username "$DOCKER_USERNAME_VAL" --password-stdin`,
+		`          echo "✅ sbx credentials refreshed"`,
+	})
+}
+
 // generateDockerSbxPreFlightStep creates a step that verifies the sbx stack works
 // end-to-end before the MCP gateway and AWF container setup begins.
 func generateDockerSbxPreFlightStep() GitHubActionStep {

--- a/pkg/workflow/docker_sbx_test.go
+++ b/pkg/workflow/docker_sbx_test.go
@@ -85,6 +85,25 @@ func TestGenerateDockerSbxInstallSteps(t *testing.T) {
 		assert.Contains(t, content, "sbx rm", "must remove the test sandbox")
 		assert.Contains(t, content, "✅ sbx ready", "must confirm readiness")
 	})
+
+	t.Run("credential refresh step", func(t *testing.T) {
+		step := generateDockerSbxCredentialRefreshStep()
+		require.NotEmpty(t, step, "credential refresh step must not be empty")
+		content := strings.Join(step, "\n")
+		assert.Contains(t, content, "Refresh sbx credentials", "must have correct step name")
+		assert.Contains(t, content, "sbx login", "must re-authenticate with sbx login")
+		assert.Contains(t, content, "DOCKER_PAT_VAL: ${{ secrets.DOCKER_PAT }}", "must use env for DOCKER_PAT")
+		assert.Contains(t, content, "DOCKER_USERNAME_VAL: ${{ secrets.DOCKER_USERNAME }}", "must use env for DOCKER_USERNAME")
+		assert.Contains(t, content, "✅ sbx credentials refreshed", "must confirm refresh")
+		// The run: section must use env var references, not raw secret expressions.
+		parts := strings.SplitN(content, "run: |", 2)
+		require.Len(t, parts, 2, "step must have a run: section")
+		runBody := parts[1]
+		assert.NotContains(t, runBody, "${{ secrets.DOCKER_PAT }}",
+			"raw secrets expression must not appear in shell commands")
+		assert.NotContains(t, runBody, "${{ secrets.DOCKER_USERNAME }}",
+			"raw secrets expression must not appear in shell commands")
+	})
 }
 
 // TestDockerSbxInstallStepOrderInBuildNpmEngineInstallStepsWithAWF verifies that all
@@ -527,4 +546,14 @@ sandbox:
 
 	// --container-runtime sbx must appear in the AWF invocation.
 	assert.Contains(t, lockStr, "--container-runtime sbx", "AWF invocation must include --container-runtime sbx")
+
+	// Credential refresh step must be present.
+	assert.Contains(t, lockStr, "Refresh sbx credentials", "compiled workflow must include credential refresh step before execution")
+
+	// Credential refresh step must appear AFTER pre-flight but BEFORE execution.
+	refreshPos := strings.Index(lockStr, "Refresh sbx credentials")
+	preflightPos := strings.Index(lockStr, "pre-flight smoke test")
+	execPos := strings.Index(lockStr, "agentic_execution")
+	assert.Greater(t, refreshPos, preflightPos, "credential refresh must come after pre-flight step")
+	assert.Less(t, refreshPos, execPos, "credential refresh must come before agent execution step")
 }


### PR DESCRIPTION
### Summary

Fixes intermittent `"user is not authenticated to Docker"` errors that occur when AWF calls `sbx create` during agent execution. Docker Hub OAuth tokens obtained by `sbx login` during the daemon-setup step can expire or be invalidated between workflow steps. This PR emits a credential-refresh step immediately before agent execution for all `sbx`-runtime workflows.

### Changes

#### `pkg/workflow/compiler_yaml_ai_execution.go`

- In `generateAgentRunSteps`, added a conditional block: when `isDockerSbxRuntime(data)` is true, emits the new credential-refresh step after the CLI proxy step and before agent execution.

#### `pkg/workflow/docker_sbx_install.go`

- Added `generateDockerSbxCredentialRefreshStep()` — returns a `GitHubActionStep` that emits a GitHub Actions step named **"Refresh sbx credentials"**.
- The step maps `DOCKER_PAT` and `DOCKER_USERNAME` secrets to env vars (`DOCKER_PAT_VAL`, `DOCKER_USERNAME_VAL`) and calls `sbx login --username "$DOCKER_USERNAME_VAL" --password-stdin` via `printf`.
- Secrets are passed through env vars rather than inline expressions to prevent raw `${{ secrets.* }}` from appearing in shell commands.

#### `pkg/workflow/docker_sbx_test.go`

- Unit test for `generateDockerSbxCredentialRefreshStep()`: verifies step name, `sbx login` presence, correct env var mapping, and that raw secret expressions are absent from the `run:` body.
- Integration assertion in the compiled lock YAML test: verifies the step is present in the output and positioned after the pre-flight smoke test but before `agentic_execution`.

### Root Cause

Docker Hub OAuth tokens have a limited TTL. When a workflow has multiple steps between `sbx login` (daemon setup) and `sbx create` (agent execution), the token can expire, causing authentication failures at runtime.

### Behaviour

| Scenario | Before | After |
|---|---|---|
| sbx runtime, token expired | `sbx create` fails with auth error | fresh `sbx login` runs immediately before execution |
| non-sbx runtime | no change | no change (guarded by `isDockerSbxRuntime`) |

### Testing

- New unit test: `TestGenerateDockerSbxInstallSteps/credential_refresh_step`
- Extended integration test: step ordering assertions in compiled lock YAML

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/29217689996) for #45146 · 27.4 AIC · ⌖ 8 AIC · ⊞ 4.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.68, model: claude-sonnet-4.6, id: 29217689996, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/29217689996 -->