### PR TITLE
Regularize conclusion no-op summaries

### DIFF
--- a/actions/setup/js/conclusion_summary.cjs
+++ b/actions/setup/js/conclusion_summary.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+
+const { redactStepSummaryContent } = require("./redact_secrets.cjs");
+
+/**
+ * Render no-op messages using the same regular, collapsible structure as the
+ * safe-output processing summary.
+ *
+ * @param {Array<string>} messages
+ * @param {{runUrl?: string, staged?: boolean}} [options]
+ * @returns {string}
+ */
+function buildNoopConclusionSummary(messages, options = {}) {
+  const { runUrl, staged = false } = options;
+  const emoji = staged ? "⚠️" : "✅";
+  const label = staged ? "Staged No-Op Preview" : "Conclusion Summary";
+  const count = messages.length;
+  const target = typeof runUrl === "string" && /^https?:\/\//.test(runUrl) ? `**Target:** [Workflow run](${runUrl})\n\n` : "";
+
+  let summary = `<details>\n<summary>${emoji} ${label} (${count} no-op message${count === 1 ? "" : "s"})</summary>\n\n`;
+  summary += staged ? "The following messages would be logged if staged mode was disabled:\n\n" : "The following messages were logged for transparency:\n\n";
+  summary += target;
+
+  for (let index = 0; index < messages.length; index++) {
+    summary += `<details>\n<summary>${emoji} No-Op - ${staged ? "Preview" : "Success"} (Message ${index + 1})</summary>\n\n`;
+    summary += `### No-Op\n\n${messages[index]}\n\n`;
+    summary += `</details>\n\n`;
+  }
+
+  summary += `</details>\n\n`;
+  return redactStepSummaryContent(summary);
+}
+
+module.exports = { buildNoopConclusionSummary };

--- a/actions/setup/js/conclusion_summary.test.cjs
+++ b/actions/setup/js/conclusion_summary.test.cjs
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+const { buildNoopConclusionSummary } = await import("./conclusion_summary.cjs");
+
+describe("conclusion_summary", () => {
+  it("renders regular no-op entries inside a linked conclusion summary", () => {
+    const summary = buildNoopConclusionSummary(["No changes were needed.", "Repository is already current."], {
+      runUrl: "https://github.com/owner/repo/actions/runs/123",
+    });
+
+    expect(summary).toContain("<summary>✅ Conclusion Summary (2 no-op messages)</summary>");
+    expect(summary).toContain("**Target:** [Workflow run](https://github.com/owner/repo/actions/runs/123)");
+    expect(summary).toContain("<summary>✅ No-Op - Success (Message 1)</summary>");
+    expect(summary).toContain("<summary>✅ No-Op - Success (Message 2)</summary>");
+    expect(summary).toContain("No changes were needed.");
+  });
+
+  it("renders staged no-op messages as a preview", () => {
+    const summary = buildNoopConclusionSummary(["No action needed."], { staged: true });
+
+    expect(summary).toContain("<summary>⚠️ Staged No-Op Preview (1 no-op message)</summary>");
+    expect(summary).toContain("<summary>⚠️ No-Op - Preview (Message 1)</summary>");
+  });
+
+  it("does not link non-http run targets", () => {
+    const summary = buildNoopConclusionSummary(["No action needed."], { runUrl: "javascript:alert(1)" });
+
+    expect(summary).not.toContain("javascript:");
+    expect(summary).not.toContain("**Target:**");
+  });
+});

--- a/actions/setup/js/handle_noop_message.cjs
+++ b/actions/setup/js/handle_noop_message.cjs
@@ -12,6 +12,7 @@ const { isStagedMode } = require("./safe_output_helpers.cjs");
 const { generateHistoryUrl } = require("./generate_history_link.cjs");
 const { formatAIC } = require("./model_costs.cjs");
 const { reduceModelNameToIdentifier } = require("./model_aliases.cjs");
