### PR TITLE
Refine homepage security features

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -60,7 +60,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
-  <FeatureCard icon="key" title="No secrets in agent runtime">
+  <FeatureCard icon="key" title="Zero-secret agents">
     Sensitive credentials never shared with agent process
   </FeatureCard>
   <FeatureCard icon="workflow" title="Cost Controls" href="#manage-cost-and-capacity">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -61,8 +61,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
   <FeatureCard icon="key" title="No secrets in agent runtime">
-    Sensitive credentials stay in isolated downstream
-    jobs, not inside the agent process.
+    Sensitive credentials never shared with agent process
   </FeatureCard>
   <FeatureCard icon="workflow" title="Cost Controls" href="#manage-cost-and-capacity">
     Per-run AI credit budgets, spend visibility, and OpenTelemetry cost analysis

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -39,9 +39,6 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
 ## Key Features
 
 <FeatureGrid columns={3}>
-  <FeatureCard icon="pencil" title="Simple Markdown Files" href="#example-daily-issues-report">
-    Write automation in plain markdown instead of complex YAML
-  </FeatureCard>
   <FeatureCard icon="cpu" title="AI-Powered Decision Making" href="#gallery">
     Workflows that understand context and adapt to situations
   </FeatureCard>
@@ -53,6 +50,10 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   </FeatureCard>
   <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
+  </FeatureCard>
+  <FeatureCard title="Safe outputs gate" href="/gh-aw/reference/safe-outputs/">
+    Requested actions are validated against your configured safe outputs
+    policy before anything is applied.
   </FeatureCard>
   <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
     Reduce prompt-injection risk by filtering untrusted GitHub content
@@ -90,10 +91,6 @@ flowchart LR
   <FeatureCard title="Sandbox + network firewall" href="/gh-aw/introduction/architecture/#agent-workflow-firewall-awf">
     The agent runs in a container behind the Agent Workflow Firewall
     and can only reach allowed destinations.
-  </FeatureCard>
-  <FeatureCard title="Safe outputs gate" href="/gh-aw/reference/safe-outputs/">
-    Requested actions are validated against your configured safe outputs
-    policy before anything is applied.
   </FeatureCard>
   <FeatureCard title="Threat detection" href="/gh-aw/reference/threat-detection/">
     A dedicated threat detection job scans proposed outputs and blocks

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -61,7 +61,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
   <FeatureCard icon="key" title="Zero-secret agents">
-    Sensitive credentials never shared with agent process
+    Sensitive credentials never shared agent sandbox
   </FeatureCard>
   <FeatureCard icon="workflow" title="Cost Controls" href="#manage-cost-and-capacity">
     Per-run AI credit budgets, spend visibility, and OpenTelemetry cost analysis

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -60,7 +60,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
-  <FeatureCard title="No secrets in agent runtime">
+  <FeatureCard icon="key" title="No secrets in agent runtime">
     Sensitive credentials stay in isolated downstream
     jobs, not inside the agent process.
   </FeatureCard>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,7 +55,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
   <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
-    Filter GitHub content by author trust and merge status before it reaches the agent
+    Prevent untrusted GitHub content from reaching agents to reduce prompt-injection risk
   </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,6 +51,9 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
+  <FeatureCard icon="key" title="Zero-secret agents">
+    Sensitive credentials never shared with agent sandbox
+  </FeatureCard>
   <FeatureCard icon="shield-check" title="Safe Outputs" href="/gh-aw/reference/safe-outputs/">
     All outputs are validated before applied
   </FeatureCard>
@@ -59,9 +62,6 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
-  </FeatureCard>
-  <FeatureCard icon="key" title="Zero-secret agents">
-    Sensitive credentials never shared with agent sandbox
   </FeatureCard>
   <FeatureCard icon="workflow" title="Cost Controls" href="#manage-cost-and-capacity">
     Per-run AI credit budgets, spend visibility, and OpenTelemetry cost analysis

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,12 +51,6 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="server" title="Self-Hosted & ARC Runners" href="/gh-aw/reference/self-hosted-runners/">
     Deploy on Linux self-hosted runners, including ARC with Docker-in-Docker
   </FeatureCard>
-  <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
-    Run agents in KVM-isolated Docker sbx microVMs on compatible runners
-  </FeatureCard>
-  <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
-    Reduce prompt-injection risk by filtering untrusted GitHub content
-  </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
@@ -94,6 +88,12 @@ flowchart LR
   <FeatureCard title="Sandbox + network firewall" href="/gh-aw/introduction/architecture/#agent-workflow-firewall-awf">
     The agent runs in a container behind the Agent Workflow Firewall
     and can only reach allowed destinations.
