### PR TITLE
Capitalize Zero-Secret Agents feature title

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,7 +51,7 @@ Developed by GitHub and Microsoft, workflows run with added guardrails, using sa
   <FeatureCard icon="shield-lock" title="MicroVM Isolation" href="/gh-aw/reference/glossary/#docker-sbx">
     Run agents in KVM-isolated Docker sbx microVMs on compatible runners
   </FeatureCard>
-  <FeatureCard icon="key" title="Zero-secret agents">
+  <FeatureCard icon="key" title="Zero-Secret Agents">
     Sensitive credentials never shared with agent sandbox
   </FeatureCard>
   <FeatureCard icon="shield-check" title="Safe Outputs" href="/gh-aw/reference/safe-outputs/">


### PR DESCRIPTION
### Summary

Capitalizes the title of the Zero-secret agents feature card on the documentation homepage to Zero-Secret Agents, matching the title-case style used by the other feature cards on that page (e.g. MicroVM Isolation, Safe Outputs).

### Changes

- docs/src/content/docs/index.mdx: Changed title of the key-icon FeatureCard from Zero-secret agents to Zero-Secret Agents.

### Impact

- Documentation-only change (single line, single file).
- No functional/code behavior change; purely a text/formatting fix for visual consistency on the homepage feature grid.> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/31035813353) for #50665 · auto · 20.1 AIC · ⌖ 4.05 AIC · ⊞ 6.9K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, model: auto, id: 31035813353, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/31035813353 -->