+const { buildNoopConclusionSummary } = require("./conclusion_summary.cjs");
 /**
  * Search for or create the parent issue for all agentic workflow no-op runs
  * @returns {Promise<{number: number, node_id: string}>} Parent issue number and node ID
@@ -185,27 +186,23 @@ async function main() {
 
     // --- Staged mode: preview only, do not post ---
     if (isStagedMode()) {
-      let summaryContent = "## 🎭 Staged Mode: No-Op Messages Preview\n\n";
-      summaryContent += "The following messages would be logged if staged mode was disabled:\n\n";
-      for (let i = 0; i < noopItems.length; i++) {
-        const item = noopItems[i];
-        summaryContent += `### Message ${i + 1}\n`;
-        summaryContent += `${item.message}\n\n`;
-        summaryContent += "---\n\n";
-      }
+      const summaryContent = buildNoopConclusionSummary(
+        noopItems.map(item => item.message),
+        { runUrl: process.env.GH_AW_RUN_URL, staged: true }
+      );
       await core.summary.addRaw(summaryContent).write();
       core.info("📝 No-op message preview written to step summary");
       return;
     }
 
     // --- Write step summary ---
-    let summaryContent = "\n\n## No-Op Messages\n\n";
-    summaryContent += "The following messages were logged for transparency:\n\n";
-    for (let i = 0; i < noopItems.length; i++) {
-      const item = noopItems[i];
-      core.info(`No-op message ${i + 1}: ${item.message}`);
-      summaryContent += `- ${item.message}\n`;
+    for (let index = 0; index < noopItems.length; index++) {
+      core.info(`No-op message ${index + 1}: ${noopItems[index].message}`);
     }
+    const summaryContent = buildNoopConclusionSummary(
+      noopItems.map(item => item.message),
+      { runUrl: process.env.GH_AW_RUN_URL }
+    );
     await core.summary.addRaw(summaryContent).write();
 
     // Export for downstream steps/jobs

--- a/actions/setup/js/handle_noop_message.test.cjs
+++ b/actions/setup/js/handle_noop_message.test.cjs
@@ -197,6 +197,9 @@ safe-outputs:
     const { main } = await import("./handle_noop_message.cjs?t=" + Date.now());
     await main();
 
+    const summary = mockCore.summary.addRaw.mock.calls[0][0];
+    expect(summary).toContain("<summary>✅ Conclusion Summary (1 no-op message)</summary>");
+    expect(summary).toContain("**Target:** [Workflow run](https://github.com/test-owner/test-repo/actions/runs/123)");
     expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining("report-as-issue is disabled"));
     expect(mockGithub.rest.search.issuesAndPullRequests).not.toHaveBeenCalled();
   });

--- a/actions/setup/js/notify_comment_error.cjs
+++ b/actions/setup/js/notify_comment_error.cjs
@@ -14,6 +14,7 @@ const { ERR_VALIDATION } = require("./error_codes.cjs");
 const { parseBoolTemplatable } = require("./templatable.cjs");
 const { resolveTopLevelDiscussionCommentId } = require("./github_api_helpers.cjs");
 const { assembleMarkdownBodyParts } = require("./markdown_body_helpers.cjs");
+const { buildNoopConclusionSummary } = require("./conclusion_summary.cjs");
 
 /**
  * Collect generated asset URLs from safe output jobs
@@ -158,16 +159,7 @@ async function main() {
   // If it's disabled, and there's no comment to update but we have noop messages, write to step summary.
   if (!appendOnlyComments && !commentId && noopMessages.length > 0) {
     core.info("No comment ID found, writing noop messages to step summary");
-
-    let summaryContent = "## No-Op Messages\n\n";
-    summaryContent += "The following messages were logged for transparency:\n\n";
-
-    if (noopMessages.length === 1) {
-      summaryContent += noopMessages[0];
-    } else {
-      summaryContent += noopMessages.map((msg, idx) => `${idx + 1}. ${msg}`).join("\n");
-    }
-
+    const summaryContent = buildNoopConclusionSummary(noopMessages, { runUrl });
     await core.summary.addRaw(summaryContent).write();
     core.info(`Successfully wrote ${noopMessages.length} noop message(s) to step summary`);
     return;

--- a/actions/setup/js/notify_comment_error.test.cjs
+++ b/actions/setup/js/notify_comment_error.test.cjs
@@ -56,6 +56,7 @@ const mockCore = {
           GH_AW_SAFE_OUTPUT_MESSAGES: process.env.GH_AW_SAFE_OUTPUT_MESSAGES,
           GH_AW_SAFE_OUTPUT_JOBS: process.env.GH_AW_SAFE_OUTPUT_JOBS,
           GH_AW_SAFE_OUTPUTS_RESULT: process.env.GH_AW_SAFE_OUTPUTS_RESULT,
+          GH_AW_AGENT_OUTPUT: process.env.GH_AW_AGENT_OUTPUT,
           GH_AW_OUTPUT_CREATE_ISSUE_ISSUE_URL: process.env.GH_AW_OUTPUT_CREATE_ISSUE_ISSUE_URL,
           GH_AW_OUTPUT_ADD_COMMENT_COMMENT_URL: process.env.GH_AW_OUTPUT_ADD_COMMENT_COMMENT_URL,
           GH_AW_OUTPUT_CREATE_PULL_REQUEST_PULL_REQUEST_URL: process.env.GH_AW_OUTPUT_CREATE_PULL_REQUEST_PULL_REQUEST_URL,
@@ -69,6 +70,27 @@ const mockCore = {
         });
       }),
       describe("when comment ID is not provided", () => {
+        it("should write a regular linked conclusion summary for noop messages", async () => {
+          const tempDir = fs.mkdtempSync("/tmp/gh-aw-conclusion-summary-");
+          const outputPath = path.join(tempDir, "agent-output.json");
+          fs.writeFileSync(outputPath, JSON.stringify({ items: [{ type: "noop", message: "No changes were needed." }] }));
+          try {
+            delete process.env.GH_AW_COMMENT_ID;
+            process.env.GH_AW_AGENT_OUTPUT = outputPath;
+            process.env.GH_AW_RUN_URL = "https://github.com/owner/repo/actions/runs/123";
+            process.env.GH_AW_WORKFLOW_NAME = "test-workflow";
+            process.env.GH_AW_AGENT_CONCLUSION = "success";
+
+            await eval(`(async () => { ${notifyCommentScript}; await main(); })()`);
+
+            const summary = mockCore.summary.addRaw.mock.calls[0][0];
+            expect(summary).toContain("<summary>✅ Conclusion Summary (1 no-op message)</summary>");
+            expect(summary).toContain("**Target:** [Workflow run](https://github.com/owner/repo/actions/runs/123)");
+          } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+          }
+        });
+
         it("should skip comment update", async () => {
           (delete process.env.GH_AW_COMMENT_ID,
             (process.env.GH_AW_RUN_URL = "https://github.com/owner/repo/actions/runs/123"),


### PR DESCRIPTION
Extends #51478's fix for #51477 to the summary emitted by the `conclusion` job for delegated `noop` safe outputs.

### Changes
- render conclusion no-op output as a collapsible summary with regular per-message entries
- link the summary to the workflow run when an HTTP(S) run URL is available
- share the formatter between the normal no-op handler and the status-comment fallback
- redact credential-shaped content before writing the step summary

### Validation
- `GH_AW_PROMPTS_DIR="$PWD/../md" npx vitest run --no-file-parallelism conclusion_summary.test.cjs handle_noop_message.test.cjs notify_comment_error.test.cjs` (59 tests passed)
- `make fmt-cjs && make lint-cjs` (passed)
- `make agent-report-progress` passed formatting, build, schema freshness, lint, and Go checks; setup JavaScript tests remain blocked by 11 pre-existing TypeScript errors in unrelated files