### PR TITLE
docs(enclaves): correct delegation control listener reachability claim

### DIFF
--- a/pkg/workflow/enclaves.go
+++ b/pkg/workflow/enclaves.go
@@ -53,13 +53,14 @@ const (
 	maxDynamicEnclaveTimeoutSeconds = 4740
 	enclaveMCPTransportAllowance    = 60
 	// enclaveDelegationControlPortOffset is added to the job's MCP gateway data-plane
-	// port to derive the private, host-only listener port for mcpg's
-	// github-repository-delegation-v1 control plane. Deriving it from the (per-job
-	// configurable) data-plane port, rather than a single fixed literal, avoids a
-	// port collision on self-hosted runners that execute multiple concurrent jobs
-	// with distinct gateway ports on the same host. The control port is bound
-	// separately from MCP_GATEWAY_PORT and published only to loopback so neither
-	// the primary agent nor the enclave executor network can route to it.
+	// port to derive the listener port for mcpg's github-repository-delegation-v1
+	// control plane. Deriving it from the (per-job configurable) data-plane port,
+	// rather than a single fixed literal, avoids a port collision on self-hosted
+	// runners that execute multiple concurrent jobs with distinct gateway ports on
+	// the same host. The control port is bound separately from MCP_GATEWAY_PORT and
+	// published only to host loopback; in bridge mode, co-attached containers can
+	// still reach the in-container listener directly, so capability authentication
+	// is the enforced control.
 	//
 	// Contract: this offset only avoids collisions between a single job's own
 	// data-plane and control ports. Operators running self-hosted runners with

--- a/pkg/workflow/mcp_setup_gateway.go
+++ b/pkg/workflow/mcp_setup_gateway.go
@@ -330,7 +330,11 @@ func writeMCPGatewayExports(yaml *strings.Builder, opts writeMCPGatewayExportsOp
 			// the host's network namespace, so 127.0.0.1 works directly and is kept
 			// tightest-scoped. The host-side publication (see buildMCPGatewayContainerCommand)
 			// stays on 127.0.0.1 either way, so the control port is never reachable from
-			// outside the host regardless of the in-container bind address.
+			// outside the host regardless of the in-container bind address. Note this
+			// says nothing about container-to-container reachability: in bridge mode a
+			// peer co-attached to a network mcpg joins can dial this 0.0.0.0 listener on
+			// the container IP directly. The capability is what guards the control API;
+			// see the -p comment in buildMCPGatewayContainerCommand and github/gh-aw#59268.
 			controlListenHost := "127.0.0.1"
 			if isAWFNetworkIsolationEnabled(workflowData) {
 				controlListenHost = "0.0.0.0"
@@ -457,13 +461,28 @@ func buildMCPGatewayContainerCommand(opts buildMCPGatewayContainerCommandOptions
 			containerCmd.WriteString(" -p 127.0.0.1:${MCP_GATEWAY_PORT}:${MCP_GATEWAY_PORT}")
 		}
 		if enclaveDynamicRepositoryPolicyEnabled(workflowData) {
-			// The delegation control listener is host-private only: unlike the data
-			// plane above, this -p flag always publishes to the host's 127.0.0.1, never
-			// 0.0.0.0, so the primary-agent network, enclave executor network, and any
-			// docker-sbx guest cannot route to it -- only the AWF host process reaches
-			// it. The in-container bind address (the right-hand side of MCP_GATEWAY_DELEGATION_CONTROL_LISTEN,
-			// set in writeMCPGatewayExports) is 0.0.0.0 here in bridge mode so Docker's
-			// NAT can actually reach the listener inside the container.
+			// Unlike the data plane above, this -p flag always publishes to the host's
+			// 127.0.0.1, never 0.0.0.0, so the control port is not reachable from
+			// outside the runner and AWF reaches it over host loopback.
+			//
+			// This publication scope is deliberately NOT relied on as a
+			// container-to-container isolation boundary, and must not be described as
+			// one. The in-container bind address (the right-hand side of
+			// MCP_GATEWAY_DELEGATION_CONTROL_LISTEN, set in writeMCPGatewayExports) is
+			// 0.0.0.0 in bridge mode because Docker NATs a published port to the
+			// container's bridge IP and a container-local 127.0.0.1 bind would be
+			// unreachable. A peer co-attached to any network mcpg joins can therefore
+			// address the container IP and this port directly, without traversing the
+			// published host port -- co-attachment, not publication scope, determines
+			// container-to-container reachability.
+			//
+			// The enforced control on this listener is authentication, by design (see
+			// github/gh-aw#59268): every request must present the 256-bit AWF-only
+			// capability minted in writeMCPGatewayExports, which is never placed in any
+			// primary-agent, enclave-executor, or model-sidecar environment or mount.
+			// mcpg verifies it in constant time against a stored SHA-256 digest, before
+			// any control routing, on a handler kept separate from the executor-facing
+			// data plane, so a valid executor bearer cannot reach control operations.
 			containerCmd.WriteString(" -p 127.0.0.1:${MCP_GATEWAY_DELEGATION_CONTROL_LISTEN#*:}:${MCP_GATEWAY_DELEGATION_CONTROL_LISTEN#*:}")
 		}
 	} else {


### PR DESCRIPTION
## Summary

Corrects a factually incorrect security comment on mcpg's delegation control listener, and records the accepted design: **capability authentication is the enforced control on that listener**, not network topology.

Comment-only change. No behavior change, no generated-output change.

## The incorrect claim

`buildMCPGatewayContainerCommand` publishes the control port with `-p 127.0.0.1:<port>:<port>` and asserted:

> the primary-agent network, enclave executor network, and any docker-sbx guest **cannot route to it** — only the AWF host process reaches it

That conclusion doesn't follow from its own premise. `-p 127.0.0.1:X:X` constrains the **host-published** path only. The in-container listener is deliberately bound to `0.0.0.0` in bridge mode (`writeMCPGatewayExports`, and the comment there says why — Docker NATs a published port to the container's bridge IP, so a container-local `127.0.0.1` bind would be unreachable). A peer co-attached to any network mcpg joins reaches the container IP directly and never traverses the published port.

This isn't hypothetical. AWF asserts the co-attachment on every dynamic run — mcpg is a required member of the enclave-agent network at `172.31.0.40`, which is how the enclave reaches the GitHub data plane at all:

```js
// gh-aw-firewall containers/enclave/agent-executor/docker-enclave-runner.js:35-39
if (this.config.githubEnabled || this.config.dynamicEnabled) {
  const steadyStateMembers = [proxyMember,
    `${this.config.githubGatewayContainer}@172.31.0.40/24,`];
```

Control sits on the same interface at data-port + 10 (`enclaveDelegationControlPortOffset = 10`).

## Why this is a comment fix and not a topology change

Per maintainer decision, we accept the 256-bit capability as the control here rather than adding a second, topological one. That's defensible on the implementation as it stands:

| Property | Where |
|---|---|
| 256-bit CSPRNG secret, `::add-mask::`-ed | `mcp_setup_gateway.go:315-316` |
| Excluded from the agent environment via `--exclude-env` | `awf_env.go:108`, `:174` — and the exclusion condition is *broader* than the setting condition |
| Stored only as a SHA-256 digest, never in comparable form | mcpg `internal/delegation/capability.go` |
| `subtle.ConstantTimeCompare` over fixed-size digests | same — doesn't leak length or content |
| 32-byte minimum enforced at construction | `minControlCapabilityBytes` |
| Verified **before any control routing**, plus a POST requirement | mcpg `internal/proxy/delegation.go:49` |
| Served by a handler separate from the executor data plane | `ControlHandler()` vs `Handler()` — a valid executor bearer cannot reach control ops |

So the residual risk is capability *leakage*, not brute force. Network isolation would only have added depth against that. The comment now says this plainly instead of implying a routing guarantee that doesn't hold.

The `writeMCPGatewayExports` comment was accurate ("never reachable from outside the host") but misleading by omission, so it gets a pointer rather than a rewrite.

## Validation

- `gofmt -l` clean
- `go build ./pkg/workflow/` clean
- `go vet ./pkg/workflow/` clean
- `go test ./pkg/workflow/ -run 'Enclave|Delegation|AWFExclude'` — pass

Existing coverage already locks the properties we're relying on (`enclaves_test.go:671-680`): capability minting, masking, `GITHUB_ENV` handoff, and exclusion of both the capability and the control endpoint from the agent environment. No new test is needed for a comment change, and I confirmed the exclusion assertions exist rather than adding a duplicate.

Refs github/gh-aw#59268
Refs github/gh-aw-firewall#8195


---



> Generated by [👨‍🍳 PR Sous Chef](https://github.com/github/gh-aw/actions/runs/34168294676) · pi · gpt54 · 40.3 AIC · ⌖ 8.65 AIC · ⊞ 9.2K · [◷](https://github.com/search?q=repo%3Agithub%2Fgh-aw+%22gh-aw-workflow-call-id%3A+github%2Fgh-aw%2Fpr-sous-chef%22&type=pullrequests)
> <sub>Comment <em>/souschef</em> to run again</sub>

<!-- gh-aw-agentic-workflow: PR Sous Chef, engine: pi, model: openai/gpt-5.4, id: 34168294676, workflow_id: pr-sous-chef, run: https://github.com/github/gh-aw/actions/runs/34168294676 -->