### PR TITLE
fix: remove stale CGO job dependencies

### DIFF
--- a/.github/workflows/cgo.yml
+++ b/.github/workflows/cgo.yml
@@ -2520,9 +2520,6 @@ jobs:
     - canary-go
     - build
     - build-wasm
-    - zizmor
-    - poutine
-    - actionlint
     - bench
     - check-validator-sizes
     - lint-go


### PR DESCRIPTION
## Summary
- remove `zizmor`, `poutine`, and `actionlint` from `notify-failure.needs`
- restore valid CGO workflow job references after those jobs were removed

## Validation
- `actionlint -shellcheck= .github/workflows/cgo.yml`
- `make agent-report-progress`