### PR TITLE
fix(setup): validate plural gateway agent IDs

### DIFF
--- a/actions/setup/js/start_mcp_gateway.cjs
+++ b/actions/setup/js/start_mcp_gateway.cjs
@@ -650,6 +650,27 @@ function detectEngineType(configDir, env = process.env, existsSync = fs.existsSy
   return "unknown";
 }
 
+/**
+ * Validates the mutually exclusive gateway agent identifier forms.
+ *
+ * @param {Record<string, unknown>} gateway
+ * @returns {string | null}
+ */
+function validateGatewayAgentIdentifiers(gateway) {
+  const hasAgentId = Object.prototype.hasOwnProperty.call(gateway, "agentId");
+  const hasAgentIds = Object.prototype.hasOwnProperty.call(gateway, "agentIds");
+
+  if (hasAgentId === hasAgentIds) {
+    return "ERROR: Gateway configuration must specify exactly one of 'agentId' or 'agentIds'";
+  }
+  if (hasAgentId) {
+    return typeof gateway.agentId === "string" && gateway.agentId.length > 0 ? null : "ERROR: Gateway 'agentId' must be a non-empty string";
+  }
+  return Array.isArray(gateway.agentIds) && gateway.agentIds.length > 0 && gateway.agentIds.every(agentId => typeof agentId === "string" && agentId.length > 0)
+    ? null
+    : "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings";
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -821,8 +842,9 @@ async function main() {
     core.setFailed("ERROR: Gateway configuration is missing required 'domain' field");
     return;
   }
-  if (!("agentId" in gw) || gw.agentId == null) {
-    core.setFailed("ERROR: Gateway configuration is missing required 'agentId' field");
+  const agentIdentifierError = validateGatewayAgentIdentifiers(gw);
+  if (agentIdentifierError) {
+    core.setFailed(agentIdentifierError);
     return;
   }
 
@@ -1379,5 +1401,6 @@ module.exports = {
   normalizeSinkVisibilityEncoding,
   redactGatewayDiagnostics,
   resolveCopilotConfigPaths,
+  validateGatewayAgentIdentifiers,
   writeGatewayStartupMarker,
 };

--- a/actions/setup/js/start_mcp_gateway.test.cjs
+++ b/actions/setup/js/start_mcp_gateway.test.cjs
@@ -27,6 +27,7 @@ import {
   resolveGatewayHealthRetryConfig,
   normalizeSinkVisibilityEncoding,
   resolveCopilotConfigPaths,
+  validateGatewayAgentIdentifiers,
 } from "./start_mcp_gateway.cjs";
 
 describe("start_mcp_gateway logging", () => {
@@ -491,5 +492,26 @@ describe("start_mcp_gateway extractOptionalServerNames", () => {
   it("returns an empty list when no servers are configured", () => {
     expect(extractOptionalServerNames({})).toEqual([]);
     expect(extractOptionalServerNames({ mcpServers: null })).toEqual([]);
+  });
+});
+
+describe("start_mcp_gateway gateway agent identifier validation", () => {
+  it.each([
+    ["accepts a singular agent ID", { agentId: "agent-1" }, null],
+    ["accepts one plural agent ID", { agentIds: ["agent-1"] }, null],
+    ["accepts multiple plural agent IDs", { agentIds: ["agent-1", "agent-2"] }, null],
+    ["rejects an empty plural agent ID list", { agentIds: [] }, "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"],
+    ["rejects a non-array plural agent ID", { agentIds: "agent-1" }, "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"],
+    ["rejects an empty ID in the plural list", { agentIds: ["agent-1", ""] }, "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"],
+    ["rejects a non-string ID in the plural list", { agentIds: ["agent-1", 2] }, "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"],
+    ["rejects both identifier forms", { agentId: "agent-1", agentIds: ["agent-1"] }, "ERROR: Gateway configuration must specify exactly one of 'agentId' or 'agentIds'"],
+    ["rejects neither identifier form", {}, "ERROR: Gateway configuration must specify exactly one of 'agentId' or 'agentIds'"],
+  ])("%s", (_name, gateway, expectedError) => {
+    expect(validateGatewayAgentIdentifiers(gateway)).toBe(expectedError);
+  });
+
+  it("rejects an empty or malformed singular agent ID", () => {
+    expect(validateGatewayAgentIdentifiers({ agentId: "" })).toBe("ERROR: Gateway 'agentId' must be a non-empty string");
+    expect(validateGatewayAgentIdentifiers({ agentId: ["agent-1"] })).toBe("ERROR: Gateway 'agentId' must be a non-empty string");
   });
 });

--- a/actions/setup/sh/start_mcp_gateway.sh
+++ b/actions/setup/sh/start_mcp_gateway.sh
@@ -159,8 +159,23 @@ if ! echo "$MCP_CONFIG" | jq -e '.gateway.domain' >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! echo "$MCP_CONFIG" | jq -e '.gateway.agentId' >/dev/null 2>&1; then
-  echo "ERROR: Gateway configuration is missing required 'agentId' field"
+AGENT_IDENTIFIER_ERROR=$(echo "$MCP_CONFIG" | jq -r '
+  if ((.gateway | has("agentId")) == (.gateway | has("agentIds"))) then
+    "ERROR: Gateway configuration must specify exactly one of '\''agentId'\'' or '\''agentIds'\''"
+  elif (.gateway | has("agentId")) then
+    if (.gateway.agentId | type == "string" and length > 0) then
+      ""
+    else
+      "ERROR: Gateway '\''agentId'\'' must be a non-empty string"
+    end
+  elif (.gateway.agentIds | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) then
+    ""
+  else
+    "ERROR: Gateway '\''agentIds'\'' must be a non-empty array of non-empty strings"
+  end
+')
+if [ -n "$AGENT_IDENTIFIER_ERROR" ]; then
+  echo "$AGENT_IDENTIFIER_ERROR"
   exit 1
 fi
 

--- a/actions/setup/sh/start_mcp_gateway_test.sh
+++ b/actions/setup/sh/start_mcp_gateway_test.sh
@@ -349,6 +349,54 @@ EOF
   rm -rf "$tmpdir" /tmp/gh-aw/mcp-config /tmp/gh-aw/mcp-gateway-started
 }
 
+test_gateway_agent_identifier_validation() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local fake_bin="$tmpdir/bin"
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/docker" << 'EOF'
+#!/usr/bin/env bash
+exit 42
+EOF
+  chmod +x "$fake_bin/docker"
+
+  assert_agent_identifier_config() {
+    local test_name="$1"
+    local gateway_config="$2"
+    local expected_message="$3"
+    local output
+    set +e
+    output=$(printf '%s\n' "{\"mcpServers\":{},\"gateway\":{\"port\":8080,\"domain\":\"localhost\",${gateway_config}}}" | \
+      PATH="$fake_bin:$PATH" \
+      MCP_GATEWAY_PORT="8080" \
+      MCP_GATEWAY_DOMAIN="localhost" \
+      MCP_GATEWAY_AGENT_ID="test-key" \
+      MCP_GATEWAY_DOCKER_COMMAND="docker run -i --rm --network host test-image" \
+      bash "$SCRIPT_PATH" 2>&1)
+    set -e
+
+    if grep -Fq "$expected_message" <<< "$output"; then
+      print_result "$test_name" "PASS"
+    else
+      print_result "$test_name" "FAIL"
+    fi
+  }
+
+  assert_agent_identifier_config "Accepts a singular agent ID" '"agentId":"agent-1"' "Configuration validated successfully"
+  assert_agent_identifier_config "Accepts one plural agent ID" '"agentIds":["agent-1"]' "Configuration validated successfully"
+  assert_agent_identifier_config "Accepts multiple plural agent IDs" '"agentIds":["agent-1","agent-2"]' "Configuration validated successfully"
+  assert_agent_identifier_config "Rejects an empty plural agent ID list" '"agentIds":[]' "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"
+  assert_agent_identifier_config "Rejects a non-array plural agent ID" '"agentIds":"agent-1"' "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"
+  assert_agent_identifier_config "Rejects an empty ID in the plural list" '"agentIds":["agent-1",""]' "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"
+  assert_agent_identifier_config "Rejects a non-string ID in the plural list" '"agentIds":["agent-1",2]' "ERROR: Gateway 'agentIds' must be a non-empty array of non-empty strings"
+  assert_agent_identifier_config "Rejects both identifier forms" '"agentId":"agent-1","agentIds":["agent-1"]' "ERROR: Gateway configuration must specify exactly one of 'agentId' or 'agentIds'"
+  assert_agent_identifier_config "Rejects neither identifier form" '"other":"value"' "ERROR: Gateway configuration must specify exactly one of 'agentId' or 'agentIds'"
+  assert_agent_identifier_config "Rejects an empty singular agent ID" '"agentId":""' "ERROR: Gateway 'agentId' must be a non-empty string"
+  assert_agent_identifier_config "Rejects a malformed singular agent ID" '"agentId":["agent-1"]' "ERROR: Gateway 'agentId' must be a non-empty string"
+
+  rm -rf "$tmpdir" /tmp/gh-aw/mcp-config /tmp/gh-aw/mcp-gateway-started
+}
+
 # Run all tests
 echo "=== Testing start_mcp_gateway.sh ==="
 echo "Script: $SCRIPT_PATH"
@@ -363,6 +411,7 @@ test_container_missing_rm_flag
 test_container_missing_network_flag
 test_validation_functions_exist
 test_gateway_startup_diagnostics
+test_gateway_agent_identifier_validation
 
 # Print summary
 echo ""


### PR DESCRIPTION
## Summary

- accept gateway configurations with exactly one valid `agentId` or `agentIds` form in both setup-action startup implementations
- reject empty, malformed, both-present, and neither-present identifier configurations consistently
- add focused JavaScript and shell coverage for singular and plural gateway identifiers

## Context

This fixes the `Start MCP Gateway` failure in the [gh-aw-firewall smoke run](https://github.com/github/gh-aw-firewall/actions/runs/33660222369), where setup rejected the valid shared-enclave `gateway.agentIds` configuration with `ERROR: Gateway configuration is missing required 'agentId' field`.

The plural configuration is emitted by the shared multi-agent enclave compilation merged in #57973 and is supported by gh-aw-mcpg v0.4.15.

## Validation

- `npx vitest run actions/setup/js/start_mcp_gateway.test.cjs`
- `bash actions/setup/sh/start_mcp_gateway_test.sh`
- `make lint-cjs`
- `make shellcheck-setup-sh`
- `make agent-report-progress`

No generated action artifacts were updated because setup copies the committed `actions/setup/js/` and `actions/setup/sh/` sources directly at runtime.