### PR TITLE
fix add normalization for git describe compiler versions

### DIFF
--- a/pkg/cli/add_package_manifest.go
+++ b/pkg/cli/add_package_manifest.go
@@ -246,6 +246,7 @@ func parseRepositoryPackageManifest(manifestPath string, content []byte) (*repos
 		if !semverutil.IsValid(currentVersion) {
 			return nil, nil, fmt.Errorf("invalid Agentic Workflow manifest %q: min-version validation requires a semantic-versioned compiler, but the current compiler version %q is not a valid semantic version (this indicates a build issue)", manifestPath, currentVersion)
 		}
+		currentVersion = semverutil.NormalizeGitDescribeSemver(currentVersion)
 		if semverutil.Compare(currentVersion, manifest.MinVersion) < 0 {
 			return nil, nil, fmt.Errorf("invalid Agentic Workflow manifest %q: min-version %q requires gh-aw %s or newer (current: %s)", manifestPath, manifest.MinVersion, manifest.MinVersion, currentVersion)
 		}

--- a/pkg/cli/add_package_manifest_test.go
+++ b/pkg/cli/add_package_manifest_test.go
@@ -377,6 +377,37 @@ files:
 		assert.Equal(t, []string{"workflows/review.md"}, pkg.InstallationSource)
 	})
 
