### PR TITLE
Mask shim secrets in memory

### DIFF
--- a/actions/setup/js/shim.cjs
+++ b/actions/setup/js/shim.cjs
@@ -14,7 +14,25 @@
 
 const escapeCommandData = value => String(value).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
 
+const secrets = new Set();
+
+const maskSecrets = value => {
+  let masked = String(value);
+  const orderedSecrets = [...secrets].sort((left, right) => right.length - left.length);
+  for (const secret of orderedSecrets) {
+    masked = masked.split(secret).join("***");
+  }
+  return masked;
+};
+
 const setSecret = /** @param {string} value */ value => {
+  const secret = String(value);
+  if (secret.length === 0) {
+    return;
+  }
+
+  process.stderr.write(`::add-mask::${escapeCommandData(secret)}\n`);
+  secrets.add(secret);
 };
 
 if (!global.core) {
@@ -25,7 +43,7 @@ if (!global.core) {
    * @param {string} message
    */
   const writeShimLog = (level, message) => {
-    process.stderr.write(`[${level}] ${message}\n`);
+    process.stderr.write(`[${level}] ${maskSecrets(message)}\n`);
   };
 
   global.core = {

--- a/actions/setup/js/shim.cjs
+++ b/actions/setup/js/shim.cjs
@@ -12,16 +12,37 @@
  * `github-script`) the respective block is a no-op.
  */
 
-const escapeCommandData = value => String(value).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-
 const secrets = new Set();
 
 const maskSecrets = value => {
-  let masked = String(value);
-  const orderedSecrets = [...secrets].sort((left, right) => right.length - left.length);
-  for (const secret of orderedSecrets) {
-    masked = masked.split(secret).join("***");
+  const text = String(value);
+  const ranges = [];
+  for (const secret of secrets) {
+    for (let start = text.indexOf(secret); start !== -1; start = text.indexOf(secret, start + 1)) {
+      ranges.push([start, start + secret.length]);
+    }
   }
+
+  if (ranges.length === 0) {
+    return text;
+  }
+
+  ranges.sort((left, right) => left[0] - right[0]);
+  let masked = "";
+  let cursor = 0;
+  let [rangeStart, rangeEnd] = ranges[0];
+  for (const [start, end] of ranges.slice(1)) {
+    if (start <= rangeEnd) {
+      rangeEnd = Math.max(rangeEnd, end);
+      continue;
+    }
+    masked += `${text.slice(cursor, rangeStart)}***`;
+    cursor = rangeEnd;
+    rangeStart = start;
+    rangeEnd = end;
+  }
+
+  masked += `${text.slice(cursor, rangeStart)}***${text.slice(rangeEnd)}`;
   return masked;
 };
 
@@ -31,7 +52,7 @@ const setSecret = /** @param {string} value */ value => {
     return;
   }
 
-  process.stderr.write(`::add-mask::${escapeCommandData(secret)}\n`);
+  // Do not emit an add-mask workflow command here: that would write the secret to stderr.
   secrets.add(secret);
 };
 

--- a/actions/setup/js/shim.test.cjs
+++ b/actions/setup/js/shim.test.cjs
@@ -3,14 +3,14 @@ import { spawnSync } from "child_process";
 import { join } from "path";
 
 describe("core shim", () => {
-  it("emits an escaped add-mask workflow command for derived secrets", () => {
+  it("does not emit derived secrets when registering them", () => {
     const shimPath = join(import.meta.dirname, "shim.cjs");
     const result = spawnSync(process.execPath, ["-e", `require(${JSON.stringify(shimPath)}); core.setSecret("derived%secret\\r\\nvalue");`], {
       encoding: "utf8",
     });
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toBe("::add-mask::derived%25secret%0D%0Avalue\n");
+    expect(result.stderr).toBe("");
   });
 
   it("masks registered secrets in every future shim output", () => {
@@ -31,9 +31,7 @@ describe("core shim", () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toBe(
-      ["::add-mask::derived.secret", "[debug] debug *** ***", "[info] info ***", "[notice] notice ***", "[warning] warning ***", "[error] error ***", "[output] ***-name=***-value", "[error] failed ***", ""].join("\n")
-    );
+    expect(result.stderr).toBe(["[debug] debug *** ***", "[info] info ***", "[notice] notice ***", "[warning] warning ***", "[error] error ***", "[output] ***-name=***-value", "[error] failed ***", ""].join("\n"));
   });
 
   it("masks overlapping secrets without revealing suffixes", () => {
@@ -49,7 +47,22 @@ describe("core shim", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toBe("::add-mask::token\n::add-mask::token-with-suffix\n[info] *** ***\n");
+    expect(result.stderr).toBe("[info] *** ***\n");
+  });
+
+  it("masks self-overlapping secrets without revealing suffixes", () => {
+    const shimPath = join(import.meta.dirname, "shim.cjs");
+    const script = `
+      require(${JSON.stringify(shimPath)});
+      core.setSecret("aaa");
+      core.info("aaaa");
+    `;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("[info] ***\n");
   });
 
   it("ignores empty secrets", () => {
@@ -69,6 +82,6 @@ describe("core shim", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toBe("::add-mask::derived-value\n");
+    expect(result.stderr).toBe("");
   });
 });

--- a/actions/setup/js/shim.test.cjs
+++ b/actions/setup/js/shim.test.cjs
@@ -13,6 +13,55 @@ describe("core shim", () => {
     expect(result.stderr).toBe("::add-mask::derived%25secret%0D%0Avalue\n");
   });
 
+  it("masks registered secrets in every future shim output", () => {
+    const shimPath = join(import.meta.dirname, "shim.cjs");
+    const script = `
+      require(${JSON.stringify(shimPath)});
+      core.setSecret("derived.secret");
+      core.debug("debug derived.secret derived.secret");
+      core.info("info derived.secret");
+      core.notice("notice derived.secret");
+      core.warning("warning derived.secret");
+      core.error("error derived.secret");
+      core.setOutput("derived.secret-name", "derived.secret-value");
+      core.setFailed("failed derived.secret");
+    `;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe(
+      ["::add-mask::derived.secret", "[debug] debug *** ***", "[info] info ***", "[notice] notice ***", "[warning] warning ***", "[error] error ***", "[output] ***-name=***-value", "[error] failed ***", ""].join("\n")
+    );
+  });
+
+  it("masks overlapping secrets without revealing suffixes", () => {
+    const shimPath = join(import.meta.dirname, "shim.cjs");
+    const script = `
+      require(${JSON.stringify(shimPath)});
+      core.setSecret("token");
+      core.setSecret("token-with-suffix");
+      core.info("token-with-suffix token");
+    `;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("::add-mask::token\n::add-mask::token-with-suffix\n[info] *** ***\n");
+  });
+
+  it("ignores empty secrets", () => {
+    const shimPath = join(import.meta.dirname, "shim.cjs");
+    const result = spawnSync(process.execPath, ["-e", `require(${JSON.stringify(shimPath)}); core.setSecret(""); core.info("visible");`], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("[info] visible\n");
+  });
+
   it("adds setSecret to an existing partial core object", () => {
     const shimPath = join(import.meta.dirname, "shim.cjs");
     const result = spawnSync(process.execPath, ["-e", `global.core = { info() {} }; require(${JSON.stringify(shimPath)}); core.setSecret("derived-value");`], {


### PR DESCRIPTION
## Summary

- retain values registered through `core.setSecret()` in the standalone shim
- mask registered values across all future shim log and output calls
- handle repeated, overlapping, escaped, and empty secret values safely

## Testing

- `make agent-report-progress`