### PR TITLE
Optimize agent progress validation

### DIFF
--- a/.github/skills/developer/SKILL.md
+++ b/.github/skills/developer/SKILL.md
@@ -31,7 +31,7 @@ Run validation in tiers — catch compile errors early, defer slow tests to the 
    ```bash
    make agent-report-progress-no-test
    ```
-3. **Before the FINAL `report_progress` call** (slower, once per session — includes test-unit)
+3. **Before the FINAL `report_progress` call** (change-scoped, includes impacted Go tests)
    ```bash
    make agent-report-progress
    ```
@@ -40,9 +40,9 @@ Run validation in tiers — catch compile errors early, defer slow tests to the 
    make agent-finish
    ```
 
-> **Key rule:** Run `test-unit` only before the **final** `report_progress` call, not before intermediate saves. Each unnecessary invocation adds 120+ seconds to total validation time.
+> **Key rule:** Run `test-unit` only before the **final** `report_progress` call, not before intermediate saves. The pre-PR targets scope formatting, linting, tests, and workflow drift checks to the branch changes.
 
-> **Timeout budget:** `make test-unit` is expected to take up to 120 seconds. If it exceeds that, use `make test-impacted-go` to run only tests for packages affected by the current branch's changes.
+> **Timeout budget:** `make agent-report-progress` should normally finish in under 30 seconds. Workflow source or compiler changes additionally run the full workflow drift check. Set `TEST_UNIT_RUN_FULL=1` only when the full Go suite is required.
 
 ### Change-type command matrix
 

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ test-impacted-js: build-js
 		echo "Set BASE_REF explicitly, for example: make test-impacted-js BASE_REF=origin/main"; \
 		exit 1; \
 	fi; \
-	CHANGED_JS_FILES=$$(git diff --name-only --diff-filter=ACMR "$$BASE_COMMIT"..HEAD -- actions/setup/js eslint-factory | grep -E '\.(cjs|js|mjs|ts)$$' || true); \
+	CHANGED_JS_FILES=$$({ git diff --name-only --diff-filter=ACMR "$$BASE_COMMIT" -- actions/setup/js eslint-factory; git ls-files --others --exclude-standard -- actions/setup/js eslint-factory; } | sort -u | grep -E '\.(cjs|js|mjs|ts)$$' || true); \
 	if [ -z "$$CHANGED_JS_FILES" ]; then \
 		echo "No changed JavaScript/TypeScript files under actions/setup/js or eslint-factory; skipping impacted JS tests."; \
 		exit 0; \
@@ -293,7 +293,7 @@ test-impacted-go:
 		echo "Set BASE_REF explicitly, for example: make test-impacted-go BASE_REF=origin/main"; \
 		exit 1; \
 	fi; \
-	CHANGED_GO_FILES=$$(git diff --name-only --diff-filter=ACMR "$$BASE_COMMIT"..HEAD | grep -E '\.go$$' || true); \
+	CHANGED_GO_FILES=$$({ git diff --name-only --diff-filter=ACDMR "$$BASE_COMMIT"; git ls-files --others --exclude-standard; } | sort -u | grep -E '\.go$$' || true); \
 	if [ -z "$$CHANGED_GO_FILES" ]; then \
 		echo "No changed Go files; skipping impacted Go tests."; \
 		exit 0; \
@@ -344,11 +344,22 @@ test-impacted-go:
 		CHANGED_GO_PACKAGES="$$COVERAGE_GO_PACKAGES"; \
 		echo "Running impacted Go unit tests from CI coverage correlation: $$CHANGED_GO_PACKAGES"; \
 	else \
-		CHANGED_GO_PACKAGES=$$(printf '%s\n' "$$CHANGED_GO_FILES" | while IFS= read -r file; do dirname "$$file"; done | sort -u | sed 's|^|./|'); \
+		CHANGED_GO_PACKAGES=$$(printf '%s\n' "$$CHANGED_GO_FILES" | while IFS= read -r file; do \
+			dir=$$(dirname "$$file"); \
+			if find "$$dir" -maxdepth 1 -type f -name '*.go' -print -quit 2>/dev/null | grep -q .; then \
+				printf './%s\n' "$$dir"; \
+			fi; \
+		done | sort -u); \
+		if [ -z "$$CHANGED_GO_PACKAGES" ]; then \
+			echo "No remaining Go packages for the changed files; skipping impacted Go tests."; \
+			exit 0; \
+		fi; \
 		echo "Running impacted Go unit tests in changed-file packages: $$CHANGED_GO_PACKAGES"; \
 	fi; \
 	SELECTED_GO_TESTS=""; \
-	if command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then \
+	if [ "$(CI_COVERAGE_ENABLED)" != "1" ]; then \
+		echo "CI timing correlation disabled; using local impacted-test sampling."; \
+	elif command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then \
 		UNIT_RUN_ID="$(CI_UNIT_RUN_ID)"; \
 		if [ -z "$$UNIT_RUN_ID" ]; then \
 			UNIT_RUN_ID=$$(gh run list --workflow "$(CI_UNIT_WORKFLOW_FILE)" --branch "$$COVERAGE_SOURCE_BRANCH" --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true); \
@@ -450,7 +461,8 @@ test-impacted-go:
 
 # Test both impacted JavaScript and Go unit tests
 .PHONY: test-impacted
-test-impacted: test-impacted-js test-impacted-go
+test-impacted:
+	@$(MAKE) --no-print-directory -j2 test-impacted-js test-impacted-go
 
 # Install JavaScript dependencies
 .PHONY: deps-js
@@ -1313,19 +1325,18 @@ sbom:
 agent-finish: deps-dev fmt lint build build-wasm test-all validate-otel-contract fix recompile dependabot generate-schema-docs generate-agent-factory generate-llms-txt security-scan
 	@echo "Agent finished tasks successfully."
 
-# Fast pre-PR gate — run before every intermediate report_progress call.
-# Skips test-unit for speed; use agent-report-progress for the final report_progress call.
-# stale-lock guard (fast, no binary) + build + fmt + lint + workflow drift check.
+# Change-scoped pre-PR gate — run before every intermediate report_progress call.
+# The driver runs independent lint checks in parallel after formatting and build.
 .PHONY: agent-report-progress-no-test
-agent-report-progress-no-test: check-stale-lock-files build fmt lint check-workflow-drift
-	@echo "Pre-PR validation passed (zero lint errors, lock files in sync). Safe to call report_progress."
+agent-report-progress-no-test:
+	@bash scripts/agent-report-progress.sh
 
-# Full pre-PR gate with tests — run once before the final report_progress call.
-# Includes formatting + lint validation to prevent lint-fix PR churn:
-# stale-lock guard (fast, no binary) + build + fmt + lint + test-unit + workflow drift check.
+# Change-scoped pre-PR gate with impacted tests — run once before the final
+# report_progress call. Independent lint and test groups run in parallel; full
+# workflow recompilation remains isolated because it temporarily rewrites files.
 .PHONY: agent-report-progress
-agent-report-progress: check-stale-lock-files build fmt lint test-unit check-workflow-drift
-	@echo "Pre-PR validation passed (zero lint errors, lock files in sync, tests pass). Safe to call report_progress."
+agent-report-progress:
+	@bash scripts/agent-report-progress.sh --with-tests
 
 # Extended pre-PR gate with lock-file-only linting.
 .PHONY: agent-report-progress-lint
@@ -1426,8 +1437,8 @@ help:
 	@echo "  clean-docs       - Clean documentation artifacts (dist, node_modules, .astro)"
 
 	@echo "  agent-finish                - Complete validation sequence (build, test, fix, recompile, fmt, lint, security-scan)"
-	@echo "  agent-report-progress-no-test - Fast pre-PR gate (no test-unit): check-stale-lock-files + build + fmt + lint + check-workflow-drift"
-	@echo "  agent-report-progress       - Full pre-PR gate (final save only): same as above + test-unit"
+	@echo "  agent-report-progress-no-test - Fast change-scoped pre-PR gate without tests"
+	@echo "  agent-report-progress       - Change-scoped pre-PR gate with impacted Go tests"
 	@echo "  agent-report-progress-lint  - Full pre-PR gate + gh aw lint lock-file check"
 	@echo "  sbom             - Generate SBOM in SPDX and CycloneDX formats (requires syft)"
 	@echo "  help             - Show this help message"

--- a/scripts/agent-report-progress.sh
+++ b/scripts/agent-report-progress.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+set +o histexpand
+set -euo pipefail
+
+WITH_TESTS=0
+JS_TEST_EXCLUDES=(
+    --exclude '**/*.integration.test.cjs'
+    --exclude '**/frontmatter_hash_github_api.test.cjs'
+)
+if [ "${1:-}" = "--with-tests" ]; then
+    WITH_TESTS=1
+elif [ "$#" -ne 0 ]; then
+    echo "Usage: scripts/agent-report-progress.sh [--with-tests]" >&2
+    exit 1
+fi
+
+PARALLEL_DIR=$(mktemp -d)
+job_pids=()
+job_labels=()
+job_logs=()
+
+cleanup() {
+    rm -rf "$PARALLEL_DIR"
+}
+trap cleanup EXIT
+
+start_job() {
+    local label="$1"
+    shift
+    local index="${#job_pids[@]}"
+    local log_file="$PARALLEL_DIR/job-$index.log"
+
+    echo "Starting $label..."
+    ("$@") >"$log_file" 2>&1 &
+    job_pids+=("$!")
+    job_labels+=("$label")
+    job_logs+=("$log_file")
+}
+
+wait_for_jobs() {
+    local failed=0
+    local index
+
+    for index in "${!job_pids[@]}"; do
+        if wait "${job_pids[$index]}"; then
+            echo "✓ ${job_labels[$index]}"
+        else
+            echo "✗ ${job_labels[$index]}" >&2
+            failed=1
+        fi
+        cat "${job_logs[$index]}"
+    done
+
+    job_pids=()
+    job_labels=()
+    job_logs=()
+    return "$failed"
+}
+
+BASE_REF="${BASE_REF:-origin/main}"
+BASE_COMMIT=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
+if [ -z "$BASE_COMMIT" ]; then
+    echo "Error: unable to determine merge-base from BASE_REF=$BASE_REF." >&2
+    echo "Set BASE_REF explicitly, for example: BASE_REF=origin/main make agent-report-progress" >&2
+    exit 1
+fi
+
+mapfile -t CHANGED_FILES < <(
+    {
+        git diff --name-only --diff-filter=ACDMR "$BASE_COMMIT"
+        git ls-files --others --exclude-standard
+    } | sed '/^$/d' | LC_ALL=C sort -u
+)
+
+if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
+    echo "No changes relative to $BASE_REF; skipping pre-PR validation."
+    exit 0
+fi
+
+go_files=()
+go_packages=()
+prettier_files=()
+setup_js_files=()
+eslint_factory_files=()
+action_shell_files=()
+workflow_drift_required=0
+model_alias_validation_required=0
+
+for file in "${CHANGED_FILES[@]}"; do
+    case "$file" in
+        *.go)
+            package_dir=$(dirname "$file")
+            if find "$package_dir" -maxdepth 1 -type f -name '*.go' -print -quit 2>/dev/null | grep -q .; then
+                go_packages+=("./$package_dir")
+            fi
+            if [ -f "$file" ]; then
+                go_files+=("$file")
+            fi
+            ;;
+    esac
+
+    case "$file" in
+        *.cjs|*.js|*.mjs|*.ts|*.json)
+            if [ -f "$file" ]; then
+                prettier_files+=("$file")
+            fi
+            ;;
+    esac
+
+    case "$file" in
+        actions/setup/js/*.cjs|actions/setup/js/*.js|actions/setup/js/*.mjs|actions/setup/js/*.ts)
+            [ -f "$file" ] && setup_js_files+=("${file#actions/setup/js/}")
+            ;;
+        eslint-factory/*.cjs|eslint-factory/*.js|eslint-factory/*.mjs|eslint-factory/*.ts)
+            [ -f "$file" ] && eslint_factory_files+=("$file")
+            ;;
+        actions/setup/sh/*.sh)
+            [ -f "$file" ] && action_shell_files+=("$file")
+            ;;
+    esac
+
+    case "$file" in
+        .github/workflows/*.md|.github/workflows/*.lock.yml|cmd/*.go|pkg/*.go|go.mod|go.sum)
+            workflow_drift_required=1
+            ;;
+    esac
+
+    case "$file" in
+        pkg/cli/data/models.json|actions/setup/js/models.json)
+            model_alias_validation_required=1
+            ;;
+    esac
+done
+
+echo "Validating ${#CHANGED_FILES[@]} changed file(s) relative to $BASE_REF..."
+
+CHECK_STALE_LOCK_BASE_REF="$BASE_REF" make --no-print-directory check-stale-lock-files
+
+if [ "${#go_files[@]}" -gt 0 ]; then
+    echo "Formatting ${#go_files[@]} changed Go file(s)..."
+    gofmt -w "${go_files[@]}"
+fi
+
+if [ "${#prettier_files[@]}" -gt 0 ]; then
+    echo "Formatting ${#prettier_files[@]} changed JavaScript/TypeScript/JSON file(s)..."
+    npx prettier --write "${prettier_files[@]}" --ignore-path .prettierignore --log-level=error
+fi
+
+git diff --check "$BASE_COMMIT"
+
+echo "Building gh-aw..."
+make --no-print-directory build
+
+mapfile -t go_packages < <(printf '%s\n' "${go_packages[@]}" | sed '/^$/d' | LC_ALL=C sort -u)
+
+lint_go_packages() {
+    GOPATH=$(go env GOPATH)
+    if command -v golangci-lint >/dev/null 2>&1 || [ -x "$GOPATH/bin/golangci-lint" ]; then
+        PATH="$GOPATH/bin:$PATH" golangci-lint run "${go_packages[@]}"
+    else
+        echo "golangci-lint is not installed. Run 'make deps-dev' to install dependencies." >&2
+        return 1
+    fi
+}
+
+lint_javascript() {
+    (cd eslint-factory && npm run build --silent)
+
+    if [ "${#setup_js_files[@]}" -gt 0 ]; then
+        (
+            cd actions/setup/js
+            ../../../eslint-factory/node_modules/.bin/eslint \
+                --config ../../../eslint-factory/eslint.config.cjs \
+                "${setup_js_files[@]}"
+        )
+    fi
+}
+
+lint_action_shell_files() {
+    make --no-print-directory lint-action-sh
+    GOPATH=$(go env GOPATH)
+    if command -v shellcheck >/dev/null 2>&1 || [ -x "$GOPATH/bin/shellcheck" ]; then
+        PATH="$GOPATH/bin:$PATH" shellcheck --severity=error "${action_shell_files[@]}"
+    else
+        echo "shellcheck is not installed. Run 'make deps-dev' to install dependencies." >&2
+        return 1
+    fi
+}
+
+test_setup_javascript() {
+    (
+        cd actions/setup/js
+        npm run typecheck --silent
+        npm run test:js -- \
+            --no-file-parallelism \
+            --passWithNoTests \
+            "${JS_TEST_EXCLUDES[@]}" \
+            "${setup_js_files[@]}"
+    )
+}
+
+test_eslint_factory() {
+    (cd eslint-factory && npm test)
+}
+
+test_go_packages() {
+    make --no-print-directory test-unit BASE_REF="$BASE_REF"
+}
+
+if [ "${#go_packages[@]}" -gt 0 ]; then
+    start_job "Go lint (${#go_packages[@]} package(s))" lint_go_packages
+fi
+if [ "${#setup_js_files[@]}" -gt 0 ] || [ "${#eslint_factory_files[@]}" -gt 0 ]; then
+    start_job "JavaScript lint" lint_javascript
+fi
+if [ "${#action_shell_files[@]}" -gt 0 ]; then
+    start_job "action shell lint" lint_action_shell_files
+fi
+if [ "$model_alias_validation_required" -eq 1 ]; then
+    start_job "model alias validation" make --no-print-directory validate-model-alias-chains
+fi
+start_job "schema freshness check" make --no-print-directory check-stale-schema-binary
+
+if [ "$WITH_TESTS" -eq 1 ]; then
+    start_job "impacted Go tests" test_go_packages
+    if [ "${#setup_js_files[@]}" -gt 0 ]; then
+        start_job "impacted setup JavaScript tests" test_setup_javascript
+    fi
+    if [ "${#eslint_factory_files[@]}" -gt 0 ]; then
+        start_job "eslint-factory tests" test_eslint_factory
+    fi
+fi
+
+wait_for_jobs
+
+if [ "$workflow_drift_required" -eq 1 ]; then
+    make --no-print-directory check-workflow-drift
+else
+    echo "No workflow source or compiler changes; skipping full workflow recompilation."
+fi
+
+if [ "$WITH_TESTS" -eq 1 ]; then
+    echo "Pre-PR validation passed (changed files formatted and linted, impacted tests pass). Safe to call report_progress."
+else
+    echo "Pre-PR validation passed (changed files formatted and linted). Safe to call report_progress."
+fi

--- a/scripts/check-stale-lock-files.sh
+++ b/scripts/check-stale-lock-files.sh
@@ -74,17 +74,23 @@ if [ ! -d "$WORKFLOWS_DIR" ]; then
 fi
 
 collect_modified_files() {
-    # Explicit base ref compare (clean checkout safe, CI-friendly).
+    # Compare the merge-base to the current working tree so committed, staged,
+    # and unstaged branch changes are all covered.
     if [ -n "$BASE_REF" ]; then
         if git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
-            git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true
-            return
+            merge_base=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
+            if [ -n "$merge_base" ]; then
+                git diff --name-only "$merge_base" 2>/dev/null || true
+                git ls-files --others --exclude-standard
+                return
+            fi
         fi
         echo -e "${YELLOW}WARN${NC}: --base-ref not found (${BASE_REF}); falling back to working-tree check." >&2
     fi
 
-    # Local contributor path: staged/unstaged vs HEAD.
+    # Local contributor path: staged/unstaged and untracked files vs HEAD.
     git diff --name-only HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard
 }
 
 all_modified=$(collect_modified_files)

--- a/scripts/check-workflow-drift.sh
+++ b/scripts/check-workflow-drift.sh
@@ -59,6 +59,12 @@ SNAPSHOT_DIR=$(mktemp -d)
 PRE_LOCKFILES_FILE="$SNAPSHOT_DIR/pre-lockfiles.txt"
 POST_LOCKFILES_FILE="$SNAPSHOT_DIR/post-lockfiles.txt"
 SNAPSHOT_ROOT="$SNAPSHOT_DIR/original"
+# Keep this list aligned with the generated filenames in
+# pkg/workflow/central_slash_command_workflow.go.
+MAINTENANCE_FILES=(
+    ".github/workflows/agentic_commands.yml"
+    ".github/workflows/agentic_slash_commands.yml"
+)
 
 restore_lockfiles() {
     local file
@@ -70,6 +76,15 @@ restore_lockfiles() {
         mkdir -p "$(dirname "$file")"
         cp "$SNAPSHOT_ROOT/$file" "$file"
     done < "$PRE_LOCKFILES_FILE"
+
+    for file in "${MAINTENANCE_FILES[@]}"; do
+        if [ -f "$SNAPSHOT_ROOT/$file" ]; then
+            mkdir -p "$(dirname "$file")"
+            cp "$SNAPSHOT_ROOT/$file" "$file"
+        else
+            rm -f "$file"
+        fi
+    done
 }
 
 cleanup() {
@@ -86,6 +101,12 @@ while IFS= read -r file; do
     mkdir -p "$SNAPSHOT_ROOT/$(dirname "$file")"
     cp "$file" "$SNAPSHOT_ROOT/$file"
 done < "$PRE_LOCKFILES_FILE"
+for file in "${MAINTENANCE_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        mkdir -p "$SNAPSHOT_ROOT/$(dirname "$file")"
+        cp "$file" "$SNAPSHOT_ROOT/$file"
+    fi
+done
 
 echo "Checking for workflow markdown/lock file drift..."
 echo ""

--- a/scripts/check-workflow-drift_test.sh
+++ b/scripts/check-workflow-drift_test.sh
@@ -22,6 +22,9 @@ EOF
   cat > "$repo_dir/.github/workflows/example.lock.yml" <<'EOF'
 lock: original
 EOF
+  cat > "$repo_dir/.github/workflows/agentic_commands.yml" <<'EOF'
+commands: original
+EOF
 }
 
 create_fake_binary() {
@@ -41,6 +44,9 @@ case "${FAKE_COMPILE_MODE:-stable}" in
   mutate)
     cat > .github/workflows/example.lock.yml <<'OUT'
 lock: mutated
+OUT
+    cat > .github/workflows/agentic_commands.yml <<'OUT'
+commands: mutated
 OUT
     ;;
   fail)
@@ -90,10 +96,11 @@ elif grep -q ".github/workflows/example.lock.yml" "$TEST2_OUTPUT" \
   && grep -Fq ".github/workflows/*.md" "$TEST2_OUTPUT" \
   && grep -q "make recompile" "$TEST2_OUTPUT" \
   && grep -q "report_progress" "$TEST2_OUTPUT" \
-  && grep -q "^lock: original$" "$TEST_REPO/.github/workflows/example.lock.yml"; then
-  pass "drift is reported and the original file is restored"
+  && grep -q "^lock: original$" "$TEST_REPO/.github/workflows/example.lock.yml" \
+  && grep -q "^commands: original$" "$TEST_REPO/.github/workflows/agentic_commands.yml"; then
+  pass "drift is reported and all generated files are restored"
 else
-  fail "drift output or restoration was incorrect" "$(cat "$TEST2_OUTPUT"; echo; cat "$TEST_REPO/.github/workflows/example.lock.yml")"
+  fail "drift output or restoration was incorrect" "$(cat "$TEST2_OUTPUT"; echo; cat "$TEST_REPO/.github/workflows/example.lock.yml"; cat "$TEST_REPO/.github/workflows/agentic_commands.yml")"
 fi
 
 # Test 3: missing binary gets a targeted error.


### PR DESCRIPTION
## Summary

- scope `agent-report-progress` validation to changed files
- run independent lint and impacted test groups in parallel
- skip full workflow recompilation unless workflow/compiler inputs changed
- preserve generated maintenance workflows during drift checks

## Performance

- previous path: over 6 minutes (`fmt` ~78s, lint >212s, workflow drift ~81s)
- optimized path for this change set: ~3.2s
- impacted Go package validation with parallel lint/tests: ~7.8s