### PR TITLE
Improve maintenance workflow repository discovery

### DIFF
--- a/.github/aw/create-agentic-workflow.md
+++ b/.github/aw/create-agentic-workflow.md
@@ -20,6 +20,7 @@ Design and create new workflow files under `.github/workflows/` using the instal
 
 Load these topic files only when relevant:
 
+- [maintainer.md](maintainer.md) for recurring repository maintenance, backlog triage, owned-PR upkeep, or long-term code health
 - [campaign.md](campaign.md) for campaign, KPI, pacing, cadence, or `stop-after`
 - [experiments.md](experiments.md) for experiments, A/B tests, variants, or prompt comparisons
 - [visual-regression.md](visual-regression.md) for screenshot comparison workflows
@@ -40,13 +41,14 @@ Start with exactly:
 Then follow a progressive interview — ask one question at a time, advance only when the current phase is clear:
 
 1. **Goal** — confirm workflow name (kebab-case), brief description, optional emoji.
-2. **Trigger** — ask "When should this run?" and map to an `on:` block (see trigger mapping in [designer.md](designer.md)).
-3. **Scope** — ask what it reads and what it creates or updates; map to `permissions:`, `tools:`, and `safe-outputs:`.
-4. **Data strategy** — ask whether GitHub data should be pre-fetched with `gh` + `jq` (DataOps default); map to `steps:`.
-5. **Guardrails** — ask whether it should block, advise, or silently log; guide toward `noop` and safe-output behavior.
-6. **Context & network** — ask about external APIs, MCP servers, and required secrets; map to `network.allowed` and `env:`.
-7. **Engine** (skip if obvious) — if ambiguous, suggest Copilot as the default.
-8. **Confirmation** — present a structured summary before generating:
+2. **Repository survey for maintenance workflows** — before choosing a portfolio or cadence, inspect the target repository using [maintainer.md](maintainer.md). Infer project type, contribution and validation rules, repository layout, recent activity, issue and pull request state, labels, releases, and CI health. Summarize the observed signals and derive an initial low-risk strategy; ask only for policy or capacity information that cannot be inferred.
+3. **Trigger** — ask "When should this run?" and map to an `on:` block (see trigger mapping in [designer.md](designer.md)).
+4. **Scope** — ask what it reads and what it creates or updates; map to `permissions:`, `tools:`, and `safe-outputs:`.
+5. **Data strategy** — ask whether GitHub data should be pre-fetched with `gh` + `jq` (DataOps default); map to `steps:`.
+6. **Guardrails** — ask whether it should block, advise, or silently log; guide toward `noop` and safe-output behavior.
+7. **Context & network** — ask about external APIs, MCP servers, and required secrets; map to `network.allowed` and `env:`.
+8. **Engine** (skip if obvious) — if ambiguous, suggest Copilot as the default.
+9. **Confirmation** — present a structured summary before generating:
 
    ```text
    Proposed workflow:
@@ -57,6 +59,8 @@ Then follow a progressive interview — ask one question at a time, advance only
    - Safe outputs: <list or none>
    - Network: <allowed summary>
    - Integrations/Auth: <service/mcp + required secrets/env vars>
+   - Repository signals: <maintenance workflows only>
+   - Initial maintenance portfolio: <maintenance workflows only>
    - Intent: <one-sentence task>
    ```
 
@@ -318,6 +322,7 @@ Before finalizing any `pull_request`-triggered reporting workflow, verify:
 Before finalizing any newly generated workflow, verify:
 
 - [ ] **Trigger fit**: trigger matches user intent and event granularity (for example `pull_request`, `workflow_run`, `deployment_status`, `schedule`, `slash_command`)
+- [ ] **Maintenance baseline**: recurring maintenance strategies are derived from a bounded repository survey, with observed signals separated from recommendations
 - [ ] **Tool fit**: enabled tools are the minimal set needed for reads/analysis (prefer `gh-proxy`; add `playwright`/`cache-memory` only when required)
 - [ ] **Safe outputs**: all visible writes route through `safe-outputs:` and include `noop` for explicit no-op outcomes
 - [ ] **Permissions**: agent job remains read-only; no direct write scopes granted

--- a/.github/aw/designer.md
+++ b/.github/aw/designer.md
@@ -9,6 +9,7 @@ Use this before `.github/aw/create-agentic-workflow.md` when requirements are un
 - Use `.github/aw/designer.md` to discover and confirm requirements.
 - Use `.github/aw/create-agentic-workflow.md` once requirements are clear and ready for implementation.
 - Use `.github/aw/agentic-chat.md` when the user wants a specification/pseudo-code instead of a runnable workflow file.
+- Load `.github/aw/maintainer.md` when the goal is recurring repository maintenance, backlog reduction, owned-PR upkeep, or long-term code health.
 
 ## Interview Framework
 
@@ -22,6 +23,21 @@ Capture:
 - Workflow name (kebab-case candidate)
 - Brief description
 - Optional emoji
