### PR TITLE
test: isolate update checks from agent CI environment

### DIFF
--- a/pkg/cli/compile_update_check_test.go
+++ b/pkg/cli/compile_update_check_test.go
@@ -42,6 +42,7 @@ func TestShouldRunCompileUpdateCheck(t *testing.T) {
 	t.Setenv("CI", "")
 	t.Setenv("CONTINUOUS_INTEGRATION", "")
 	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("COPILOT_AGENT_SESSION_ID", "")
 	t.Setenv("GH_AW_MCP_SERVER", "")
 	t.Setenv(compileUpdateCheckDisableEnv, "")
 	assert.True(t, shouldRunCompileUpdateCheck(false), "check should run when not disabled")
@@ -298,6 +299,7 @@ func TestStartCompileUpdateCheckDoesNotBlockShutdown(t *testing.T) {
 	t.Setenv("CI", "")
 	t.Setenv("CONTINUOUS_INTEGRATION", "")
 	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("COPILOT_AGENT_SESSION_ID", "")
 	t.Setenv("GH_AW_MCP_SERVER", "")
 	t.Setenv(compileUpdateCheckDisableEnv, "")
 	getCompileUpdateCheckFilePathFunc = func() string {
@@ -358,6 +360,7 @@ func TestStartCompileUpdateCheckSilentlyHandlesLockedDownNetwork(t *testing.T) {
 	t.Setenv("CI", "")
 	t.Setenv("CONTINUOUS_INTEGRATION", "")
 	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("COPILOT_AGENT_SESSION_ID", "")
 	t.Setenv("GH_AW_MCP_SERVER", "")
 	t.Setenv(compileUpdateCheckDisableEnv, "")
 	getCompileUpdateCheckFilePathFunc = func() string {

--- a/pkg/cli/update_check_test.go
+++ b/pkg/cli/update_check_test.go
@@ -27,10 +27,12 @@ func (f fakeReleaseClient) DoWithContext(ctx context.Context, method string, pat
 func TestShouldCheckForUpdate(t *testing.T) {
 	// Save original environment
 	origCI := os.Getenv("CI")
+	origCopilotAgentSessionID := os.Getenv("COPILOT_AGENT_SESSION_ID")
 	origMCP := os.Getenv("GH_AW_MCP_SERVER")
 	origGetLastCheckFilePath := getLastCheckFilePathFunc
 	defer func() {
 		os.Setenv("CI", origCI)
+		os.Setenv("COPILOT_AGENT_SESSION_ID", origCopilotAgentSessionID)
 		os.Setenv("GH_AW_MCP_SERVER", origMCP)
 		getLastCheckFilePathFunc = origGetLastCheckFilePath
 	}()
@@ -100,6 +102,7 @@ func TestShouldCheckForUpdate(t *testing.T) {
 				os.Unsetenv("CI")
 				os.Unsetenv("CONTINUOUS_INTEGRATION")
 				os.Unsetenv("GITHUB_ACTIONS")
+				os.Unsetenv("COPILOT_AGENT_SESSION_ID")
 			} else {
 				os.Setenv("CI", tt.ciEnv)
 			}
@@ -241,6 +244,7 @@ func TestCheckForUpdatesAsync_ContextCancellation(t *testing.T) {
 	t.Setenv("CI", "")
 	t.Setenv("GITHUB_ACTIONS", "")
 	t.Setenv("CONTINUOUS_INTEGRATION", "")
+	t.Setenv("COPILOT_AGENT_SESSION_ID", "")
 	t.Setenv("GH_AW_MCP_SERVER", "")
 
 	// Create temporary directory for last check file
@@ -281,6 +285,7 @@ func TestCheckForUpdatesAsync_JoinsGoroutine(t *testing.T) {
 	t.Setenv("CI", "")
 	t.Setenv("GITHUB_ACTIONS", "")
 	t.Setenv("CONTINUOUS_INTEGRATION", "")
+	t.Setenv("COPILOT_AGENT_SESSION_ID", "")
 	t.Setenv("GH_AW_MCP_SERVER", "")
 
 	// Create temporary directory for last check file


### PR DESCRIPTION
## Summary
- clear `COPILOT_AGENT_SESSION_ID` in update-check tests that require a non-CI environment
- prevent caller environment from disabling background update-check test paths

## Validation
- `make test-unit-all`
- `make agent-report-progress`