### PR TITLE
Highlight self-hosted runners and microVM isolation

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,7 +55,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
   <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
-    Filter GitHub content by author trust and merge status before it reaches the agent
+    Prevent untrusted GitHub content from reaching agents to reduce prompt-injection risk
   </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,7 +55,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
   <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
-    Prevent untrusted GitHub content from reaching agents to reduce prompt-injection risk
+    Reduce prompt-injection risk by filtering untrusted GitHub content
   </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -48,6 +48,15 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="beaker" title="Multiple AI Engines" href="/gh-aw/reference/engines/">
     Support for Copilot, Claude, Codex, and custom AI processors
   </FeatureCard>
+  <FeatureCard icon="server" title="Self-Hosted & ARC Runners" href="/gh-aw/reference/self-hosted-runners/">
+    Deploy on Linux self-hosted runners, including ARC with Docker-in-Docker
+  </FeatureCard>
+  <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
+    Run agents in KVM-isolated Docker sbx microVMs on compatible runners
+  </FeatureCard>
+  <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
+    Filter GitHub content by author trust and merge status before it reaches the agent
+  </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>


### PR DESCRIPTION
### Summary

Documentation-only update to the homepage feature grid, adding three new `FeatureCard` entries to highlight security and infrastructure capabilities that were previously undocumented on the landing page.

### Changes

- **File**: `docs/src/content/docs/index.mdx` (1 file changed)
- Added three `FeatureCard` components to the homepage feature list:
  - **Self-Hosted & ARC Runners** → `/gh-aw/reference/self-hosted-runners/` — deploying on Linux self-hosted runners, including ARC with Docker-in-Docker
  - **MicroVM Isolation** → `/gh-aw/reference/glossary/#docker-sbx` — running agents in KVM-isolated Docker sbx microVMs on compatible runners
  - **Integrity Filtering** → `/gh-aw/reference/integrity/` — reducing prompt-injection risk by filtering untrusted GitHub content

### Impact

- No code, schema, or behavioral changes — impact is limited to marketing/discoverability on the docs homepage.
- Not a breaking change.

### Commits

- `f04fbef1d` docs: highlight runner and sandbox support
- `203f726a4` docs: emphasize prompt injection defense
- `9132bf670` docs: refine integrity filtering copy> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/31030529502) for #50643 · auto · 24.2 AIC · ⌖ 4.61 AIC · ⊞ 6.9K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, model: auto, id: 31030529502, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/31030529502 -->