+	t.Run("accepts git describe compiler version for matching min-version", func(t *testing.T) {
+		SetVersionInfo("v1.0.0-27-g117acb7f9c")
+		t.Cleanup(func() {
+			SetVersionInfo("v1.2.3")
+		})
+
+		downloadPackageFileFromGitHubForHost = func(_ context.Context, owner, repo, path, ref, host string) ([]byte, error) {
+			switch path {
+			case "aw.yml":
+				return []byte(`manifest-version: "1"
+min-version: v1.0.0
+name: Repo Assist
+files:
+  - workflows/review.md
+`), nil
+			case "README.md":
+				return []byte("# Repo Assist\n"), nil
+			default:
+				return nil, createRepositoryPackageNotFoundError(path)
+			}
+		}
+		listPackageWorkflowFilesForHost = func(_ context.Context, owner, repo, ref, workflowPath, host string) ([]string, error) {
+			t.Fatalf("unexpected scan of %s", workflowPath)
+			return nil, nil
+		}
+
+		pkg, err := resolveRepositoryPackage(t.Context(), &RepoSpec{RepoSlug: "owner/repo"}, "")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"workflows/review.md"}, pkg.InstallationSource)
+	})
+
 	t.Run("accepts manifest without manifest-version", func(t *testing.T) {
 		downloadPackageFileFromGitHubForHost = func(_ context.Context, owner, repo, path, ref, host string) ([]byte, error) {
 			switch path {

--- a/pkg/semverutil/semverutil.go
+++ b/pkg/semverutil/semverutil.go
@@ -22,6 +22,7 @@ var semverLog = logger.New("semverutil:semverutil")
 // It intentionally excludes prerelease and build-metadata suffixes because GitHub Actions
 // version pins use only these three forms.
 var actionVersionTagRegex = regexp.MustCompile(`^v[0-9]+(\.[0-9]+(\.[0-9]+)?)?$`)
+var gitDescribePrereleaseRegex = regexp.MustCompile(`^[0-9]+-g[0-9a-f]+(?:-dirty)?$`)
 
 // SemanticVersion represents a parsed semantic version.
 type SemanticVersion struct {
@@ -121,6 +122,29 @@ func Compare(v1, v2 string) int {
 	}
 
 	return result
+}
+
+// NormalizeGitDescribeSemver collapses local git-describe compiler versions to
+// their base release tag for compatibility checks.
+//
+// Examples:
+//   - v1.2.3-27-gabc1234      -> v1.2.3
+//   - v1.2.3-27-gabc1234-dirty -> v1.2.3
+//   - v1.2.3-dirty            -> v1.2.3
+//   - v1.2.3-beta.1           -> v1.2.3-beta.1
+func NormalizeGitDescribeSemver(v string) string {
+	v = EnsureVPrefix(strings.TrimSpace(v))
+	if !semver.IsValid(v) {
+		return v
+	}
+
+	canonical := semver.Canonical(v)
+	prerelease := strings.TrimPrefix(semver.Prerelease(canonical), "-")
+	if prerelease == "dirty" || gitDescribePrereleaseRegex.MatchString(prerelease) {
+		return strings.TrimSuffix(canonical, semver.Prerelease(canonical))
+	}
+
+	return canonical
 }
 
 // IsPreciseVersion returns true if the version has explicit minor and patch components

--- a/pkg/semverutil/semverutil_test.go
+++ b/pkg/semverutil/semverutil_test.go
@@ -187,6 +187,49 @@ func TestCompare(t *testing.T) {
 	}
 }
 
+func TestNormalizeGitDescribeSemver(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "release tag unchanged",
+			input: "v1.2.3",
+			want:  "v1.2.3",
+		},
+		{
+			name:  "git describe output collapses to base tag",
+			input: "v1.2.3-27-g117acb7f9c",
+			want:  "v1.2.3",
+		},
+		{
+			name:  "dirty tag collapses to base tag",
+			input: "v1.2.3-dirty",
+			want:  "v1.2.3",
+		},
+		{
+			name:  "git describe dirty output collapses to base tag",
+			input: "v1.2.3-27-g117acb7f9c-dirty",
+			want:  "v1.2.3",
+		},
+		{
+			name:  "real prerelease remains prerelease",
+			input: "v1.2.3-beta.1",
+			want:  "v1.2.3-beta.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeGitDescribeSemver(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeGitDescribeSemver(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsCompatible(t *testing.T) {
 	tests := []struct {
 		pin       string


### PR DESCRIPTION
### Summary

Fixes a false `min-version` failure when `gh-aw` is built from a non-tagged local commit. In that case, `git describe` produces a version like `v1.0.0-27-g117acb7f9c`, which is semantically _older_ than `v1.0.0` under standard semver prerelease ordering, causing the min-version check to incorrectly reject a compatible compiler.

### Changes

#### `pkg/semverutil/semverutil.go`

- Added `gitDescribePrereleaseRegex` to match git-describe prerelease patterns (`<N>-g<hash>` and `<N>-g<hash>-dirty`).
- Added `NormalizeGitDescribeSemver(v string) string` which strips git-describe-style and `dirty` prerelease suffixes, collapsing the version to its base release tag.
  - `v1.2.3-27-gabc1234` → `v1.2.3`
  - `v1.2.3-27-gabc1234-dirty` → `v1.2.3`
  - `v1.2.3-dirty` → `v1.2.3`
  - `v1.2.3-beta.1` → `v1.2.3-beta.1` (real prerelease preserved)

#### `pkg/cli/add_package_manifest.go`

- After validating `currentVersion` is a valid semver, normalizes it with `semverutil.NormalizeGitDescribeSemver` before comparing against `manifest.MinVersion`.

#### Tests

- `pkg/semverutil/semverutil_test.go`: `TestNormalizeGitDescribeSemver` — 5 table-driven cases covering clean tag, git-describe output, dirty, git-describe+dirty, and real prerelease.
- `pkg/cli/add_package_manifest_test.go`: new case verifying that a compiler version of `v1.0.0-27-g117acb7f9c` satisfies `min-version: v1.0.0`.

### Risk

Low. Normalisation applies only to the in-memory compiler version string during manifest min-version checks. No stored data, API surface, or other comparisons are affected. Real prerelease labels are preserved.

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/29513696516) for #46030 · 32.1 AIC · ⌖ 4.64 AIC · ⊞ 4.7K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, version: 1.0.70, model: claude-sonnet-4.6, id: 29513696516, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/29513696516 -->