### PR TITLE
Fix MCP gateway environment injection

### DIFF
--- a/actions/setup/js/start_mcp_gateway.cjs
+++ b/actions/setup/js/start_mcp_gateway.cjs
@@ -96,6 +96,9 @@ function injectCustomGatewayEnvArgs(args, env = process.env) {
     throw new Error("GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES must be an array of valid environment variable names");
   }
 
+  // Missing indexed transport values intentionally become empty container env vars.
+  // This preserves deterministic NAME→slot mapping and keeps Docker argument injection
+  // impossible even if the compiler/runtime metadata ever diverges.
   const customArgs = names.flatMap((name, index) => ["-e", `${name}=${env[`GH_AW_MCP_GATEWAY_ENV_${index}`] || ""}`]);
   return [...args.slice(0, markerIndex), ...customArgs, ...args.slice(markerIndex + 1)];
 }

--- a/actions/setup/js/start_mcp_gateway.cjs
+++ b/actions/setup/js/start_mcp_gateway.cjs
@@ -27,6 +27,7 @@ require("./shim.cjs");
  * Optional:
  * - GH_AW_ENGINE: Engine type (copilot, codex, claude, gemini)
  * - GH_AW_MCP_CLI_SERVERS: JSON array of server names to exclude from agent config
+ * - GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: JSON array of custom gateway environment variable names
  */
 
 const { spawn, execSync } = require("child_process");
@@ -39,6 +40,8 @@ const { getErrorMessage } = require("./error_helpers.cjs");
 
 /** @type {number | null} */
 let activeGatewayPid = null;
+const customGatewayEnvMarker = "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__";
+const customGatewayEnvNamePattern = /^[A-Z_][A-Z0-9_]*$/;
 
 // ---------------------------------------------------------------------------
 // Timing helpers
