### PR TITLE
Reduce shellcheck compile verbosity

### DIFF
--- a/pkg/cli/shellcheck.go
+++ b/pkg/cli/shellcheck.go
@@ -261,7 +261,6 @@ func runShellcheckOnScript(info runStepInfo, ignoreCodes []string, verbose bool)
 
 	if verbose {
 		shellcheckLog.Printf("Invoking: shellcheck %s", strings.Join(args, " "))
-		fmt.Fprintf(&out, "%s\n", console.FormatInfoMessage("shellcheck "+strings.Join(args[:len(args)-1], " ")+" <script>"))
 	}
 
 	// #nosec G204 -- shellcheck is a trusted system binary; args are built
@@ -340,7 +339,6 @@ func runShellcheckOnScriptViaDocker(ctx context.Context, info runStepInfo, ignor
 
 	if verbose {
 		shellcheckLog.Printf("Invoking: docker %s", strings.Join(args, " "))
-		fmt.Fprintf(&out, "%s\n", console.FormatInfoMessage("docker run --rm -i "+ShellcheckImage+" <shellcheck flags> <script>"))
 	}
 
 	// #nosec G204 -- ShellcheckImage is a SHA-pinned constant; all other args are

--- a/pkg/cli/shellcheck_test.go
+++ b/pkg/cli/shellcheck_test.go
@@ -283,6 +283,29 @@ func TestRunShellcheckOnLockFilesEmpty(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRunShellcheckOnScriptVerboseDoesNotEmitInvocation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses shell script stub")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "shellcheck")
+	require.NoError(t, os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+	require.NoError(t, os.Setenv("PATH", dir))
+
+	out, err := runShellcheckOnScript(runStepInfo{
+		Name:     "native step",
+		Script:   "echo hello",
+		Shell:    "bash",
+		LockFile: "/tmp/test.lock.yml",
+	}, shellcheckDefaultIgnoreCodes, true)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
 func TestRunShellcheckOnScriptViaDocker(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses shell script stub")
@@ -303,8 +326,9 @@ exit 0
 			Shell:    "bash",
 			LockFile: "/tmp/test.lock.yml",
 		}
-		_, err := runShellcheckOnScriptViaDocker(context.Background(), info, []string{"SC2016"}, false)
+		out, err := runShellcheckOnScriptViaDocker(context.Background(), info, []string{"SC2016"}, true)
 		require.NoError(t, err)
+		assert.Empty(t, out)
 
 		argsText, readErr := os.ReadFile(os.Getenv("DOCKER_ARGS_FILE"))
 		require.NoError(t, readErr)


### PR DESCRIPTION
### Overview

Reduces the verbosity of `gh aw compile` output by removing shellcheck/docker invocation lines that were being written directly into the compile output buffer during verbose shellcheck runs.

### What changed

- **`pkg/cli/shellcheck.go`**: In `runShellcheckOnScript` and `runShellcheckOnScriptViaDocker`, removed the `fmt.Fprintf(&out, ...)` calls that printed the formatted shellcheck/docker invocation command (via `console.FormatInfoMessage`) into the compile output whenever `verbose` was `true`. The `shellcheckLog.Printf(...)` debug log call is retained, so invocation details are still available via `DEBUG=cli:*` logging instead of always appearing in normal compile output.
- **`pkg/cli/shellcheck_test.go`**:
  - Added `TestRunShellcheckOnScriptVerboseDoesNotEmitInvocation`, which stubs a `shellcheck` binary on `PATH` and asserts that calling `runShellcheckOnScript` with `verbose=true` returns empty output.
  - Updated `TestRunShellcheckOnScriptViaDocker` to invoke with `verbose=true` (previously `false`) and assert the returned output is empty, confirming the Docker code path no longer leaks invocation text into compile output either.

### Why

The shellcheck/docker invocation strings were noisy and not meaningful to end users during normal `gh aw compile` runs; they belong in debug-level logging (`shellcheckLog`), not in the primary output stream.

### Testing

- New and updated unit tests in `pkg/cli/shellcheck_test.go` assert empty output for both the native shellcheck path and the Docker path when `verbose=true`.

### Impact

- No breaking changes. Behavior of shellcheck error/warning reporting is unaffected; only the extra informational invocation line is removed from compile output. Users needing invocation details can enable debug logging (e.g., `DEBUG=cli:*`).

> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/30872449629) for #50155 · auto · 42.5 AIC · ⌖ 7.13 AIC · ⊞ 6.9K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, model: auto, id: 30872449629, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/30872449629 -->