+  </FeatureCard>
+  <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
+    Run agents in KVM-isolated Docker sbx microVMs on compatible runners
+  </FeatureCard>
+  <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
+    Reduce prompt-injection risk by filtering untrusted GitHub content
   </FeatureCard>
   <FeatureCard title="Safe outputs gate" href="/gh-aw/reference/safe-outputs/">
     Requested actions are validated against your configured safe outputs

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,11 +51,18 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="server" title="Self-Hosted & ARC Runners" href="/gh-aw/reference/self-hosted-runners/">
     Deploy on Linux self-hosted runners, including ARC with Docker-in-Docker
   </FeatureCard>
+  <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
+    Run agents in KVM-isolated Docker sbx microVMs on compatible runners
+  </FeatureCard>
+  <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
+    Reduce prompt-injection risk by filtering untrusted GitHub content
+  </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
-  <FeatureCard icon="shield-lock" title="Safety First" href="#guardrails-built-in">
-    Sandboxed execution with minimal permissions and safe output processing
+  <FeatureCard title="No secrets in agent runtime">
+    Sensitive credentials stay in isolated downstream
+    jobs, not inside the agent process.
   </FeatureCard>
   <FeatureCard icon="workflow" title="Cost Controls" href="#manage-cost-and-capacity">
     Per-run AI credit budgets, spend visibility, and OpenTelemetry cost analysis
@@ -81,19 +88,9 @@ flowchart LR
     The agent can read repository state, but it cannot
     push commits or write to issues directly.
   </FeatureCard>
-  <FeatureCard title="No secrets in agent runtime">
-    Sensitive credentials stay in isolated downstream
-    jobs, not inside the agent process.
-  </FeatureCard>
   <FeatureCard title="Sandbox + network firewall" href="/gh-aw/introduction/architecture/#agent-workflow-firewall-awf">
     The agent runs in a container behind the Agent Workflow Firewall
     and can only reach allowed destinations.
-  </FeatureCard>
-  <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
-    Run agents in KVM-isolated Docker sbx microVMs on compatible runners
-  </FeatureCard>
-  <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
-    Reduce prompt-injection risk by filtering untrusted GitHub content
   </FeatureCard>
   <FeatureCard title="Safe outputs gate" href="/gh-aw/reference/safe-outputs/">
     Requested actions are validated against your configured safe outputs

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -55,7 +55,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
   <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
-    Prevent untrusted GitHub content from reaching agents to reduce prompt-injection risk
+    Reduce prompt-injection risk by filtering untrusted GitHub content
   </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -48,6 +48,15 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="beaker" title="Multiple AI Engines" href="/gh-aw/reference/engines/">
     Support for Copilot, Claude, Codex, and custom AI processors
   </FeatureCard>
+  <FeatureCard icon="server" title="Self-Hosted & ARC Runners" href="/gh-aw/reference/self-hosted-runners/">
+    Deploy on Linux self-hosted runners, including ARC with Docker-in-Docker
+  </FeatureCard>
+  <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
+    Run agents in KVM-isolated Docker sbx microVMs on compatible runners
+  </FeatureCard>
+  <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
+    Filter GitHub content by author trust and merge status before it reaches the agent
+  </FeatureCard>
   <FeatureCard icon="mark-github" title="GitHub Integration" href="/gh-aw/reference/github-tools/">
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -61,7 +61,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
     Deep integration with Actions, Issues, PRs, Discussions, and repository management
   </FeatureCard>
   <FeatureCard icon="key" title="Zero-secret agents">
-    Sensitive credentials never shared agent sandbox
+    Sensitive credentials never shared with agent sandbox
   </FeatureCard>
   <FeatureCard icon="workflow" title="Cost Controls" href="#manage-cost-and-capacity">
     Per-run AI credit budgets, spend visibility, and OpenTelemetry cost analysis

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -83,10 +83,6 @@ flowchart LR
 ```
 
 <FeatureGrid columns={3}>
-  <FeatureCard title="Read-only token">
-    The agent can read repository state, but it cannot
-    push commits or write to issues directly.
-  </FeatureCard>
   <FeatureCard title="Sandbox + network firewall" href="/gh-aw/introduction/architecture/#agent-workflow-firewall-awf">
     The agent runs in a container behind the Agent Workflow Firewall
     and can only reach allowed destinations.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,9 +51,8 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
-  <FeatureCard title="Safe outputs gate" href="/gh-aw/reference/safe-outputs/">
-    Requested actions are validated against your configured safe outputs
-    policy before anything is applied.
+  <FeatureCard icon="shield-check" title="Safe Outputs" href="/gh-aw/reference/safe-outputs/">
+    All outputs are validated before applied
   </FeatureCard>
   <FeatureCard icon="filter" title="Integrity Filtering" href="/gh-aw/reference/integrity/">
     Reduce prompt-injection risk by filtering untrusted GitHub content


### PR DESCRIPTION
## Summary

- replace Simple Markdown Files with Safe outputs gate in the Key Features grid
- keep MicroVM Isolation and Integrity Filtering as key features
- replace Safety First with Zero-secret agents
- remove the moved Safe outputs and no-secrets cards from Guardrails Built-In

## Testing

- `make agent-report-progress`