@@ -67,6 +70,34 @@ function printTiming(startMs, label) {
  */
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Replaces the compiler marker with atomic Docker -e arguments. Runtime values
+ * never enter MCP_GATEWAY_DOCKER_COMMAND, preventing Docker argument injection.
+ *
+ * @param {string[]} args
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string[]}
+ */
+function injectCustomGatewayEnvArgs(args, env = process.env) {
+  const markerIndex = args.indexOf(customGatewayEnvMarker);
+  if (markerIndex === -1) {
+    return args;
+  }
+
+  let names;
+  try {
+    names = JSON.parse(env.GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES || "[]");
+  } catch (err) {
+    throw new Error(`GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES must be valid JSON: ${getErrorMessage(err)}`, { cause: err });
+  }
+  if (!Array.isArray(names) || !names.every(name => typeof name === "string" && customGatewayEnvNamePattern.test(name))) {
+    throw new Error("GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES must be an array of valid environment variable names");
+  }
+
+  const customArgs = names.flatMap((name, index) => ["-e", `${name}=${env[`GH_AW_MCP_GATEWAY_ENV_${index}`] || ""}`]);
+  return [...args.slice(0, markerIndex), ...customArgs, ...args.slice(markerIndex + 1)];
 }
 
 /**
@@ -536,12 +567,13 @@ async function main() {
   const gatewayStartTime = nowMs();
 
   // Split docker command into args, respecting simple quoting
-  const args = dockerCommand.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  let args = Array.from(dockerCommand.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []);
   const cmd = args.shift();
   if (!cmd) {
     core.setFailed("ERROR: MCP_GATEWAY_DOCKER_COMMAND did not contain an executable command");
     return;
   }
+  args = injectCustomGatewayEnvArgs(args);
 
   const outputFd = fs.openSync(outputPath, "w", 0o600);
 
@@ -1026,6 +1058,7 @@ module.exports = {
   hasNonEmptyOTLPHeaders,
   isOTLPIfMissingIgnore,
   getJSONParseErrorContext,
+  injectCustomGatewayEnvArgs,
   normalizeSinkVisibilityEncoding,
   resolveCopilotConfigPaths,
 };

--- a/actions/setup/js/start_mcp_gateway.test.cjs
+++ b/actions/setup/js/start_mcp_gateway.test.cjs
@@ -17,26 +17,6 @@ describe("start_mcp_gateway logging", () => {
     expect(source).not.toContain("/tmp/gh-aw/mcp-logs/stderr.log");
   });
 
-  describe("start_mcp_gateway custom environment arguments", () => {
-    it("passes hostile values as one atomic Docker argument", () => {
-      const hostileValue = `x" --privileged -v /workspace/evil:/evil --entrypoint /evil -e X="x`;
-      const args = injectCustomGatewayEnvArgs(["run", "--rm", "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__", "gateway-image"], {
-        GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["BASH_ENV"]',
-        GH_AW_MCP_GATEWAY_ENV_0: hostileValue,
-      });
-
-      expect(args).toEqual(["run", "--rm", "-e", `BASH_ENV=${hostileValue}`, "gateway-image"]);
-    });
-
-    it("rejects malformed or unsafe environment variable names", () => {
-      expect(() =>
-        injectCustomGatewayEnvArgs(["run", "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__", "gateway-image"], {
-          GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["BAD-NAME"]',
-        })
-      ).toThrow(/valid environment variable names/);
-    });
-  });
-
   it("does not create the MCP gateway startup log", () => {
     const source = fs.readFileSync(new URL("./start_mcp_gateway.cjs", import.meta.url), "utf8");
     expect(source).not.toContain("/tmp/gh-aw/mcp-logs/start-gateway.log");
@@ -45,6 +25,61 @@ describe("start_mcp_gateway logging", () => {
   it("discards the gateway child process stderr", () => {
     const source = fs.readFileSync(new URL("./start_mcp_gateway.cjs", import.meta.url), "utf8");
     expect(source).toContain(`stdio: ["pipe", outputFd, "ignore"]`);
+  });
+});
+
+describe("start_mcp_gateway custom environment arguments", () => {
+  const marker = "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__";
+
+  it("passes hostile values as one atomic Docker argument", () => {
+    const hostileValue = `x" --privileged -v /workspace/evil:/evil --entrypoint /evil -e X="x`;
+    const args = injectCustomGatewayEnvArgs(["run", "--rm", marker, "gateway-image"], {
+      GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["BASH_ENV"]',
+      GH_AW_MCP_GATEWAY_ENV_0: hostileValue,
+    });
+
+    expect(args).toEqual(["run", "--rm", "-e", `BASH_ENV=${hostileValue}`, "gateway-image"]);
+  });
+
+  it("preserves sorted multi-value index mapping and empty values", () => {
+    const args = injectCustomGatewayEnvArgs(["run", marker, "gateway-image"], {
+      GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["ALPHA","EMPTY","OMEGA"]',
+      GH_AW_MCP_GATEWAY_ENV_0: "first",
+      GH_AW_MCP_GATEWAY_ENV_1: "",
+      GH_AW_MCP_GATEWAY_ENV_2: "last\nline",
+    });
+
+    expect(args).toEqual(["run", "-e", "ALPHA=first", "-e", "EMPTY=", "-e", "OMEGA=last\nline", "gateway-image"]);
+  });
+
+  it("uses an empty value when transport metadata is missing", () => {
+    const args = injectCustomGatewayEnvArgs(["run", marker, "gateway-image"], {
+      GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["PRESENT","MISSING"]',
+      GH_AW_MCP_GATEWAY_ENV_0: "value",
+    });
+
+    expect(args).toEqual(["run", "-e", "PRESENT=value", "-e", "MISSING=", "gateway-image"]);
+  });
+
+  it("leaves commands without the marker unchanged", () => {
+    const args = ["run", "--rm", "gateway-image"];
+    expect(injectCustomGatewayEnvArgs(args, { GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "not-json" })).toBe(args);
+  });
+
+  it("rejects malformed JSON metadata", () => {
+    expect(() =>
+      injectCustomGatewayEnvArgs(["run", marker, "gateway-image"], {
+        GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "not-json",
+      })
+    ).toThrow(/must be valid JSON/);
+  });
+
+  it("rejects malformed or unsafe environment variable names", () => {
+    expect(() =>
+      injectCustomGatewayEnvArgs(["run", marker, "gateway-image"], {
+        GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["BAD-NAME"]',
+      })
+    ).toThrow(/valid environment variable names/);
   });
 });
 

--- a/actions/setup/js/start_mcp_gateway.test.cjs
+++ b/actions/setup/js/start_mcp_gateway.test.cjs
@@ -1,11 +1,40 @@
 import fs from "fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applyOTLPIgnoreIfMissing, detectEngineType, getJSONParseErrorContext, getOTLPIfMissingMode, hasNonEmptyOTLPHeaders, normalizeSinkVisibilityEncoding, resolveCopilotConfigPaths } from "./start_mcp_gateway.cjs";
+import {
+  applyOTLPIgnoreIfMissing,
+  detectEngineType,
+  getJSONParseErrorContext,
+  getOTLPIfMissingMode,
+  hasNonEmptyOTLPHeaders,
+  injectCustomGatewayEnvArgs,
+  normalizeSinkVisibilityEncoding,
+  resolveCopilotConfigPaths,
+} from "./start_mcp_gateway.cjs";
 
 describe("start_mcp_gateway logging", () => {
   it("does not create the legacy MCP gateway stderr log", () => {
     const source = fs.readFileSync(new URL("./start_mcp_gateway.cjs", import.meta.url), "utf8");
     expect(source).not.toContain("/tmp/gh-aw/mcp-logs/stderr.log");
+  });
+
+  describe("start_mcp_gateway custom environment arguments", () => {
+    it("passes hostile values as one atomic Docker argument", () => {
+      const hostileValue = `x" --privileged -v /workspace/evil:/evil --entrypoint /evil -e X="x`;
+      const args = injectCustomGatewayEnvArgs(["run", "--rm", "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__", "gateway-image"], {
+        GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["BASH_ENV"]',
+        GH_AW_MCP_GATEWAY_ENV_0: hostileValue,
+      });
+
+      expect(args).toEqual(["run", "--rm", "-e", `BASH_ENV=${hostileValue}`, "gateway-image"]);
+    });
+
+    it("rejects malformed or unsafe environment variable names", () => {
+      expect(() =>
+        injectCustomGatewayEnvArgs(["run", "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__", "gateway-image"], {
+          GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: '["BAD-NAME"]',
+        })
+      ).toThrow(/valid environment variable names/);
+    });
   });
 
   it("does not create the MCP gateway startup log", () => {

--- a/docs/adr/50924-secure-mcp-gateway-env-injection.md
+++ b/docs/adr/50924-secure-mcp-gateway-env-injection.md
@@ -1,0 +1,48 @@
+# ADR-50924: Secure MCP Gateway Custom Environment Injection via Compiler-Controlled Transport Variables
+
+**Date**: 2026-08-06
+**Status**: Draft
+**Deciders**: pelikhan
+
+---
+
+### Context
+
+The MCP gateway allows workflow authors to supply custom environment variables under `sandbox.mcp.env`. Before this change, these values were interpolated directly into two unsafe positions: (1) the GitHub Actions `run:` shell script as `export NAME=VALUE` statements, and (2) the serialized Docker command string as `-e NAME` flags (with values forwarded from the shell environment). This approach is exploitable: values containing shell metacharacters (`;`, backticks, newlines) can inject arbitrary commands into the shell script before the gateway process starts, and a value assigned to `BASH_ENV` would be sourced by Bash on the runner host before the run script executes. These issues are tracked as GHSA-j77w-g4jj-hp99.
+
+### Decision
+
+We will route `sandbox.mcp.env` values through compiler-controlled transport environment variables (`GH_AW_MCP_GATEWAY_ENV_0`, `GH_AW_MCP_GATEWAY_ENV_1`, …) and a companion manifest variable (`GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES`) instead of embedding them in the shell script or Docker command string. The Go compiler writes the values under indexed names that have no special meaning to Bash; a marker token (`__GH_AW_MCP_GATEWAY_CUSTOM_ENV__`) is placed in the Docker command string and replaced at runtime by the JavaScript launcher (`start_mcp_gateway.cjs`) with atomic `-e NAME=VALUE` arguments constructed from the transport variables. Env var names are validated at compile time (Go regex) and at runtime (JS regex) against `^[A-Z_][A-Z0-9_]*$`.
+
+### Alternatives Considered
+
+#### Alternative 1: Shell-escape values before embedding in the run script
+
+Escape all shell-special characters in `sandbox.mcp.env` values before interpolating them into `export NAME=VALUE` lines in the generated `run:` block. This is the simplest approach and requires no protocol changes.
+
+Not chosen because: shell escaping is notoriously difficult to get right across all Bash versions and special variables (e.g., `BASH_ENV` is sourced before the script body runs, so even a correctly-escaped assignment can still be exploited if the name itself is dangerous). A missed edge case would reintroduce the vulnerability silently.
+
+#### Alternative 2: Quote env values in the Docker command string
+
+Embed values as `"NAME=VALUE"` tokens in the serialized `MCP_GATEWAY_DOCKER_COMMAND` string, relying on the existing shell-split regex to pass them as quoted arguments to `spawn()`.
+
+Not chosen because: the serialized command is a string that is split by regex in JS; adding values there keeps runtime secrets inside a compiled YAML string and makes the split logic responsible for correctly handling arbitrary byte sequences including quotes, spaces, and newlines. A value containing `"` or a newline would break the split or the quoting, and the serialized form would capture secret values in CI logs.
+
+### Consequences
+
+#### Positive
+- Shell metacharacters (`;`, backticks, newlines, `BASH_ENV`) in custom env values can no longer inject commands into the runner shell or be sourced by Bash before the run script executes, because values never appear in the `run:` block.
+- Custom values are never embedded in the compiled Docker command string, so they do not appear in workflow lock files, CI logs, or debug output of the gateway command.
+- Defense-in-depth: env var name validation occurs at both compile time (Go) and at gateway launch time (JS), so a malformed name is rejected before it can reach the container.
+
+#### Negative
+- Increased complexity: the transport is a two-layer protocol (Go compiler writes indexed transport vars; JS launcher reads the manifest, validates names, and reconstructs atomic `-e` arguments) that must be kept in sync across two languages.
+- The marker token `__GH_AW_MCP_GATEWAY_CUSTOM_ENV__` is a non-obvious in-band signal that appears in the Docker command string and must remain undocumented to avoid forgery; any refactor that removes or renames it silently breaks custom env injection.
+
+#### Neutral
+- The number of GitHub Actions step environment variables increases by `N+1` for a workflow with `N` custom MCP env vars.
+- Workflows that previously relied on the `export NAME=VALUE` path in the run script to make custom env vars available to shell commands other than the gateway itself will no longer have those exports — those workflows would have needed explicit `export` steps anyway.
+
+---
+
+*ADR created by [adr-writer agent]. Review and finalize before changing status from Draft to Accepted.*

--- a/pkg/workflow/mcp_gateway_env_security_integration_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_integration_test.go
@@ -43,7 +43,11 @@ func extractMCPGatewayStepSection(jobSection, stepName string) string {
 				continue
 			}
 			inStep = true
-			stepPrefix = line[:strings.Index(line, "- name: ")]
+			idx := strings.Index(line, "- name: ")
+			if idx < 0 {
+				return ""
+			}
+			stepPrefix = line[:idx]
 			stepLines = append(stepLines, line)
 			continue
 		}
@@ -106,7 +110,7 @@ mcp-servers:
     url: "https://example.com/mcp"
     env:
       FORWARDED_NAMES: ${{ env.GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES }}
-      FORWARDED_VALUE: ${{ env.GH_AW_MCP_GATEWAY_ENV_0 }}
+      FORWARDED_VALUE: ${{ env.GH_AW_MCP_GATEWAY_ENV_5 }}
 ---`), 0o644))
 
 	workflowPath := filepath.Join(tmpDir, "test-workflow.md")
@@ -150,5 +154,6 @@ Verify MCP gateway reserved env name handling.
 	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"API_TOKEN\"]"`)
 	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_ENV_0: "custom-token"`)
 	assert.NotContains(t, gatewayStep, `${{ env.GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES }}`)
-	assert.NotContains(t, gatewayStep, `${{ env.GH_AW_MCP_GATEWAY_ENV_0 }}`)
+	assert.NotContains(t, gatewayStep, `${{ env.GH_AW_MCP_GATEWAY_ENV_5 }}`)
+	assert.NotContains(t, gatewayStep, "GH_AW_MCP_GATEWAY_ENV_5:")
 }

--- a/pkg/workflow/mcp_gateway_env_security_integration_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_integration_test.go
@@ -106,6 +106,7 @@ mcp-servers:
     url: "https://example.com/mcp"
     env:
       FORWARDED_NAMES: ${{ env.GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES }}
+      FORWARDED_VALUE: ${{ env.GH_AW_MCP_GATEWAY_ENV_0 }}
 ---`), 0o644))
 
 	workflowPath := filepath.Join(tmpDir, "test-workflow.md")
@@ -148,4 +149,6 @@ Verify MCP gateway reserved env name handling.
 	assert.Equal(t, 1, strings.Count(gatewayStep, mcpGatewayCustomEnvNamesVar+":"))
 	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"API_TOKEN\"]"`)
 	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_ENV_0: "custom-token"`)
+	assert.NotContains(t, gatewayStep, `${{ env.GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES }}`)
+	assert.NotContains(t, gatewayStep, `${{ env.GH_AW_MCP_GATEWAY_ENV_0 }}`)
 }

--- a/pkg/workflow/mcp_gateway_env_security_integration_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_integration_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/github/gh-aw/pkg/stringutil"
+	"github.com/github/gh-aw/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func compileMCPGatewayWorkflowLock(t *testing.T, workflowContent string) string {
+	t.Helper()
+
+	tmpDir := testutil.TempDir(t, "mcp-gateway-env-security")
+	workflowPath := filepath.Join(tmpDir, "test-workflow.md")
+	require.NoError(t, os.WriteFile(workflowPath, []byte(workflowContent), 0o644))
+
+	compiler := NewCompiler()
+	require.NoError(t, compiler.CompileWorkflow(workflowPath))
+
+	lockPath := stringutil.MarkdownToLockFile(workflowPath)
+	lockContent, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	return string(lockContent)
+}
+
+func extractMCPGatewayStepSection(jobSection, stepName string) string {
+	lines := strings.Split(jobSection, "\n")
+	var stepLines []string
+	var stepPrefix string
+	inStep := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inStep {
+			if trimmed != "- name: "+stepName {
+				continue
+			}
+			inStep = true
+			stepPrefix = line[:strings.Index(line, "- name: ")]
+			stepLines = append(stepLines, line)
+			continue
+		}
+
+		if strings.HasPrefix(line, stepPrefix+"- ") {
+			break
+		}
+		stepLines = append(stepLines, line)
+	}
+
+	if len(stepLines) == 0 {
+		return ""
+	}
+
+	return strings.Join(stepLines, "\n")
+}
+
+func TestMCPGatewayCustomEnvIntegrationUsesTransportVariables(t *testing.T) {
+	lockContent := compileMCPGatewayWorkflowLock(t, `---
+on: workflow_dispatch
+strict: false
+engine: copilot
+tools:
+  github:
+    toolsets: [repos]
+sandbox:
+  mcp:
+    env:
+      API_TOKEN: custom-token
+      BASH_ENV: "$(touch /tmp/pwned)"
+---
+
+# Test Workflow
+
+Verify MCP gateway custom env transport.
+`)
+
+	agentSection := extractJobSection(lockContent, "agent")
+	require.NotEmpty(t, agentSection)
+
+	gatewayStep := extractMCPGatewayStepSection(agentSection, "Start MCP Gateway")
+	require.NotEmpty(t, gatewayStep)
+
+	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"API_TOKEN\",\"BASH_ENV\"]"`)
+	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_ENV_0: "custom-token"`)
+	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_ENV_1: "$(touch /tmp/pwned)"`)
+	assert.NotContains(t, gatewayStep, "\n          API_TOKEN:")
+	assert.NotContains(t, gatewayStep, "\n          BASH_ENV:")
+	assert.NotContains(t, gatewayStep, "export API_TOKEN=")
+	assert.NotContains(t, gatewayStep, "export BASH_ENV=")
+}
+
+func TestMCPGatewayCustomEnvIntegrationKeepsMetadataNameUnique(t *testing.T) {
+	tmpDir := testutil.TempDir(t, "mcp-gateway-env-collision")
+	sharedMCPPath := filepath.Join(tmpDir, "shared-mcp.md")
+	require.NoError(t, os.WriteFile(sharedMCPPath, []byte(`---
+on: workflow_dispatch
+mcp-servers:
+  collision:
+    url: "https://example.com/mcp"
+    env:
+      FORWARDED_NAMES: ${{ env.GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES }}
+---`), 0o644))
+
+	workflowPath := filepath.Join(tmpDir, "test-workflow.md")
+	require.NoError(t, os.WriteFile(workflowPath, []byte(`---
+on: workflow_dispatch
+strict: false
+engine: copilot
+imports:
+  - shared-mcp.md
+tools:
+  github:
+    toolsets: [repos]
+sandbox:
+  mcp:
+    env:
+      API_TOKEN: custom-token
+---
+
+# Test Workflow
+
+Verify MCP gateway reserved env name handling.
+`), 0o644))
+
+	compiler := NewCompiler()
+	require.NoError(t, compiler.CompileWorkflow(workflowPath))
+
+	lockPath := stringutil.MarkdownToLockFile(workflowPath)
+	lockBytes, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	lockContent := string(lockBytes)
+	assert.Contains(t, lockContent, `"collision": {`)
+	assert.NotContains(t, lockContent, "FORWARDED_NAMES")
+
+	agentSection := extractJobSection(lockContent, "agent")
+	require.NotEmpty(t, agentSection)
+
+	gatewayStep := extractMCPGatewayStepSection(agentSection, "Start MCP Gateway")
+	require.NotEmpty(t, gatewayStep)
+
+	assert.Equal(t, 1, strings.Count(gatewayStep, mcpGatewayCustomEnvNamesVar+":"))
+	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"API_TOKEN\"]"`)
+	assert.Contains(t, gatewayStep, `GH_AW_MCP_GATEWAY_ENV_0: "custom-token"`)
+}

--- a/pkg/workflow/mcp_gateway_env_security_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_test.go
@@ -102,6 +102,20 @@ func TestMCPGatewayCustomEnvPreservesGitHubExpressionAsData(t *testing.T) {
 	assert.NotContains(t, yaml.String(), "API_TOKEN:")
 }
 
+func TestMCPGatewayCustomEnvReservesTransportMetadataName(t *testing.T) {
+	var yaml strings.Builder
+	writeMCPGatewayStepEnv(&yaml, map[string]string{
+		mcpGatewayCustomEnvNamesVar: "${{ secrets.COLLISION }}",
+	}, nil, map[string]string{
+		"API_TOKEN": "custom-token",
+	})
+
+	output := yaml.String()
+	assert.Equal(t, 1, strings.Count(output, mcpGatewayCustomEnvNamesVar+":"))
+	assert.Contains(t, output, `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"API_TOKEN\"]"`)
+	assert.NotContains(t, output, "${{ secrets.COLLISION }}")
+}
+
 func TestMCPGatewayCustomEnvCommandContract(t *testing.T) {
 	gatewayConfig := &MCPGatewayRuntimeConfig{
 		Container: "ghcr.io/github/gh-aw-mcpg",

--- a/pkg/workflow/mcp_gateway_env_security_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_test.go
@@ -1,0 +1,88 @@
+//go:build !integration
+
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPGatewayCustomEnvValuesStayOutOfRunScript(t *testing.T) {
+	gatewayEnv := map[string]string{
+		"AAA_INJECT":   "legit; echo PWNED_$(id) > /tmp/pwned #",
+		"BBB_NEWLINE":  "ok\n          echo PWNED_NEWLINE",
+		"CCC_BACKTICK": "`touch /tmp/PWNED_BACKTICK`",
+	}
+
+	var stepEnv strings.Builder
+	writeMCPGatewayStepEnv(&stepEnv, nil, nil, gatewayEnv)
+
+	assert.Contains(t, stepEnv.String(), `GH_AW_MCP_GATEWAY_ENV_0: "legit; echo PWNED_$(id) > /tmp/pwned #"`)
+	assert.Contains(t, stepEnv.String(), `GH_AW_MCP_GATEWAY_ENV_1: "ok\n          echo PWNED_NEWLINE"`)
+	assert.Contains(t, stepEnv.String(), "GH_AW_MCP_GATEWAY_ENV_2: \"`touch /tmp/PWNED_BACKTICK`\"")
+	assert.Contains(t, stepEnv.String(), `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"AAA_INJECT\",\"BBB_NEWLINE\",\"CCC_BACKTICK\"]"`)
+	assert.NotContains(t, stepEnv.String(), "AAA_INJECT:")
+	assert.NotContains(t, stepEnv.String(), "BBB_NEWLINE:")
+	assert.NotContains(t, stepEnv.String(), "CCC_BACKTICK:")
+
+	var runScript strings.Builder
+	writeMCPGatewayExports(&runScript, writeMCPGatewayExportsOptions{
+		engine:        NewCopilotEngine(),
+		workflowData:  &WorkflowData{},
+		gatewayConfig: &MCPGatewayRuntimeConfig{Env: gatewayEnv},
+		port:          8080,
+		domain:        "localhost",
+		payloadDir:    "/tmp/payloads",
+	})
+
+	assert.NotContains(t, runScript.String(), "AAA_INJECT")
+	assert.NotContains(t, runScript.String(), "BBB_NEWLINE")
+	assert.NotContains(t, runScript.String(), "CCC_BACKTICK")
+
+	var containerCommand strings.Builder
+	appendMCPGatewayCustomAndHTTPEnvFlags(
+		&containerCommand,
+		&WorkflowData{},
+		&MCPGatewayRuntimeConfig{Env: gatewayEnv},
+		nil,
+		false,
+		nil,
+		nil,
+		NewCopilotEngine(),
+	)
+	assert.Equal(t, " "+mcpGatewayCustomEnvMarker, containerCommand.String())
+}
+
+func TestMCPGatewayCustomEnvOverridesGeneratedStepEnv(t *testing.T) {
+	var yaml strings.Builder
+	writeMCPGatewayStepEnv(
+		&yaml,
+		map[string]string{"API_TOKEN": "${{ secrets.DEFAULT_TOKEN }}"},
+		map[string]string{"TARGET_REPO": "${{ inputs.target_repo }}"},
+		map[string]string{
+			"API_TOKEN":   "custom-token",
+			"TARGET_REPO": "custom-repo",
+		},
+	)
+
+	output := yaml.String()
+	require.Zero(t, strings.Count(output, "API_TOKEN:"))
+	require.Zero(t, strings.Count(output, "TARGET_REPO:"))
+	assert.Contains(t, output, `GH_AW_MCP_GATEWAY_ENV_0: "custom-token"`)
+	assert.Contains(t, output, `GH_AW_MCP_GATEWAY_ENV_1: "custom-repo"`)
+	assert.NotContains(t, output, "API_TOKEN:")
+	assert.NotContains(t, output, "TARGET_REPO:")
+}
+
+func TestMCPGatewayCustomEnvDoesNotSetBashEnvOnHost(t *testing.T) {
+	var yaml strings.Builder
+	writeMCPGatewayStepEnv(&yaml, nil, nil, map[string]string{
+		"BASH_ENV": "$(touch /tmp/pwned)",
+	})
+
+	assert.Contains(t, yaml.String(), `GH_AW_MCP_GATEWAY_ENV_0: "$(touch /tmp/pwned)"`)
+	assert.NotContains(t, yaml.String(), "BASH_ENV:")
+}

--- a/pkg/workflow/mcp_gateway_env_security_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_test.go
@@ -116,6 +116,21 @@ func TestMCPGatewayCustomEnvReservesTransportMetadataName(t *testing.T) {
 	assert.NotContains(t, output, "${{ secrets.COLLISION }}")
 }
 
+func TestMCPGatewayCustomEnvReservesTransportPrefix(t *testing.T) {
+	var yaml strings.Builder
+	writeMCPGatewayStepEnv(&yaml, map[string]string{
+		"GH_AW_MCP_GATEWAY_ENV_5": "${{ secrets.COLLISION }}",
+	}, nil, map[string]string{
+		"API_TOKEN": "custom-token",
+	})
+
+	output := yaml.String()
+	assert.Contains(t, output, `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES: "[\"API_TOKEN\"]"`)
+	assert.Contains(t, output, `GH_AW_MCP_GATEWAY_ENV_0: "custom-token"`)
+	assert.NotContains(t, output, "GH_AW_MCP_GATEWAY_ENV_5")
+	assert.NotContains(t, output, "${{ secrets.COLLISION }}")
+}
+
 func TestMCPGatewayCustomEnvCommandContract(t *testing.T) {
 	gatewayConfig := &MCPGatewayRuntimeConfig{
 		Container: "ghcr.io/github/gh-aw-mcpg",

--- a/pkg/workflow/mcp_gateway_env_security_test.go
+++ b/pkg/workflow/mcp_gateway_env_security_test.go
@@ -3,6 +3,7 @@
 package workflow
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -60,7 +61,10 @@ func TestMCPGatewayCustomEnvOverridesGeneratedStepEnv(t *testing.T) {
 	var yaml strings.Builder
 	writeMCPGatewayStepEnv(
 		&yaml,
-		map[string]string{"API_TOKEN": "${{ secrets.DEFAULT_TOKEN }}"},
+		map[string]string{
+			"API_TOKEN":               "${{ secrets.DEFAULT_TOKEN }}",
+			"GH_AW_MCP_GATEWAY_ENV_0": "reserved-value",
+		},
 		map[string]string{"TARGET_REPO": "${{ inputs.target_repo }}"},
 		map[string]string{
 			"API_TOKEN":   "custom-token",
@@ -75,6 +79,7 @@ func TestMCPGatewayCustomEnvOverridesGeneratedStepEnv(t *testing.T) {
 	assert.Contains(t, output, `GH_AW_MCP_GATEWAY_ENV_1: "custom-repo"`)
 	assert.NotContains(t, output, "API_TOKEN:")
 	assert.NotContains(t, output, "TARGET_REPO:")
+	assert.NotContains(t, output, "reserved-value")
 }
 
 func TestMCPGatewayCustomEnvDoesNotSetBashEnvOnHost(t *testing.T) {
@@ -85,4 +90,43 @@ func TestMCPGatewayCustomEnvDoesNotSetBashEnvOnHost(t *testing.T) {
 
 	assert.Contains(t, yaml.String(), `GH_AW_MCP_GATEWAY_ENV_0: "$(touch /tmp/pwned)"`)
 	assert.NotContains(t, yaml.String(), "BASH_ENV:")
+}
+
+func TestMCPGatewayCustomEnvPreservesGitHubExpressionAsData(t *testing.T) {
+	var yaml strings.Builder
+	writeMCPGatewayStepEnv(&yaml, nil, nil, map[string]string{
+		"API_TOKEN": "${{ inputs.api_token }}",
+	})
+
+	assert.Contains(t, yaml.String(), `GH_AW_MCP_GATEWAY_ENV_0: "${{ inputs.api_token }}"`)
+	assert.NotContains(t, yaml.String(), "API_TOKEN:")
+}
+
+func TestMCPGatewayCustomEnvCommandContract(t *testing.T) {
+	gatewayConfig := &MCPGatewayRuntimeConfig{
+		Container: "ghcr.io/github/gh-aw-mcpg",
+		Env:       map[string]string{"API_TOKEN": "value"},
+	}
+	workflowData := &WorkflowData{
+		SandboxConfig: &SandboxConfig{MCP: gatewayConfig},
+	}
+
+	command := buildMCPGatewayContainerCommand(buildMCPGatewayContainerCommandOptions{
+		engine:        NewCopilotEngine(),
+		workflowData:  workflowData,
+		gatewayConfig: gatewayConfig,
+	})
+
+	markerIndex := strings.Index(command, mcpGatewayCustomEnvMarker)
+	imageIndex := strings.Index(command, "ghcr.io/github/gh-aw-mcpg:")
+	require.GreaterOrEqual(t, markerIndex, 0, "Docker command should contain the custom environment marker")
+	require.Greater(t, imageIndex, markerIndex, "Custom environment marker should appear before the container image")
+	assert.NotContains(t, command, "GH_AW_MCP_GATEWAY_ENV_0")
+	assert.NotContains(t, command, "API_TOKEN=value")
+
+	launcher, err := os.ReadFile("../../actions/setup/js/start_mcp_gateway.cjs")
+	require.NoError(t, err)
+	assert.Contains(t, string(launcher), `const customGatewayEnvMarker = "`+mcpGatewayCustomEnvMarker+`"`)
+	assert.Contains(t, string(launcher), mcpGatewayCustomEnvNamesVar)
+	assert.Contains(t, string(launcher), "GH_AW_MCP_GATEWAY_ENV_${index}")
 }

--- a/pkg/workflow/mcp_setup_gateway.go
+++ b/pkg/workflow/mcp_setup_gateway.go
@@ -88,7 +88,8 @@ func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string,
 	}
 	yaml.WriteString("        env:\n")
 	customEnvVarNames := sliceutil.SortedKeys(gatewayEnvVars)
-	transportEnvVarNames := make(map[string]struct{}, len(customEnvVarNames))
+	transportEnvVarNames := make(map[string]struct{}, len(customEnvVarNames)+1)
+	transportEnvVarNames[mcpGatewayCustomEnvNamesVar] = struct{}{}
 	for i := range customEnvVarNames {
 		transportEnvVarNames[mcpGatewayCustomEnvTransportName(i)] = struct{}{}
 	}

--- a/pkg/workflow/mcp_setup_gateway.go
+++ b/pkg/workflow/mcp_setup_gateway.go
@@ -14,6 +14,9 @@ import (
 	"github.com/github/gh-aw/pkg/workflow/compilerenv"
 )
 
+const mcpGatewayCustomEnvNamesVar = "GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES"
+const mcpGatewayCustomEnvMarker = "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__"
+
 func generateMCPGatewaySetup(yaml *strings.Builder, tools map[string]any, mcpTools []string, engine CodingAgentEngine, workflowData *WorkflowData, hasAgenticWorkflows bool, safeOutputsInputEnvVars map[string]string) error {
 	// If the engine provides an MCP config-adapter script (e.g. Goose), write it to disk
 	// before starting the gateway so that start_mcp_gateway.cjs can execute it once the
@@ -28,8 +31,10 @@ func generateMCPGatewaySetup(yaml *strings.Builder, tools map[string]any, mcpToo
 	}
 	yaml.WriteString("      - name: Start MCP Gateway\n")
 	yaml.WriteString("        id: start-mcp-gateway\n")
+	ensureDefaultMCPGatewayConfig(workflowData)
+	gatewayConfig := workflowData.SandboxConfig.MCP
 	mcpEnvVars := collectMCPEnvironmentVariables(tools, mcpTools, workflowData, hasAgenticWorkflows)
-	writeMCPGatewayStepEnv(yaml, mcpEnvVars, safeOutputsInputEnvVars)
+	writeMCPGatewayStepEnv(yaml, mcpEnvVars, safeOutputsInputEnvVars, gatewayConfig.Env)
 	yaml.WriteString("        run: |\n")
 	yaml.WriteString("          set -eo pipefail\n")
 	yaml.WriteString("          mkdir -p \"${RUNNER_TEMP}/gh-aw/mcp-config\"\n")
@@ -37,8 +42,6 @@ func generateMCPGatewaySetup(yaml *strings.Builder, tools map[string]any, mcpToo
 		yaml.WriteString("          mkdir -p /tmp/gh-aw/mcp-logs/playwright\n")
 		yaml.WriteString("          chmod 777 /tmp/gh-aw/mcp-logs/playwright\n")
 	}
-	ensureDefaultMCPGatewayConfig(workflowData)
-	gatewayConfig := workflowData.SandboxConfig.MCP
 	port, domain, payloadDir, payloadPathPrefix, payloadSizeThreshold := resolveMCPGatewayValues(workflowData, gatewayConfig)
 	githubToolRaw, hasGitHub := tools["github"]
 	githubTool, _ := githubToolRaw.(map[string]any)
@@ -79,23 +82,56 @@ func generateMCPGatewaySetup(yaml *strings.Builder, tools map[string]any, mcpToo
 	return engine.RenderMCPConfig(yaml, tools, mcpTools, workflowData)
 }
 
-func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string, safeOutputsInputEnvVars map[string]string) {
-	if len(mcpEnvVars) == 0 && len(safeOutputsInputEnvVars) == 0 {
+func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string, safeOutputsInputEnvVars map[string]string, gatewayEnvVars map[string]string) {
+	if len(mcpEnvVars) == 0 && len(safeOutputsInputEnvVars) == 0 && len(gatewayEnvVars) == 0 {
 		return
 	}
 	yaml.WriteString("        env:\n")
+	customEnvVarNames := sliceutil.SortedKeys(gatewayEnvVars)
+	transportEnvVarNames := make(map[string]struct{}, len(customEnvVarNames))
+	for i := range customEnvVarNames {
+		transportEnvVarNames[mcpGatewayCustomEnvTransportName(i)] = struct{}{}
+	}
 	// Write MCP env vars first (sorted)
 	envVarNames := sliceutil.MapKeys(mcpEnvVars)
 	sort.Strings(envVarNames)
 	for _, envVarName := range envVarNames {
+		if _, overridden := gatewayEnvVars[envVarName]; overridden {
+			continue
+		}
+		if _, reserved := transportEnvVarNames[envVarName]; reserved {
+			continue
+		}
 		fmt.Fprintf(yaml, "          %s: %s\n", envVarName, mcpEnvVars[envVarName])
 	}
 	// Write safe-outputs input env vars (sorted); these must also be present in the
 	// runner step environment so the docker -e flag can forward them to the container.
 	inputVarNames := sliceutil.SortedKeys(safeOutputsInputEnvVars)
 	for _, envVarName := range inputVarNames {
+		if _, overridden := gatewayEnvVars[envVarName]; overridden {
+			continue
+		}
+		if _, reserved := transportEnvVarNames[envVarName]; reserved {
+			continue
+		}
 		fmt.Fprintf(yaml, "          %s: %s\n", envVarName, safeOutputsInputEnvVars[envVarName])
 	}
+	// Use compiler-controlled transport names so special environment variables such
+	// as BASH_ENV cannot affect the host shell before the run script starts.
+	if len(customEnvVarNames) > 0 {
+		customEnvNamesJSON, err := json.Marshal(customEnvVarNames)
+		if err != nil {
+			panic(fmt.Sprintf("BUG: failed to marshal MCP gateway environment variable names: %v", err))
+		}
+		yaml.WriteString(formatYAMLEnv("          ", mcpGatewayCustomEnvNamesVar, string(customEnvNamesJSON)))
+		for i, envVarName := range customEnvVarNames {
+			yaml.WriteString(formatYAMLEnv("          ", mcpGatewayCustomEnvTransportName(i), gatewayEnvVars[envVarName]))
+		}
+	}
+}
+
+func mcpGatewayCustomEnvTransportName(index int) string {
+	return fmt.Sprintf("GH_AW_MCP_GATEWAY_ENV_%d", index)
 }
 
 func resolveMCPGatewayValues(workflowData *WorkflowData, gatewayConfig *MCPGatewayRuntimeConfig) (int, string, string, string, int) {
@@ -209,13 +245,6 @@ func writeMCPGatewayExports(yaml *strings.Builder, opts writeMCPGatewayExportsOp
 	}
 	if hasGitHub && getGitHubType(githubTool) == GitHubMCPModeRemote && engine.GetID() == "copilot" {
 		yaml.WriteString("          export GITHUB_PERSONAL_ACCESS_TOKEN=\"$GITHUB_MCP_SERVER_TOKEN\"\n")
-	}
-	if len(gatewayConfig.Env) > 0 {
-		envVarNames := sliceutil.MapKeys(gatewayConfig.Env)
-		sort.Strings(envVarNames)
-		for _, envVarName := range envVarNames {
-			fmt.Fprintf(yaml, "          export %s=%s\n", envVarName, gatewayConfig.Env[envVarName])
-		}
 	}
 }
 
@@ -402,11 +431,7 @@ func appendMCPGatewaySafeOutputsInputEnvFlags(containerCmd *strings.Builder, saf
 
 func appendMCPGatewayCustomAndHTTPEnvFlags(containerCmd *strings.Builder, workflowData *WorkflowData, gatewayConfig *MCPGatewayRuntimeConfig, mcpEnvVars map[string]string, hasGitHub bool, githubTool map[string]any, tools map[string]any, engine CodingAgentEngine) {
 	if len(gatewayConfig.Env) > 0 {
-		envVarNames := sliceutil.MapKeys(gatewayConfig.Env)
-		sort.Strings(envVarNames)
-		for _, envVarName := range envVarNames {
-			containerCmd.WriteString(" -e " + envVarName)
-		}
+		containerCmd.WriteString(" " + mcpGatewayCustomEnvMarker)
 	}
 	if len(mcpEnvVars) == 0 {
 		return

--- a/pkg/workflow/mcp_setup_gateway.go
+++ b/pkg/workflow/mcp_setup_gateway.go
@@ -15,6 +15,7 @@ import (
 )
 
 const mcpGatewayCustomEnvNamesVar = "GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES"
+const mcpGatewayCustomEnvTransportPrefix = "GH_AW_MCP_GATEWAY_ENV_"
 const mcpGatewayCustomEnvMarker = "__GH_AW_MCP_GATEWAY_CUSTOM_ENV__"
 
 func generateMCPGatewaySetup(yaml *strings.Builder, tools map[string]any, mcpTools []string, engine CodingAgentEngine, workflowData *WorkflowData, hasAgenticWorkflows bool, safeOutputsInputEnvVars map[string]string) error {
@@ -88,11 +89,6 @@ func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string,
 	}
 	yaml.WriteString("        env:\n")
 	customEnvVarNames := sliceutil.SortedKeys(gatewayEnvVars)
-	transportEnvVarNames := make(map[string]struct{}, len(customEnvVarNames)+1)
-	transportEnvVarNames[mcpGatewayCustomEnvNamesVar] = struct{}{}
-	for i := range customEnvVarNames {
-		transportEnvVarNames[mcpGatewayCustomEnvTransportName(i)] = struct{}{}
-	}
 	// Write MCP env vars first (sorted)
 	envVarNames := sliceutil.MapKeys(mcpEnvVars)
 	sort.Strings(envVarNames)
@@ -100,7 +96,7 @@ func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string,
 		if _, overridden := gatewayEnvVars[envVarName]; overridden {
 			continue
 		}
-		if _, reserved := transportEnvVarNames[envVarName]; reserved {
+		if isReservedMCPGatewayTransportEnvVar(envVarName) {
 			continue
 		}
 		fmt.Fprintf(yaml, "          %s: %s\n", envVarName, mcpEnvVars[envVarName])
@@ -112,7 +108,7 @@ func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string,
 		if _, overridden := gatewayEnvVars[envVarName]; overridden {
 			continue
 		}
-		if _, reserved := transportEnvVarNames[envVarName]; reserved {
+		if isReservedMCPGatewayTransportEnvVar(envVarName) {
 			continue
 		}
 		fmt.Fprintf(yaml, "          %s: %s\n", envVarName, safeOutputsInputEnvVars[envVarName])
@@ -132,7 +128,13 @@ func writeMCPGatewayStepEnv(yaml *strings.Builder, mcpEnvVars map[string]string,
 }
 
 func mcpGatewayCustomEnvTransportName(index int) string {
-	return fmt.Sprintf("GH_AW_MCP_GATEWAY_ENV_%d", index)
+	return fmt.Sprintf("%s%d", mcpGatewayCustomEnvTransportPrefix, index)
+}
+
+func isReservedMCPGatewayTransportEnvVar(name string) bool {
+	// GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES is reserved alongside, not within,
+	// the indexed GH_AW_MCP_GATEWAY_ENV_* transport namespace.
+	return name == mcpGatewayCustomEnvNamesVar || strings.HasPrefix(name, mcpGatewayCustomEnvTransportPrefix)
 }
 
 func resolveMCPGatewayValues(workflowData *WorkflowData, gatewayConfig *MCPGatewayRuntimeConfig) (int, string, string, string, int) {

--- a/pkg/workflow/sandbox_validation.go
+++ b/pkg/workflow/sandbox_validation.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/github/gh-aw/pkg/constants"
 	"github.com/github/gh-aw/pkg/logger"
+	"github.com/github/gh-aw/pkg/sliceutil"
 )
 
 var sandboxValidationLog = logger.New("workflow:sandbox_validation")
@@ -27,6 +28,7 @@ var sandboxValidationLog = logger.New("workflow:sandbox_validation")
 const minSandboxDisableJustificationLength = 20
 
 var githubActionsExpressionPattern = regexp.MustCompile(`\$\{\{[\s\S]*\}\}`)
+var mcpGatewayEnvNamePattern = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 
 // validateMountsSyntax validates that mount strings follow the correct syntax
 // Expected format: "source:destination:mode" where mode is either "ro" or "rw"
@@ -199,6 +201,19 @@ func validateSandboxConfig(workflowData *WorkflowData) error {
 			return err
 		}
 		sandboxValidationLog.Printf("Validated MCP gateway port: %d", sandboxConfig.MCP.Port)
+	}
+
+	if sandboxConfig.MCP != nil {
+		for _, name := range sliceutil.SortedKeys(sandboxConfig.MCP.Env) {
+			if !mcpGatewayEnvNamePattern.MatchString(name) {
+				return NewValidationError(
+					"sandbox.mcp.env."+name,
+					name,
+					fmt.Sprintf("environment variable names should match %s", mcpGatewayEnvNamePattern),
+					"Use uppercase letters, digits, and underscores, starting with a letter or underscore. Example:\n\nsandbox:\n  mcp:\n    env:\n      API_TOKEN: value",
+				)
+			}
+		}
 	}
 
 	// Validate that if agent sandbox is enabled, MCP gateway is always enabled.

--- a/pkg/workflow/sandbox_validation.go
+++ b/pkg/workflow/sandbox_validation.go
@@ -205,6 +205,14 @@ func validateSandboxConfig(workflowData *WorkflowData) error {
 
 	if sandboxConfig.MCP != nil {
 		for _, name := range sliceutil.SortedKeys(sandboxConfig.MCP.Env) {
+			if isReservedMCPGatewayTransportEnvVar(name) {
+				return NewValidationError(
+					"sandbox.mcp.env."+name,
+					name,
+					"environment variable names in the GH_AW_MCP_GATEWAY_ namespace are reserved for internal transport",
+					"Choose a different name that does not start with GH_AW_MCP_GATEWAY_. Example:\n\nsandbox:\n  mcp:\n    env:\n      API_TOKEN: value",
+				)
+			}
 			if !mcpGatewayEnvNamePattern.MatchString(name) {
 				return NewValidationError(
 					"sandbox.mcp.env."+name,

--- a/pkg/workflow/sandbox_validation_test.go
+++ b/pkg/workflow/sandbox_validation_test.go
@@ -225,6 +225,24 @@ func TestValidateSandboxConfigMCPEnvironmentVariableNames(t *testing.T) {
 		assert.Contains(t, err.Error(), "^[A-Z_][A-Z0-9_]*$")
 		assert.Contains(t, err.Error(), "API_TOKEN")
 	})
+
+	t.Run("reserved transport names fail validation", func(t *testing.T) {
+		workflowData := &WorkflowData{
+			SandboxConfig: &SandboxConfig{
+				MCP: &MCPGatewayRuntimeConfig{
+					Env: map[string]string{
+						"GH_AW_MCP_GATEWAY_ENV_0": "value",
+					},
+				},
+			},
+		}
+
+		err := validateSandboxConfig(workflowData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sandbox.mcp.env.GH_AW_MCP_GATEWAY_ENV_0")
+		assert.Contains(t, err.Error(), "reserved for internal transport")
+		assert.Contains(t, err.Error(), "GH_AW_MCP_GATEWAY_")
+	})
 }
 
 // TestValidateSandboxConfigStoresJustification tests that a valid justification is

--- a/pkg/workflow/sandbox_validation_test.go
+++ b/pkg/workflow/sandbox_validation_test.go
@@ -192,6 +192,41 @@ func TestValidateSandboxConfigTrustBoundaryMessage(t *testing.T) {
 	assert.Contains(t, errMsg, "dangerously-disable-sandbox-agent", "diagnostic must name the required feature flag")
 }
 
+func TestValidateSandboxConfigMCPEnvironmentVariableNames(t *testing.T) {
+	t.Run("valid names pass validation", func(t *testing.T) {
+		workflowData := &WorkflowData{
+			SandboxConfig: &SandboxConfig{
+				MCP: &MCPGatewayRuntimeConfig{
+					Env: map[string]string{
+						"API_TOKEN": "value",
+						"_DEBUG":    "true",
+					},
+				},
+			},
+		}
+
+		require.NoError(t, validateSandboxConfig(workflowData))
+	})
+
+	t.Run("invalid names fail validation", func(t *testing.T) {
+		workflowData := &WorkflowData{
+			SandboxConfig: &SandboxConfig{
+				MCP: &MCPGatewayRuntimeConfig{
+					Env: map[string]string{
+						"BAD-NAME": "value",
+					},
+				},
+			},
+		}
+
+		err := validateSandboxConfig(workflowData)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sandbox.mcp.env.BAD-NAME")
+		assert.Contains(t, err.Error(), "^[A-Z_][A-Z0-9_]*$")
+		assert.Contains(t, err.Error(), "API_TOKEN")
+	})
+}
+
 // TestValidateSandboxConfigStoresJustification tests that a valid justification is
 // stored in AgentSandboxConfig.DisableReason for downstream diagnostics and audit.
 func TestValidateSandboxConfigStoresJustification(t *testing.T) {


### PR DESCRIPTION
### Overview

Fixes a security vulnerability (**GHSA-j77w-g4jj-hp99**) in the MCP gateway's handling of `sandbox.mcp.env` custom environment variables. Previously, user-supplied values were interpolated directly into the generated GitHub Actions shell script (`export NAME=VALUE`) and into the serialized Docker command string (`-e NAME` flags forwarded from the shell environment). Both paths were exploitable: shell metacharacters (`;`, backticks, newlines) in a value could inject arbitrary commands into the runner shell before the gateway process started, and a value assigned to `BASH_ENV` would be sourced by Bash on the host before the run script even executed.

### Security fix

Custom env values are now routed through compiler-controlled, indexed **transport variables** instead of being embedded in shell code or the Docker command string:

- The Go compiler writes each `sandbox.mcp.env` value under `GH_AW_MCP_GATEWAY_ENV_0`, `GH_AW_MCP_GATEWAY_ENV_1`, ... in the step's YAML `env:` block (safe, non-shell-interpolated) plus a manifest variable `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES` (JSON array of the original names).
- A marker token `__GH_AW_MCP_GATEWAY_CUSTOM_ENV__` is placed in the serialized Docker command string instead of literal `-e NAME` flags.
- At runtime, `start_mcp_gateway.cjs` replaces the marker with atomic `-e NAME=VALUE` Docker arguments built directly from `process.env`, so values never pass through shell parsing or string splitting.
- Environment variable names are validated against `^[A-Z_][A-Z0-9_]*$` both at compile time (Go, `pkg/workflow/sandbox_validation.go`) and at runtime (JS, `start_mcp_gateway.cjs`).
- Names in the `GH_AW_MCP_GATEWAY_` namespace (including `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES`) are reserved for internal transport and rejected during validation to prevent collisions/spoofing.

### Key changes

<details>
<summary>Runtime launcher — <code>actions/setup/js/start_mcp_gateway.cjs</code></summary>

- Added `injectCustomGatewayEnvArgs(args, env)`: finds the `__GH_AW_MCP_GATEWAY_CUSTOM_ENV__` marker in the split Docker args, parses `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES`, validates names, and replaces the marker with atomic `-e NAME=VALUE` pairs sourced from indexed `GH_AW_MCP_GATEWAY_ENV_N` variables. Missing indexed values become empty strings (deterministic name→slot mapping).
- Invoked right after the Docker command string is split into args in `main()`.
- Exported for testing.

</details>

<details>
<summary>Compiler — <code>pkg/workflow/mcp_setup_gateway.go</code></summary>

- Added constants `mcpGatewayCustomEnvNamesVar`, `mcpGatewayCustomEnvTransportPrefix`, `mcpGatewayCustomEnvMarker`.
- `writeMCPGatewayStepEnv` now takes `gatewayEnvVars` and writes them as sorted, indexed `GH_AW_MCP_GATEWAY_ENV_N` step-env entries plus the `GH_AW_MCP_GATEWAY_CUSTOM_ENV_NAMES` JSON manifest, skipping any other var name that collides with the reserved namespace.
- Removed the old `export NAME=VALUE` emission from `writeMCPGatewayExports` (custom values no longer touch the run script).
- `appendMCPGatewayCustomAndHTTPEnvFlags` now emits the `__GH_AW_MCP_GATEWAY_CUSTOM_ENV__` marker instead of literal `-e NAME` flags in the Docker command string.
- Added `isReservedMCPGatewayTransportEnvVar` helper.

</details>

<details>
<summary>Validation — <code>pkg/workflow/sandbox_validation.go</code></summary>

- Added `mcpGatewayEnvNamePattern` (`^[A-Z_][A-Z0-9_]*$`) and validation in `validateSandboxConfig` that rejects `sandbox.mcp.env` names that are malformed or fall in the reserved `GH_AW_MCP_GATEWAY_` transport namespace, with actionable error messages/examples.

</details>

<details>
<summary>Docs — <code>docs/adr/50924-secure-mcp-gateway-env-injection.md</code></summary>

- New ADR documenting the vulnerability, the compiler-controlled transport-variable decision, two rejected alternatives (shell-escaping values; quoting values in the Docker command string), and consequences (positive/negative/neutral).

</details>

### Testing

- `actions/setup/js/start_mcp_gateway.test.cjs`: new tests for `injectCustomGatewayEnvArgs` covering hostile values (Docker flag/shell injection attempts), multi-value index mapping with empty values, missing transport metadata, commands without the marker, malformed JSON, and invalid names.
- `pkg/workflow/mcp_gateway_env_security_test.go` (new, `!integration`): verifies custom env values never appear as literal `export` statements, step-env keys, or in the run script; verifies overriding of generated step env, `BASH_ENV` and GitHub-expression values are treated as opaque data, reserved-name collision handling, and the marker/transport-variable contract with the JS launcher.
- `pkg/workflow/mcp_gateway_env_security_integration_test.go` (new, `integration` build tag): compiles real workflow markdown and asserts the generated lock file's "Start MCP Gateway" step contains the transport variables (not literal exports) and that a shared-MCP-config name collision with reserved transport names does not leak or duplicate metadata.
- `pkg/workflow/sandbox_validation_test.go`: new cases for valid/invalid/reserved `sandbox.mcp.env` names.

**References:**> Generated by [PR Description Updater](https://github.com/github/gh-aw/actions/runs/31135698663) for #50924 · auto · 96.7 AIC · ⊞ 6.8K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-description-caveman%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Description Updater, engine: copilot, model: auto, id: 31135698663, workflow_id: pr-description-caveman, run: https://github.com/github/gh-aw/actions/runs/31135698663 -->