+
+### Phase 1b: Repository Survey for Maintenance Workflows
+
+Before asking the user to choose maintenance tasks, inspect the target repository and establish an evidence-based baseline. Do not ask for information that repository files or GitHub data can answer.
+
+Survey:
+
+- project type and ecosystems from manifests, languages, repository layout, generated files, and monorepo boundaries
+- local rules from `AGENTS.md`, `CONTRIBUTING.md`, `CODEOWNERS`, pull request templates, release documentation, and existing automation
+- recent activity over a representative window: commits, releases, issue and pull request creation/closure, contributor activity, and automation volume
+- issue health: open count, age distribution, unlabelled items, stale items, milestones, recurring categories, response status, and duplicate signals
+- pull request health: open count, age, review state, failed checks, merge conflicts, abandoned work, and bot-owned versus contributor-owned items
+- validation and operational health: available format/lint/build/test commands, recent CI failures, flaky signals, dependency update load, and release cadence
+
+Use bounded queries and report the window, limits, and unavailable data. Separate observed facts from inferred strategy. Based on the survey, recommend two or three low-risk task families, a conservative cadence, per-run limits, state/deduplication needs, and pressure valves. Ask the user only about policy choices that cannot be inferred, such as acceptable maintainer attention, protected areas, or whether contributor-facing comments are allowed.
 
 ### Phase 2: Trigger
 
@@ -124,6 +140,7 @@ Present a structured summary and ask for approval before generation.
 | "run on PRs from forks" | `on: pull_request:` plus explicit `forks:` allowlist and fork security guardrails |
 | "sometimes automatic, sometimes manual" | semi-active pattern: combine `schedule`/event triggers with `workflow_dispatch` |
 | "manually", "on demand" | `on: workflow_dispatch:` |
+| "maintain this repository long term" | survey the repository first, then choose a bounded `schedule` plus optional `workflow_dispatch` |
 | "when a deployment fails" | `on: deployment_status:` |
 | "when another workflow finishes" | `on: workflow_run:` |
 

--- a/.github/aw/maintainer.md
+++ b/.github/aw/maintainer.md
@@ -21,6 +21,34 @@ A maintenance workflow should make useful progress without consuming disproporti
 
 These rules deliberately balance bias toward progress with quality over quantity. The workflow should search systematically for useful work, but it should not manufacture comments or changes to prove activity.
 
+## Survey the repository before choosing a strategy
+
+Do not begin maintenance workflow design from a generic task portfolio. First inspect the target repository so the initial strategy reflects its technology, activity, backlog, and maintainer practices.
+
+Build a bounded baseline from:
+
+| Area | Signals to inspect |
+|---|---|
+| Project shape | Languages, manifests, generated files, monorepo boundaries, package layout, build systems, and deployment targets |
+| Repository policy | `AGENTS.md`, `CONTRIBUTING.md`, `CODEOWNERS`, pull request templates, protected paths, release practices, and existing automation |
+| Activity pattern | Commits, releases, issue and pull request arrival/closure rates, contributor activity, and bot-generated activity over a stated window |
+| Issue state | Open count, age distribution, unlabelled and stale items, milestones, response status, common categories, and duplicate signals |
+| Pull request state | Open count, age, reviews, failed checks, merge conflicts, abandoned work, and workflow-owned versus contributor-owned branches |
+| Operational health | Format/lint/build/test commands, CI reliability, dependency update volume, flaky tests, release cadence, and recurring failures |
+
+Use deterministic GitHub queries and repository inspection for this survey. Bound every query, state the observation window and limits, and mark unavailable data instead of guessing. Distinguish observations from recommendations in the design summary.
+
+Derive the first portfolio from the evidence. For example:
+
+- a large unlabelled issue backlog favors bounded classification before code changes
+- many unanswered but active issues favors investigation and substantive responses
+- unhealthy workflow-owned pull requests favors self-maintenance before creating more
+- high contributor pull request volume favors review support and conservative stale-follow-up rules
+- low activity or sparse tests favors low cadence, documentation, test discovery, and maintainer reports
+- frequent releases or dependency churn favors release, dependency, and CI health tasks
+
+Recommend two or three low-risk task families, a conservative cadence, per-run limits, state requirements, and pressure valves. Ask maintainers only for policy choices that repository data cannot establish, such as acceptable attention cost, protected areas, and whether contributor-facing comments are appropriate.
+
 ## Separate invocation modes
 
 Support two distinct modes when both autonomous and requested maintenance are needed:
@@ -152,7 +180,7 @@ When a run legitimately produces no action after checking all bounded queues and
 
 Build the workflow in stages:
 
-1. **Inventory the repository.** Identify contribution rules, labels, validation commands, protected paths, ecosystems, release practices, and maintainer capacity.
+1. **Survey the repository.** Record the project shape, contribution rules, validation commands, protected paths, activity window, issue and pull request health, labels, releases, CI reliability, and existing automation. Keep observed facts separate from strategy recommendations.
 2. **Choose the initial portfolio.** Start with two or three low-risk families such as labelling, investigation, and owned-PR maintenance. Add code-writing tasks only after observing output quality.
 3. **Define live signals and applicability.** Document how each signal changes priority, when each task is eligible, and its fallback.
 4. **Define state and deduplication.** Specify cursors, timestamps, ownership markers, and retention. Avoid storing repository data that can be fetched cheaply.


### PR DESCRIPTION
## Summary

- require a bounded repository survey before designing recurring maintenance automation
- assess project shape, repository policy, activity patterns, issue/PR health, and operational signals
- derive a conservative initial portfolio, cadence, limits, state needs, and pressure valves from observed evidence
- add maintenance-specific signals to the designer summary and quality checklist

## Validation

- `git diff --check`
- `make agent-report-progress` attempted twice; both runs reached the existing JavaScript lint warnings with 0 errors, then were terminated during `golint` with exit 143
